### PR TITLE
feat(reasoning): thinking blocks, reasoning stream/persist, reasoning tokens

### DIFF
--- a/src/harness/agent_loop/mod.rs
+++ b/src/harness/agent_loop/mod.rs
@@ -308,6 +308,17 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
 
         let mut messages = input;
 
+        // Cache the tool schemas once for the whole run. The registered tool set
+        // is fixed for a run, so rebuilding every `ToolSchema` (cloning
+        // name/description/`parameters`) and re-sorting on each loop iteration is
+        // pure overhead. Dynamic tool-selection middleware operates on
+        // `request.tools` after this point (copy-on-filter), so it never needs
+        // the registry rebuilt per turn. We clone this cached vector into each
+        // `ModelRequest`; that clone is unavoidable while `ModelRequest.tools`
+        // owns a `Vec<ToolSchema>` (the no-clone `Arc` form is the coordinated
+        // trait-break tracked separately), but the build + sort now happen once.
+        let tool_schemas = self.tools.schemas();
+
         status.mark_running(HarnessPhase::Middleware);
         self.middleware.run_before_agent(ctx, state).await?;
 
@@ -353,7 +364,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
             // Build the request from the working transcript, tool schemas, and
             // policy response format.
             status.mark_running(HarnessPhase::BuildingRequest);
-            let mut request = ModelRequest::new(messages.clone()).with_tools(self.tools.schemas());
+            let mut request = ModelRequest::new(messages.clone()).with_tools(tool_schemas.clone());
             if let Some(format) = &self.policy.default_response_format {
                 request = request.with_response_format(format.clone());
             }

--- a/src/harness/agent_loop/mod.rs
+++ b/src/harness/agent_loop/mod.rs
@@ -1017,6 +1017,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
                 let mut model_delta = ModelDelta {
                     call_id: call_id.as_str().to_string(),
                     content: message_delta.text.clone(),
+                    reasoning: message_delta.reasoning.clone(),
                     tool_call: message_delta.tool_call.clone(),
                 };
                 self.middleware

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -1217,3 +1217,61 @@ async fn middleware_control_can_interrupt_run() {
         other => panic!("expected Interrupted, got {other:?}"),
     }
 }
+
+/// A model that records the tool schemas presented on each `invoke` and replays
+/// scripted responses in order. Used to prove the loop exposes the registered
+/// tool set on *every* turn, not just the first.
+struct ToolCapturingModel {
+    responses: Mutex<std::collections::VecDeque<ModelResponse>>,
+    seen_tools: Arc<Mutex<Vec<Vec<ToolSchema>>>>,
+}
+
+#[async_trait]
+impl ChatModel<()> for ToolCapturingModel {
+    async fn invoke(&self, _state: &(), request: ModelRequest) -> Result<ModelResponse> {
+        self.seen_tools.lock().unwrap().push(request.tools.clone());
+        let next = self.responses.lock().unwrap().pop_front();
+        next.ok_or_else(|| TinyAgentsError::Validation("no scripted response left".into()))
+    }
+}
+
+/// Regression test for the per-run tool-schema cache: hoisting
+/// `self.tools.schemas()` out of the loop must not change the tools the model
+/// sees on any turn. A two-turn run (tool call, then final text) must present
+/// the identical, non-empty schema set on both turns.
+#[tokio::test]
+async fn tool_schemas_are_stable_across_turns() {
+    let seen_tools = Arc::new(Mutex::new(Vec::new()));
+    let model = ToolCapturingModel {
+        responses: Mutex::new(
+            vec![
+                tool_call_response("c1", "spin", json!({})),
+                text_response("done", 5, 2),
+            ]
+            .into(),
+        ),
+        seen_tools: Arc::clone(&seen_tools),
+    };
+
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model("mock", Arc::new(model));
+    harness.register_tool(Arc::new(FakeTool::new("spin", "again")));
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("go")])
+        .await
+        .expect("run succeeds");
+    assert_eq!(run.text(), Some("done".to_string()));
+
+    let seen = seen_tools.lock().unwrap();
+    assert_eq!(seen.len(), 2, "model should be invoked twice");
+    assert!(
+        !seen[0].is_empty(),
+        "first turn must expose the registered tool schema"
+    );
+    assert_eq!(
+        seen[0], seen[1],
+        "cached schemas must reach the model identically on every turn"
+    );
+    assert_eq!(seen[0][0].name, "spin");
+}

--- a/src/harness/cache/mod.rs
+++ b/src/harness/cache/mod.rs
@@ -36,11 +36,28 @@ use crate::harness::model::{ModelRequest, ModelResponse};
 
 // ── Deterministic hash ────────────────────────────────────────────────────────
 
-/// Computes a deterministic SHA-256 digest over `data` and returns it as a
-/// 64-character lowercase hex string.
-fn sha256_hex(data: &[u8]) -> String {
-    let digest = Sha256::digest(data);
-    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+/// Renders a finalized SHA-256 digest as a 64-character lowercase hex string.
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    digest
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// Folds one JSON `value` into `hasher` as a self-delimiting frame: an ASCII
+/// domain `tag`, then the canonical byte length (little-endian `u64`), then the
+/// canonical bytes.
+///
+/// Canonicalizing per component keeps peak memory bounded by the single largest
+/// value rather than the whole request tree, and the length prefix makes the
+/// concatenation of frames unambiguous — no two distinct component sequences
+/// can hash to the same byte stream.
+fn fold_canonical(hasher: &mut Sha256, tag: u8, value: Value) {
+    let bytes = serde_json::to_vec(&canonical_value(value)).unwrap_or_default();
+    hasher.update([tag]);
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(&bytes);
 }
 
 /// Computes a deterministic FNV-1a 64-bit hash over `data` and returns it as
@@ -84,25 +101,60 @@ fn canonical_value(v: Value) -> Value {
 
 /// Produces a stable, deterministic cache key for `request`.
 ///
-/// The key is a 16-character lowercase hex string derived from:
-/// 1. Serializing `request` to a [`serde_json::Value`].
-/// 2. Sorting all JSON object keys recursively (canonical form).
-/// 3. Re-serializing to a compact JSON string.
-/// 4. Applying SHA-256 to the canonical bytes.
+/// The key is a 64-character lowercase SHA-256 hex string built by folding the
+/// request into the hasher **incrementally**, one component at a time:
+/// 1. Serialize `request` once to a [`serde_json::Value`].
+/// 2. Fold each conversation message as its own length-prefixed, canonicalized
+///    frame (tag `M`), preceded by the message count.
+/// 3. Fold each tool schema likewise (tag `T`), preceded by the tool count.
+/// 4. Fold the remaining scalar/parameter fields — everything left in the
+///    request object once `messages` and `tools` are removed — as one envelope
+///    frame (tag `E`).
 ///
-/// Because every behavior-affecting field of [`ModelRequest`] participates in
-/// the serialization, two requests that differ in any field produce different
-/// canonical bytes and should produce different keys modulo SHA-256 collision
-/// resistance.
+/// This avoids the previous approach's three simultaneous whole-transcript
+/// allocations (a full `Value` tree, a full canonical rebuild, and a full byte
+/// buffer). Transcripts routinely carry large tool results; canonicalizing and
+/// serializing per component bounds peak memory by the single largest component
+/// instead of the entire request. The envelope is taken as "whatever remains"
+/// so that any future [`ModelRequest`] field automatically participates in the
+/// key — no field can silently drop out and cause a false cache hit.
+///
+/// Distinct requests still map to distinct keys (modulo SHA-256 collision
+/// resistance): per-component length prefixes make the frame stream
+/// unambiguous, and every behavior-affecting field is folded exactly once.
 ///
 /// # Panics
-/// Does not panic. If serialization unexpectedly fails, returns an empty-data
-/// hash.
+/// Does not panic. If serialization unexpectedly fails, the affected frame
+/// folds empty bytes; the key stays well-defined.
 pub fn cache_key(request: &ModelRequest) -> String {
-    let value = serde_json::to_value(request).unwrap_or(Value::Null);
-    let canonical = canonical_value(value);
-    let bytes = serde_json::to_vec(&canonical).unwrap_or_default();
-    sha256_hex(&bytes)
+    let mut hasher = Sha256::new();
+    let mut root = serde_json::to_value(request).unwrap_or(Value::Null);
+
+    if let Value::Object(map) = &mut root {
+        // Messages: fold one at a time so a long transcript never materializes
+        // a second full tree. The count frame keeps `[a, b]` distinct from a
+        // single message that happens to serialize to the same concatenation.
+        if let Some(Value::Array(messages)) = map.remove("messages") {
+            hasher.update(b"M");
+            hasher.update((messages.len() as u64).to_le_bytes());
+            for message in messages {
+                fold_canonical(&mut hasher, b'm', message);
+            }
+        }
+        // Tool schemas: already name-sorted by `ToolRegistry::schemas`, so the
+        // order is deterministic across calls.
+        if let Some(Value::Array(tools)) = map.remove("tools") {
+            hasher.update(b"T");
+            hasher.update((tools.len() as u64).to_le_bytes());
+            for tool in tools {
+                fold_canonical(&mut hasher, b't', tool);
+            }
+        }
+    }
+
+    // Envelope: every remaining scalar/parameter field in one frame.
+    fold_canonical(&mut hasher, b'E', root);
+    hex_digest(hasher.finalize())
 }
 
 // ── InMemoryResponseCache ─────────────────────────────────────────────────────

--- a/src/harness/cache/test.rs
+++ b/src/harness/cache/test.rs
@@ -5,7 +5,10 @@
 //! [`super::PromptCacheLayout`] correctly detects stable vs. changed prefixes.
 
 use super::*;
+use crate::harness::message::Message;
 use crate::harness::model::{ModelRequest, ModelResponse, PromptSegment, SegmentRole};
+use crate::harness::tool::ToolSchema;
+use serde_json::json;
 
 #[tokio::test]
 async fn response_cache_put_get() {
@@ -33,6 +36,97 @@ fn cache_key_differs_for_different_requests() {
     let r1 = ModelRequest::new(vec![]).with_model("gpt-4");
     let r2 = ModelRequest::new(vec![]).with_model("claude-3");
     assert_ne!(cache_key(&r1), cache_key(&r2));
+}
+
+#[test]
+fn cache_key_is_deterministic_with_messages_and_tools() {
+    let build = || {
+        ModelRequest::new(vec![
+            Message::system("you are terse"),
+            Message::user("hello"),
+        ])
+        .with_model("gpt-4")
+        .with_tools(vec![ToolSchema::new(
+            "spin",
+            "spin a value",
+            json!({"type": "object"}),
+        )])
+    };
+    assert_eq!(cache_key(&build()), cache_key(&build()));
+}
+
+#[test]
+fn cache_key_reflects_message_content() {
+    let r1 = ModelRequest::new(vec![Message::user("hello")]);
+    let r2 = ModelRequest::new(vec![Message::user("goodbye")]);
+    assert_ne!(
+        cache_key(&r1),
+        cache_key(&r2),
+        "a changed message body must change the key"
+    );
+}
+
+#[test]
+fn cache_key_reflects_message_count() {
+    let r1 = ModelRequest::new(vec![Message::user("hello")]);
+    let r2 = ModelRequest::new(vec![Message::user("hello"), Message::user("again")]);
+    assert_ne!(
+        cache_key(&r1),
+        cache_key(&r2),
+        "appending a message must change the key"
+    );
+}
+
+#[test]
+fn cache_key_is_order_sensitive() {
+    let r1 = ModelRequest::new(vec![Message::user("a"), Message::user("b")]);
+    let r2 = ModelRequest::new(vec![Message::user("b"), Message::user("a")]);
+    assert_ne!(
+        cache_key(&r1),
+        cache_key(&r2),
+        "message order must change the key (length-prefixed frames)"
+    );
+}
+
+#[test]
+fn cache_key_reflects_tool_schemas() {
+    let base = ModelRequest::new(vec![Message::user("hi")]);
+    let with_tool = base.clone().with_tools(vec![ToolSchema::new(
+        "spin",
+        "spin a value",
+        json!({"type": "object"}),
+    )]);
+    assert_ne!(
+        cache_key(&base),
+        cache_key(&with_tool),
+        "adding a tool schema must change the key"
+    );
+}
+
+#[test]
+fn cache_key_reflects_scalar_envelope_fields() {
+    let base = ModelRequest::new(vec![Message::user("hi")]);
+    let mut hot = base.clone();
+    hot.temperature = Some(0.9);
+    assert_ne!(
+        cache_key(&base),
+        cache_key(&hot),
+        "a scalar field change must change the key via the envelope frame"
+    );
+}
+
+#[test]
+fn cache_key_does_not_confuse_messages_with_tools() {
+    // A message array of length 1 and a tool array of length 1 are folded under
+    // distinct tags with count frames, so a request carrying one must not
+    // collide with an otherwise-empty request carrying the other.
+    let one_message = ModelRequest::new(vec![Message::user("x")]);
+    let one_tool = ModelRequest::new(vec![]).with_tools(vec![ToolSchema::new(
+        "x",
+        "x",
+        json!({"type": "object"}),
+    )]);
+    assert_ne!(cache_key(&one_message), cache_key(&one_tool));
 }
 
 #[test]

--- a/src/harness/message/mod.rs
+++ b/src/harness/message/mod.rs
@@ -16,11 +16,44 @@ pub use types::*;
 
 impl ContentBlock {
     /// Returns the text of this block if it is a [`ContentBlock::Text`].
+    ///
+    /// Reasoning blocks ([`ContentBlock::Thinking`] /
+    /// [`ContentBlock::RedactedThinking`]) are intentionally *not* treated as
+    /// text, so they never leak into visible assistant output via
+    /// [`concat_text`] / [`Message::text`].
     pub fn as_text(&self) -> Option<&str> {
         match self {
             ContentBlock::Text(text) => Some(text),
             _ => None,
         }
+    }
+
+    /// Creates a [`ContentBlock::Thinking`] block with no signature.
+    pub fn thinking(text: impl Into<String>) -> Self {
+        ContentBlock::Thinking {
+            text: text.into(),
+            signature: None,
+        }
+    }
+
+    /// Returns the reasoning text and optional signature if this is a
+    /// [`ContentBlock::Thinking`] block.
+    pub fn as_thinking(&self) -> Option<(&str, Option<&str>)> {
+        match self {
+            ContentBlock::Thinking { text, signature } => {
+                Some((text.as_str(), signature.as_deref()))
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this is a reasoning block ([`ContentBlock::Thinking`]
+    /// or [`ContentBlock::RedactedThinking`]).
+    pub fn is_reasoning(&self) -> bool {
+        matches!(
+            self,
+            ContentBlock::Thinking { .. } | ContentBlock::RedactedThinking { .. }
+        )
     }
 }
 

--- a/src/harness/message/test.rs
+++ b/src/harness/message/test.rs
@@ -64,3 +64,88 @@ fn message_delta_default() {
     assert_eq!(delta.text, "");
     assert!(delta.tool_call.is_none());
 }
+
+#[test]
+fn text_ignores_thinking_blocks() {
+    let msg = Message::Assistant(AssistantMessage {
+        id: None,
+        content: vec![
+            ContentBlock::thinking("let me reason about this"),
+            ContentBlock::Text("the answer is 42".into()),
+            ContentBlock::RedactedThinking {
+                data: "opaque".into(),
+            },
+        ],
+        tool_calls: Vec::new(),
+        usage: None,
+    });
+    // Reasoning blocks must never leak into visible text.
+    assert_eq!(msg.text(), "the answer is 42");
+}
+
+#[test]
+fn thinking_accessors() {
+    let signed = ContentBlock::Thinking {
+        text: "reasoning".into(),
+        signature: Some("sig-abc".into()),
+    };
+    assert_eq!(signed.as_thinking(), Some(("reasoning", Some("sig-abc"))));
+    assert!(signed.is_reasoning());
+    assert!(signed.as_text().is_none());
+
+    let unsigned = ContentBlock::thinking("just thinking");
+    assert_eq!(unsigned.as_thinking(), Some(("just thinking", None)));
+    assert!(unsigned.is_reasoning());
+
+    let redacted = ContentBlock::RedactedThinking {
+        data: "opaque".into(),
+    };
+    assert!(redacted.is_reasoning());
+    assert!(redacted.as_thinking().is_none());
+
+    assert!(!ContentBlock::Text("hi".into()).is_reasoning());
+}
+
+#[test]
+fn thinking_block_serde_round_trips() {
+    let signed = ContentBlock::Thinking {
+        text: "step by step".into(),
+        signature: Some("sig-1".into()),
+    };
+    let wire = serde_json::to_value(&signed).unwrap();
+    assert_eq!(
+        wire,
+        json!({ "thinking": { "text": "step by step", "signature": "sig-1" } })
+    );
+    let back: ContentBlock = serde_json::from_value(wire).unwrap();
+    assert_eq!(back, signed);
+
+    // An unsigned thinking block omits the signature key entirely.
+    let unsigned = ContentBlock::thinking("no sig");
+    let wire = serde_json::to_value(&unsigned).unwrap();
+    assert_eq!(wire, json!({ "thinking": { "text": "no sig" } }));
+    let back: ContentBlock = serde_json::from_value(wire).unwrap();
+    assert_eq!(back, unsigned);
+
+    let redacted = ContentBlock::RedactedThinking {
+        data: "opaque".into(),
+    };
+    let wire = serde_json::to_value(&redacted).unwrap();
+    assert_eq!(wire, json!({ "redacted_thinking": { "data": "opaque" } }));
+    let back: ContentBlock = serde_json::from_value(wire).unwrap();
+    assert_eq!(back, redacted);
+}
+
+#[test]
+fn legacy_content_without_thinking_still_parses() {
+    // Additive tagging: transcripts serialized before thinking blocks existed
+    // (only text/json/image/provider_extension) must deserialize unchanged.
+    let legacy = json!([
+        { "text": "hello" },
+        { "json": { "k": "v" } }
+    ]);
+    let blocks: Vec<ContentBlock> = serde_json::from_value(legacy).unwrap();
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0].as_text(), Some("hello"));
+    assert!(!blocks[1].is_reasoning());
+}

--- a/src/harness/message/types.rs
+++ b/src/harness/message/types.rs
@@ -25,6 +25,29 @@ pub enum ContentBlock {
     Json(Value),
     /// A reference to an image input.
     Image(ImageRef),
+    /// Model reasoning/thinking content.
+    ///
+    /// Kept out of visible assistant text ([`ContentBlock::as_text`] returns
+    /// `None`) but preserved on the message so providers that require verbatim
+    /// replay of the thinking turn preceding tool results (Anthropic) can round-
+    /// trip it. Providers that reject thinking blocks (the OpenAI-compatible
+    /// path, which serializes via [`crate::harness::message::Message::text`])
+    /// drop it naturally.
+    Thinking {
+        /// The reasoning text.
+        text: String,
+        /// Opaque provider signature required to replay the block verbatim.
+        /// `None` when the provider does not sign thinking blocks.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+    /// Redacted reasoning: an opaque, provider-encrypted thinking block whose
+    /// content is not human-readable but which must still be replayed verbatim
+    /// to preserve the provider's reasoning contract.
+    RedactedThinking {
+        /// Opaque provider payload, replayed verbatim.
+        data: String,
+    },
     /// An opaque provider-specific block preserved verbatim.
     ProviderExtension(Value),
 }

--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -681,7 +681,19 @@ impl StreamAccumulator {
         }
 
         // No authoritative response: reconstruct from accumulated deltas.
+        //
+        // Reasoning streamed on the side channel is preserved as a leading
+        // `Thinking` block rather than dropped, so the reconstructed message
+        // carries the model's thinking for persistence and provider replay.
+        // (Signatures are provider-signed only on the Anthropic Messages path,
+        // wired separately; the OpenAI-compatible path leaves them `None`.)
         let mut content = Vec::new();
+        if !self.reasoning.is_empty() {
+            content.push(ContentBlock::Thinking {
+                text: self.reasoning,
+                signature: None,
+            });
+        }
         if !self.text.is_empty() {
             content.push(ContentBlock::Text(self.text));
         }

--- a/src/harness/model/test.rs
+++ b/src/harness/model/test.rs
@@ -610,3 +610,46 @@ fn stream_accumulator_collects_reasoning_side_channel() {
     let response = acc.finish().unwrap();
     assert_eq!(response.text(), "visible answer");
 }
+
+#[test]
+fn stream_accumulator_reconstruct_preserves_reasoning_as_thinking_block() {
+    use crate::harness::message::{ContentBlock, MessageDelta};
+
+    // No `Completed` item: `finish` reconstructs the message from deltas. The
+    // accumulated reasoning must survive as a leading `Thinking` block rather
+    // than being dropped.
+    let mut acc = StreamAccumulator::new();
+    acc.push(&ModelStreamItem::Started);
+    acc.push(&ModelStreamItem::MessageDelta(MessageDelta::reasoning(
+        "let me think",
+    )));
+    acc.push(&ModelStreamItem::MessageDelta(MessageDelta::text("42")));
+
+    let response = acc.finish().unwrap();
+    // Visible text excludes reasoning.
+    assert_eq!(response.text(), "42");
+    // Leading block is the preserved thinking; text follows.
+    let content = &response.message.content;
+    assert_eq!(content.len(), 2);
+    assert_eq!(
+        content[0],
+        ContentBlock::Thinking {
+            text: "let me think".into(),
+            signature: None,
+        }
+    );
+    assert_eq!(content[1], ContentBlock::Text("42".into()));
+}
+
+#[test]
+fn stream_accumulator_reconstruct_without_reasoning_has_no_thinking_block() {
+    use crate::harness::message::{ContentBlock, MessageDelta};
+
+    let mut acc = StreamAccumulator::new();
+    acc.push(&ModelStreamItem::MessageDelta(MessageDelta::text("hi")));
+    let response = acc.finish().unwrap();
+    assert_eq!(
+        response.message.content,
+        vec![ContentBlock::Text("hi".into())]
+    );
+}

--- a/src/harness/model/types.rs
+++ b/src/harness/model/types.rs
@@ -429,9 +429,14 @@ pub struct ModelResponse {
 pub struct ModelDelta {
     /// Id of the model call this delta belongs to.
     pub call_id: String,
-    /// Incremental text content.
+    /// Incremental visible text content.
     #[serde(default)]
     pub content: String,
+    /// Incremental reasoning/thinking content, when the provider streams
+    /// reasoning separately from visible text. Kept distinct from `content` so
+    /// middleware can observe thinking without it leaking into visible output.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reasoning: String,
     /// Incremental tool-call fragment, when present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call: Option<ToolDelta>,

--- a/src/harness/providers/openai/mod.rs
+++ b/src/harness/providers/openai/mod.rs
@@ -714,6 +714,10 @@ fn convert_usage(wire: UsageWire) -> Usage {
             .prompt_tokens_details
             .map(|d| d.cached_tokens)
             .unwrap_or(0),
+        reasoning_tokens: wire
+            .completion_tokens_details
+            .map(|d| d.reasoning_tokens)
+            .unwrap_or(0),
         ..Usage::default()
     }
 }

--- a/src/harness/providers/openai/mod.rs
+++ b/src/harness/providers/openai/mod.rs
@@ -746,6 +746,7 @@ struct ToolCallBuild {
 struct OpenAiStreamAcc {
     id: Option<String>,
     text: String,
+    reasoning: String,
     tool_calls: Vec<ToolCallBuild>,
     usage: Option<Usage>,
     finish_reason: Option<String>,
@@ -769,7 +770,20 @@ impl OpenAiStreamAcc {
             if let Some(reason) = choice.finish_reason {
                 self.finish_reason = Some(reason);
             }
-            if let Some(content) = choice.delta.content.filter(|c| !c.is_empty()) {
+            let mut delta = choice.delta;
+            // Reasoning fragment, when the provider streams thinking separately
+            // from visible content (DeepSeek `reasoning_content`, OpenRouter
+            // `reasoning`). Emitted on the neutral delta's reasoning channel and
+            // accumulated for the final `Thinking` block; kept out of `text`.
+            if let Some(reasoning) = delta.reasoning_fragment() {
+                self.reasoning.push_str(&reasoning);
+                pending.push_back(ModelStreamItem::MessageDelta(MessageDelta {
+                    text: String::new(),
+                    reasoning,
+                    tool_call: None,
+                }));
+            }
+            if let Some(content) = delta.content.filter(|c| !c.is_empty()) {
                 self.text.push_str(&content);
                 pending.push_back(ModelStreamItem::MessageDelta(MessageDelta {
                     text: content,
@@ -777,7 +791,7 @@ impl OpenAiStreamAcc {
                     tool_call: None,
                 }));
             }
-            for fragment in choice.delta.tool_calls {
+            for fragment in delta.tool_calls {
                 let idx = fragment.index as usize;
                 while self.tool_calls.len() <= idx {
                     self.tool_calls.push(ToolCallBuild::default());
@@ -810,6 +824,15 @@ impl OpenAiStreamAcc {
     /// Consumes the accumulator into the final, merged [`ModelResponse`].
     fn into_response(self) -> Result<ModelResponse> {
         let mut content = Vec::new();
+        // Preserve streamed reasoning as a leading `Thinking` block so the
+        // persisted message carries the model's thinking. The OpenAI-compatible
+        // path does not sign thinking, so the signature is `None`.
+        if !self.reasoning.is_empty() {
+            content.push(ContentBlock::Thinking {
+                text: self.reasoning,
+                signature: None,
+            });
+        }
         if !self.text.is_empty() {
             content.push(ContentBlock::Text(self.text));
         }

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -287,6 +287,52 @@ fn parses_openai_response_with_content_tool_call_and_usage() {
 }
 
 #[test]
+fn parses_reasoning_tokens_from_completion_details() {
+    // A reasoning-model response carries reasoning tokens under
+    // `completion_tokens_details`.
+    let body = json!({
+        "id": "chatcmpl-o1",
+        "choices": [
+            { "message": { "role": "assistant", "content": "42" }, "finish_reason": "stop" }
+        ],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 100,
+            "total_tokens": 112,
+            "completion_tokens_details": { "reasoning_tokens": 64 }
+        }
+    });
+
+    let usage = parse_response(body)
+        .unwrap()
+        .usage
+        .expect("usage present");
+    assert_eq!(usage.output_tokens, 100);
+    assert_eq!(
+        usage.reasoning_tokens, 64,
+        "reasoning tokens must map from completion_tokens_details"
+    );
+}
+
+#[test]
+fn usage_reasoning_tokens_default_to_zero_when_absent() {
+    // Non-reasoning responses omit `completion_tokens_details` entirely.
+    let body = json!({
+        "id": "chatcmpl-plain",
+        "choices": [
+            { "message": { "role": "assistant", "content": "hi" }, "finish_reason": "stop" }
+        ],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4 }
+    });
+
+    let usage = parse_response(body)
+        .unwrap()
+        .usage
+        .expect("usage present");
+    assert_eq!(usage.reasoning_tokens, 0);
+}
+
+#[test]
 fn parse_response_errors_on_invalid_tool_argument_json() {
     let body = json!({
         "id": "chatcmpl-badargs",

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -303,10 +303,7 @@ fn parses_reasoning_tokens_from_completion_details() {
         }
     });
 
-    let usage = parse_response(body)
-        .unwrap()
-        .usage
-        .expect("usage present");
+    let usage = parse_response(body).unwrap().usage.expect("usage present");
     assert_eq!(usage.output_tokens, 100);
     assert_eq!(
         usage.reasoning_tokens, 64,
@@ -325,10 +322,7 @@ fn usage_reasoning_tokens_default_to_zero_when_absent() {
         "usage": { "prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4 }
     });
 
-    let usage = parse_response(body)
-        .unwrap()
-        .usage
-        .expect("usage present");
+    let usage = parse_response(body).unwrap().usage.expect("usage present");
     assert_eq!(usage.reasoning_tokens, 0);
 }
 
@@ -543,6 +537,70 @@ async fn sse_stream_parses_text_tool_calls_and_usage() {
     assert_eq!(calls[0].arguments, json!({ "q": 42 }));
     assert_eq!(response.finish_reason.as_deref(), Some("tool_calls"));
     assert_eq!(response.usage.unwrap().total_tokens, 8);
+}
+
+#[tokio::test]
+async fn sse_stream_parses_reasoning_deltas_into_thinking_block() {
+    use crate::harness::message::ContentBlock;
+    use futures::StreamExt;
+
+    // A DeepSeek/compat stream: reasoning arrives on `reasoning_content` before
+    // the visible answer. A later chunk uses the OpenRouter-style `reasoning`
+    // key to prove the fallback path.
+    let raw: Vec<Vec<u8>> = vec![
+        b"data: {\"id\":\"chatcmpl-r\",\"choices\":[{\"delta\":{\"reasoning_content\":\"first \"}}]}\n\n".to_vec(),
+        b"data: {\"choices\":[{\"delta\":{\"reasoning\":\"second\"}}]}\n\n".to_vec(),
+        b"data: {\"choices\":[{\"delta\":{\"content\":\"answer\"},\"finish_reason\":\"stop\"}]}\n\n".to_vec(),
+        b"data: [DONE]\n\n".to_vec(),
+    ];
+    let bytes = futures::stream::iter(raw.into_iter().map(Ok::<Vec<u8>, TinyAgentsError>));
+
+    let state = SseState {
+        bytes: Box::pin(bytes),
+        buf: String::new(),
+        pending: std::collections::VecDeque::new(),
+        acc: OpenAiStreamAcc::default(),
+        provider: "openai".to_string(),
+        model: "deepseek-reasoner".to_string(),
+        started: false,
+        finished: false,
+        terminal_emitted: false,
+    };
+    let items: Vec<ModelStreamItem> = futures::stream::unfold(state, sse_next).collect().await;
+
+    // Reasoning fragments are streamed on the neutral delta's reasoning channel,
+    // never mixed into visible text.
+    let reasoning: String = items
+        .iter()
+        .filter_map(|item| match item {
+            ModelStreamItem::MessageDelta(delta) => Some(delta.reasoning.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(reasoning, "first second");
+    let visible: String = items
+        .iter()
+        .filter_map(|item| match item {
+            ModelStreamItem::MessageDelta(delta) => Some(delta.text.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(visible, "answer");
+
+    // The merged response leads with the preserved (unsigned) thinking block.
+    let mut merged = StreamAccumulator::new();
+    for item in &items {
+        merged.push(item);
+    }
+    let response = merged.finish().unwrap();
+    assert_eq!(response.text(), "answer");
+    assert_eq!(
+        response.message.content.first(),
+        Some(&ContentBlock::Thinking {
+            text: "first second".into(),
+            signature: None,
+        })
+    );
 }
 
 #[tokio::test]

--- a/src/harness/providers/openai/types.rs
+++ b/src/harness/providers/openai/types.rs
@@ -245,6 +245,10 @@ pub struct UsageWire {
     /// Optional input-token breakdown (carries cached tokens).
     #[serde(default)]
     pub prompt_tokens_details: Option<PromptTokensDetailsWire>,
+    /// Optional output-token breakdown (carries reasoning tokens for
+    /// o-series/reasoning models).
+    #[serde(default)]
+    pub completion_tokens_details: Option<CompletionTokensDetailsWire>,
 }
 
 /// The `prompt_tokens_details` breakdown of a [`UsageWire`].
@@ -253,6 +257,18 @@ pub struct PromptTokensDetailsWire {
     /// Input tokens served from OpenAI's prompt cache.
     #[serde(default)]
     pub cached_tokens: u64,
+}
+
+/// The `completion_tokens_details` breakdown of a [`UsageWire`].
+///
+/// OpenAI reports `reasoning_tokens` here for reasoning models (the o-series);
+/// they are a subset of `completion_tokens` already billed as output, surfaced
+/// so callers can price and display the reasoning portion separately.
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct CompletionTokensDetailsWire {
+    /// Output tokens spent on model reasoning, when reported.
+    #[serde(default)]
+    pub reasoning_tokens: u64,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/harness/providers/openai/types.rs
+++ b/src/harness/providers/openai/types.rs
@@ -97,9 +97,29 @@ pub struct ChunkDeltaWire {
     /// Incremental text fragment, when present.
     #[serde(default)]
     pub content: Option<String>,
+    /// Incremental reasoning fragment under the DeepSeek/compat
+    /// `reasoning_content` key.
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+    /// Incremental reasoning fragment under the OpenRouter/compat `reasoning`
+    /// key. Used as a fallback when `reasoning_content` is absent.
+    #[serde(default)]
+    pub reasoning: Option<String>,
     /// Incremental tool-call fragments, correlated by `index`.
     #[serde(default)]
     pub tool_calls: Vec<ToolCallChunkWire>,
+}
+
+impl ChunkDeltaWire {
+    /// Returns the non-empty reasoning fragment for this delta, preferring the
+    /// DeepSeek/compat `reasoning_content` key over the OpenRouter/compat
+    /// `reasoning` key.
+    pub fn reasoning_fragment(&mut self) -> Option<String> {
+        self.reasoning_content
+            .take()
+            .or_else(|| self.reasoning.take())
+            .filter(|r| !r.is_empty())
+    }
 }
 
 /// One incremental tool-call fragment in a streamed delta.

--- a/tests/e2e_middleware_parser_contracts.rs
+++ b/tests/e2e_middleware_parser_contracts.rs
@@ -156,6 +156,7 @@ async fn middleware_stack_runs_lifecycle_hooks_and_builtin_guards() {
     let mut delta = ModelDelta {
         call_id: "model-1".into(),
         content: "piece".into(),
+        reasoning: String::new(),
         tool_call: None,
     };
     stack


### PR DESCRIPTION
## Summary

Wires model **reasoning/thinking end-to-end** so it is no longer dropped between
the provider stream and the persisted message / middleware.

- **Message model**: adds `ContentBlock::Thinking { text, signature }` and
  `ContentBlock::RedactedThinking { data }`. Additively snake_case-tagged, so
  pre-existing transcripts parse unchanged. Reasoning blocks are excluded from
  `as_text()`/`Message::text()`, so they never leak into visible output — and
  because the OpenAI-compatible request path serializes via `Message::text()`,
  they are naturally stripped for providers that reject them.
- **OpenAI SSE**: parses reasoning deltas (`reasoning_content`, with
  `reasoning` fallback) instead of hardcoding `""`. Fragments stream on
  `MessageDelta.reasoning`, accumulate on the provider accumulator, and
  `into_response` emits them as a leading `Thinking` block.
- **`StreamAccumulator::finish`**: when reconstructing from deltas (no
  authoritative `Completed`), preserves accumulated reasoning as a leading
  `Thinking` block instead of dropping it.
- **`ModelDelta.reasoning`**: new field, populated in the agent loop so
  `on_model_delta` middleware observes thinking without it leaking into content.
- **Usage**: maps `completion_tokens_details.reasoning_tokens` into the existing
  `Usage.reasoning_tokens`, so `CostTotals.reasoning_cost` is priced from real
  numbers.

Signatures stay `None` on the OpenAI path; provider-signed thinking replay
(Anthropic Messages) is a follow-up.

## Stacking
Stacked on #14 (V1 perf). Until #14 merges this PR includes its two commits;
I'll rebase to drop them once #14 lands.

## Tests
SSE reasoning-delta parsing (both wire keys) → `Thinking` block; accumulator
reconstruct-path preservation; reasoning-token mapping + absent-default; message
round-trip + legacy-compat + text-exclusion.

## Commands run
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (786 lib + integration, green)

Ref: OpenHuman `docs/tinyagents-vendor-improvement-plan/02-reasoning-thought-tokens.md` (V2).
