### PR TITLE
feat(harness): invoke_stream + sub-agent delta propagation + scripted mock streaming

### DIFF
--- a/src/graph/goals/test.rs
+++ b/src/graph/goals/test.rs
@@ -274,6 +274,7 @@ mod tool_tests {
             depth: 0,
             max_turn_output_tokens: None,
             events: EventSink::new(),
+            streaming: false,
             workspace: None,
         }
     }

--- a/src/graph/todos/test.rs
+++ b/src/graph/todos/test.rs
@@ -376,6 +376,7 @@ mod tool_tests {
             depth: 0,
             max_turn_output_tokens: None,
             events: EventSink::new(),
+            streaming: false,
             workspace: None,
         }
     }

--- a/src/harness/agent_loop/entry.rs
+++ b/src/harness/agent_loop/entry.rs
@@ -177,6 +177,10 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
     ) -> Result<AgentLoopResult> {
         let run_id = ctx.config.run_id.clone();
         let thread_id = ctx.config.thread_id.clone();
+        // Record the drive mode so tool execution contexts (and the sub-agents
+        // they spawn) can match it — child deltas then propagate to the parent
+        // stream via the shared sink.
+        ctx.streaming = streaming;
 
         let mut status = HarnessRunStatus::new(run_id.clone(), ComponentId::new("agent_loop"));
         if let Some(thread) = thread_id {

--- a/src/harness/agent_loop/mod.rs
+++ b/src/harness/agent_loop/mod.rs
@@ -94,7 +94,10 @@ use serde_json::Value;
 mod entry;
 mod model_call;
 mod run_loop;
+mod stream;
 mod tools;
+
+pub use stream::AgentStreamItem;
 
 #[cfg(test)]
 mod test;

--- a/src/harness/agent_loop/stream.rs
+++ b/src/harness/agent_loop/stream.rs
@@ -1,0 +1,178 @@
+//! Caller-consumable streaming entry point ([`AgentHarness::invoke_stream`]).
+//!
+//! [`AgentHarness::invoke_streaming`] drives each model call through
+//! [`ChatModel::stream`][crate::harness::model::ChatModel::stream] but only
+//! returns the fully-accumulated [`AgentRun`] once the run is over — a caller
+//! that wants to *watch* the run unfold has to attach an
+//! [`EventListener`][crate::harness::events::EventListener] or middleware.
+//!
+//! `invoke_stream` closes that gap: it returns an async
+//! [`Stream`][futures::Stream] of [`AgentStreamItem`]s that yields every
+//! [`AgentEvent`][crate::harness::events::AgentEvent] emitted during the run —
+//! model/reasoning deltas, tool-call `ToolStarted`/`ToolCompleted` lifecycle
+//! events, and sub-agent `SubAgentStarted`/`SubAgentCompleted` events (which
+//! reach the stream because sub-agents share the parent's
+//! [`EventSink`][crate::harness::events::EventSink]) — and finishes with a
+//! terminal item carrying the completed [`AgentRun`] (or the failure).
+//!
+//! It is a thin projection over the same ordered
+//! [`EventSink::emit`][crate::harness::events::EventSink::emit] fan-out the
+//! `EventListener` path already uses, not a parallel event system: a listener
+//! forwards each [`EventRecord`] into an unbounded channel that the returned
+//! stream drains. Lineage is carried by the events themselves (`ModelDelta`
+//! stamps `run_id`; sub-agent events stamp `depth`). Streaming a child agent's
+//! own model deltas into the parent requires routing the streaming flag through
+//! the sub-agent runner and is tracked as follow-up work.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::harness::context::{RunConfig, RunContext};
+use crate::harness::events::{EventListener, EventRecord};
+use crate::harness::message::Message;
+use crate::harness::middleware::AgentRun;
+use crate::harness::runtime::AgentHarness;
+
+use super::AgentLoopResult;
+
+/// One item yielded by [`AgentHarness::invoke_stream`].
+///
+/// The stream yields zero or more [`AgentStreamItem::Event`]s in emission
+/// order, followed by exactly one terminal item — either
+/// [`AgentStreamItem::Completed`] carrying the final [`AgentRun`], or
+/// [`AgentStreamItem::Failed`] carrying the error string. No items are produced
+/// after the terminal item.
+#[derive(Clone, Debug)]
+pub enum AgentStreamItem {
+    /// A live event emitted during the run. Carries the full
+    /// [`EventRecord`] (id + offset + [`AgentEvent`][crate::harness::events::AgentEvent])
+    /// so consumers keep ordering and lineage fields (`run_id`, `depth`).
+    Event(EventRecord),
+    /// Terminal: the run completed successfully. Boxed because [`AgentRun`] is
+    /// large relative to the event variant.
+    Completed(Box<AgentRun>),
+    /// Terminal: the run failed; carries the error rendered as a string.
+    Failed(String),
+}
+
+/// An [`EventListener`] that forwards every [`EventRecord`] into an unbounded
+/// channel. `on_event` is synchronous and must not block, so the channel is
+/// unbounded; in practice its depth is bounded by run progress (the loop awaits
+/// the network between emits). Send failures (receiver dropped) are ignored so
+/// a dropped stream never disturbs the run.
+struct ChannelListener {
+    tx: tokio::sync::mpsc::UnboundedSender<EventRecord>,
+}
+
+impl EventListener for ChannelListener {
+    fn on_event(&self, record: &EventRecord) {
+        let _ = self.tx.send(record.clone());
+    }
+}
+
+/// Maps a finished run result onto its terminal [`AgentStreamItem`].
+fn terminal_item(result: Result<AgentLoopResult>) -> AgentStreamItem {
+    match result {
+        Ok(loop_result) => AgentStreamItem::Completed(Box::new(loop_result.run)),
+        Err(error) => AgentStreamItem::Failed(error.to_string()),
+    }
+}
+
+/// Drive-phase for the streaming state machine.
+enum Phase<'a> {
+    /// The run future is still executing.
+    Running(Pin<Box<dyn Future<Output = Result<AgentLoopResult>> + 'a>>),
+    /// The run has finished; drain any buffered events, then emit `terminal`.
+    Draining(AgentStreamItem),
+    /// Terminal item already emitted; the stream is exhausted.
+    Done,
+}
+
+impl<State: Send + Sync, Ctx: Send + Sync + 'static> AgentHarness<State, Ctx> {
+    /// Runs the agent loop while streaming every emitted event to the caller.
+    ///
+    /// Returns a [`Stream`][futures::Stream] of [`AgentStreamItem`]s: live
+    /// [`AgentStreamItem::Event`]s in emission order (model/reasoning deltas,
+    /// tool-call lifecycle, sub-agent lifecycle, usage, …) followed by a single
+    /// terminal [`AgentStreamItem::Completed`] / [`AgentStreamItem::Failed`].
+    /// Driving the loop and consuming the stream are the same task: the run
+    /// only makes progress while the stream is polled, so a caller that stops
+    /// polling pauses the run (and dropping the stream cancels it).
+    ///
+    /// This is the streaming counterpart of
+    /// [`AgentHarness::invoke_streaming`]; the run itself is identical (each
+    /// model call is driven through
+    /// [`ChatModel::stream`][crate::harness::model::ChatModel::stream]).
+    pub fn invoke_stream<'a>(
+        &'a self,
+        state: &'a State,
+        ctx_data: Ctx,
+        config: RunConfig,
+        input: Vec<Message>,
+    ) -> impl futures::Stream<Item = AgentStreamItem> + 'a {
+        let ctx = RunContext::new(config, ctx_data);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        // Subscribe before driving so no event (starting with `RunStarted`) is
+        // missed. The listener rides the run's `EventSink`, which sub-agents
+        // clone, so their lifecycle events reach this stream too.
+        ctx.events.subscribe(Arc::new(ChannelListener { tx }));
+
+        // `invoke_streaming_in_context_with_status` is the public wrapper over
+        // the shared `drive(.., streaming = true)` path; it drives *our* `ctx`
+        // (with the listener already attached) and hands back the terminal
+        // `AgentLoopResult`.
+        let run_fut: Pin<Box<dyn Future<Output = Result<AgentLoopResult>> + 'a>> =
+            Box::pin(self.invoke_streaming_in_context_with_status(state, ctx, input));
+
+        futures::stream::unfold(
+            (Phase::Running(run_fut), rx),
+            |(phase, mut rx)| async move {
+                match phase {
+                    Phase::Running(mut run_fut) => {
+                        tokio::select! {
+                            biased;
+                            // Prefer draining ready events so the consumer sees
+                            // fine-grained progress rather than a late burst.
+                            maybe = rx.recv() => match maybe {
+                                Some(record) => {
+                                    Some((AgentStreamItem::Event(record), (Phase::Running(run_fut), rx)))
+                                }
+                                None => {
+                                    // All senders dropped (the run's context —
+                                    // and every sub-agent clone of the sink —
+                                    // is gone): the run is finishing. Await it
+                                    // for the terminal item.
+                                    let terminal = terminal_item(run_fut.await);
+                                    Some((terminal, (Phase::Done, rx)))
+                                }
+                            },
+                            result = &mut run_fut => {
+                                // The run finished. Events emitted during this
+                                // final poll may still be buffered; drain them
+                                // ahead of the terminal item.
+                                let terminal = terminal_item(result);
+                                match rx.try_recv() {
+                                    Ok(record) => Some((
+                                        AgentStreamItem::Event(record),
+                                        (Phase::Draining(terminal), rx),
+                                    )),
+                                    Err(_) => Some((terminal, (Phase::Done, rx))),
+                                }
+                            }
+                        }
+                    }
+                    Phase::Draining(terminal) => match rx.try_recv() {
+                        Ok(record) => Some((
+                            AgentStreamItem::Event(record),
+                            (Phase::Draining(terminal), rx),
+                        )),
+                        Err(_) => Some((terminal, (Phase::Done, rx))),
+                    },
+                    Phase::Done => None,
+                }
+            },
+        )
+    }
+}

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -9,10 +9,13 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use serde_json::json;
 
+use super::AgentStreamItem;
 use crate::error::{Result, TinyAgentsError};
 use crate::harness::context::{RunConfig, RunContext};
+use crate::harness::events::AgentEvent;
 use crate::harness::limits::RunLimits;
 use crate::harness::message::{AssistantMessage, ContentBlock, Message, MessageDelta};
 use crate::harness::middleware::{
@@ -1951,4 +1954,155 @@ async fn unknown_tool_recovery_keeps_its_slot_in_a_parallel_turn() {
     assert!(run.messages[2].text().contains("unknown tool `missing`"));
     assert_eq!(second.tool_call_id, "call-b");
     assert_eq!(run.messages[3].text(), "beta-out");
+}
+
+// ── invoke_stream (caller-consumable streaming) ──────────────────────────────
+
+/// Collects an `invoke_stream` run into a vec and returns (events, terminal).
+async fn collect_stream(items: Vec<AgentStreamItem>) -> (Vec<AgentEvent>, AgentStreamItem) {
+    let terminal = items
+        .last()
+        .cloned()
+        .expect("stream must yield at least a terminal item");
+    // Exactly one terminal, and it is the final item.
+    let terminals = items
+        .iter()
+        .filter(|i| !matches!(i, AgentStreamItem::Event(_)))
+        .count();
+    assert_eq!(terminals, 1, "exactly one terminal item");
+    assert!(
+        !matches!(
+            items[..items.len() - 1].last(),
+            Some(AgentStreamItem::Completed(_))
+        ) && !matches!(
+            items[..items.len() - 1].last(),
+            Some(AgentStreamItem::Failed(_))
+        ),
+        "terminal must be last"
+    );
+    let events = items
+        .into_iter()
+        .filter_map(|i| match i {
+            AgentStreamItem::Event(r) => Some(r.event),
+            _ => None,
+        })
+        .collect();
+    (events, terminal)
+}
+
+#[tokio::test]
+async fn invoke_stream_yields_events_then_completed() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model("mock", Arc::new(MockModel::constant("hello there")));
+
+    let items: Vec<AgentStreamItem> = harness
+        .invoke_stream(
+            &(),
+            (),
+            RunConfig::new("run-stream"),
+            vec![Message::user("hi")],
+        )
+        .collect()
+        .await;
+    let (events, terminal) = collect_stream(items).await;
+
+    match terminal {
+        AgentStreamItem::Completed(run) => {
+            assert_eq!(run.text().as_deref(), Some("hello there"));
+        }
+        other => panic!("expected Completed terminal, got {other:?}"),
+    }
+    // Live events flowed before the terminal: run lifecycle + a model delta.
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RunStarted { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ModelDelta { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RunCompleted { .. }))
+    );
+}
+
+#[tokio::test]
+async fn invoke_stream_surfaces_tool_lifecycle() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("c1", "spin", json!({})),
+            text_response("done", 5, 2),
+        ])),
+    );
+    harness.register_tool(Arc::new(FakeTool::new("spin", "again")));
+
+    let items: Vec<AgentStreamItem> = harness
+        .invoke_stream(
+            &(),
+            (),
+            RunConfig::new("run-tools"),
+            vec![Message::user("go")],
+        )
+        .collect()
+        .await;
+    let (events, terminal) = collect_stream(items).await;
+
+    let started = events.iter().position(
+        |e| matches!(e, AgentEvent::ToolStarted { tool_name, .. } if tool_name == "spin"),
+    );
+    let completed = events.iter().position(
+        |e| matches!(e, AgentEvent::ToolCompleted { tool_name, .. } if tool_name == "spin"),
+    );
+    assert!(started.is_some(), "ToolStarted for spin must be streamed");
+    assert!(
+        completed.is_some(),
+        "ToolCompleted for spin must be streamed"
+    );
+    assert!(
+        started < completed,
+        "ToolStarted must precede ToolCompleted in the stream"
+    );
+    match terminal {
+        AgentStreamItem::Completed(run) => assert_eq!(run.text().as_deref(), Some("done")),
+        other => panic!("expected Completed terminal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invoke_stream_yields_failed_terminal_on_error() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    // A model that always asks for the tool, capped so the loop trips the limit.
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_tool_call("spin", json!({}))),
+    );
+    harness.register_tool(Arc::new(FakeTool::new("spin", "again")));
+    harness.with_policy(RunPolicy {
+        limits: RunLimits::default().with_max_model_calls(1),
+        ..RunPolicy::default()
+    });
+
+    let items: Vec<AgentStreamItem> = harness
+        .invoke_stream(
+            &(),
+            (),
+            RunConfig::new("run-fail"),
+            vec![Message::user("go")],
+        )
+        .collect()
+        .await;
+    let (_events, terminal) = collect_stream(items).await;
+
+    match terminal {
+        AgentStreamItem::Failed(message) => {
+            assert!(message.contains("max model calls"), "got: {message}");
+        }
+        other => panic!("expected Failed terminal, got {other:?}"),
+    }
 }

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -2106,3 +2106,62 @@ async fn invoke_stream_yields_failed_terminal_on_error() {
         other => panic!("expected Failed terminal, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn invoke_stream_scripted_incremental_deltas_surface_reasoning() {
+    // A scripted stream drives truly incremental deltas — a reasoning fragment
+    // and two text fragments — which must all surface on the event stream.
+    let script = vec![
+        ModelStreamItem::Started,
+        ModelStreamItem::MessageDelta(MessageDelta::reasoning("thinking hard")),
+        ModelStreamItem::MessageDelta(MessageDelta::text("hel")),
+        ModelStreamItem::MessageDelta(MessageDelta::text("lo")),
+        ModelStreamItem::Completed(ModelResponse::assistant("hello")),
+    ];
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model("mock", Arc::new(MockModel::streaming_script(script)));
+
+    let items: Vec<AgentStreamItem> = harness
+        .invoke_stream(
+            &(),
+            (),
+            RunConfig::new("run-script"),
+            vec![Message::user("hi")],
+        )
+        .collect()
+        .await;
+    let (events, terminal) = collect_stream(items).await;
+
+    // The scripted reasoning fragment surfaces on a ModelDelta event.
+    assert!(events.iter().any(
+        |e| matches!(e, AgentEvent::ModelDelta { delta, .. } if delta.reasoning == "thinking hard")
+    ));
+    // Text arrives as multiple incremental deltas, not one merged blob.
+    let text_deltas = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ModelDelta { delta, .. } if !delta.text.is_empty()))
+        .count();
+    assert!(
+        text_deltas >= 2,
+        "expected incremental text deltas, got {text_deltas}"
+    );
+
+    match terminal {
+        AgentStreamItem::Completed(run) => assert_eq!(run.text().as_deref(), Some("hello")),
+        other => panic!("expected Completed terminal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mock_streaming_script_invoke_folds_items_to_response() {
+    // `invoke` on a scripted-stream mock folds the items into the equivalent
+    // unary response (delta-only script → reconstructed from deltas).
+    let model = MockModel::streaming_script(vec![
+        ModelStreamItem::MessageDelta(MessageDelta::text("ab")),
+        ModelStreamItem::MessageDelta(MessageDelta::text("cd")),
+    ]);
+    let response = ChatModel::invoke(&model, &(), ModelRequest::new(vec![]))
+        .await
+        .expect("fold succeeds");
+    assert_eq!(response.text(), "abcd");
+}

--- a/src/harness/context/mod.rs
+++ b/src/harness/context/mod.rs
@@ -193,6 +193,7 @@ impl<Ctx> RunContext<Ctx> {
             cancellation: CancellationToken::new(),
             control: std::sync::Arc::new(std::sync::Mutex::new(None)),
             workspace: None,
+            streaming: false,
         }
     }
 

--- a/src/harness/context/types.rs
+++ b/src/harness/context/types.rs
@@ -193,4 +193,12 @@ pub struct RunContext<Ctx = ()> {
     /// [`WorkspaceIsolation`][crate::harness::workspace::WorkspaceIsolation]
     /// provider; `None` means no workspace policy is in effect.
     pub workspace: Option<crate::harness::workspace::WorkspaceDescriptor>,
+    /// Whether this run is being driven through the streaming loop path
+    /// (`ChatModel::stream`), set by the agent-loop driver. Threaded into each
+    /// [`ToolExecutionContext`][crate::harness::tool::ToolExecutionContext] so a
+    /// sub-agent tool can run its child in the matching mode — the child's
+    /// model/reasoning deltas then propagate to the parent's stream via the
+    /// shared [`EventSink`]. A non-streaming parent leaves this `false`, so its
+    /// event stream is unchanged.
+    pub streaming: bool,
 }

--- a/src/harness/providers/mock.rs
+++ b/src/harness/providers/mock.rs
@@ -91,6 +91,25 @@ impl MockModel {
         }
     }
 
+    /// Creates a `MockModel` that streams a caller-provided list of
+    /// [`ModelStreamItem`]s verbatim, so streaming tests are *truly*
+    /// incremental — fine-grained text/reasoning/tool-call deltas in the exact
+    /// order given — rather than the one-or-two synthetic deltas the other
+    /// constructors replay.
+    ///
+    /// [`ChatModel::stream`] emits the items as-is; [`ChatModel::invoke`] folds
+    /// them through a
+    /// [`StreamAccumulator`][crate::harness::model::StreamAccumulator] to
+    /// produce the equivalent unary [`ModelResponse`]. Items may end with a
+    /// terminal [`ModelStreamItem::Completed`], or be delta-only (the
+    /// accumulator reconstructs the response from the deltas).
+    pub fn streaming_script(items: Vec<ModelStreamItem>) -> Self {
+        Self {
+            behavior: MockBehavior::StreamScript(items),
+            inner: std::sync::Mutex::new(MockInner::default()),
+        }
+    }
+
     /// Returns the total number of [`ChatModel::invoke`] calls made so far.
     ///
     /// `stream` calls that delegate to `invoke` also increment this counter.
@@ -209,6 +228,16 @@ impl<State: Send + Sync> ChatModel<State> for MockModel {
                     resolved_model: None,
                 }
             }
+
+            MockBehavior::StreamScript(items) => {
+                // Fold the scripted stream items into the equivalent unary
+                // response so `invoke` and `stream` agree.
+                let mut accumulator = crate::harness::model::StreamAccumulator::new();
+                for item in items {
+                    accumulator.push(item);
+                }
+                accumulator.finish()?
+            }
         };
 
         // Stamp the message id on text-based responses for traceability.
@@ -231,6 +260,19 @@ impl<State: Send + Sync> ChatModel<State> for MockModel {
     /// infrastructure. Tool-call (or otherwise text-less) responses emit a
     /// single empty text delta before completing.
     async fn stream(&self, state: &State, request: ModelRequest) -> Result<ModelStream> {
+        // Scripted streams are emitted verbatim so tests see the exact,
+        // fine-grained item sequence rather than the invoke-and-replay split.
+        if let MockBehavior::StreamScript(items) = &self.behavior {
+            {
+                let mut inner = self
+                    .inner
+                    .lock()
+                    .map_err(|e| TinyAgentsError::Model(format!("MockModel lock poisoned: {e}")))?;
+                inner.call_count += 1;
+            }
+            return Ok(Box::pin(futures::stream::iter(items.clone())));
+        }
+
         let response = self.invoke(state, request).await?;
         let text = response.text();
 

--- a/src/harness/providers/types.rs
+++ b/src/harness/providers/types.rs
@@ -261,6 +261,14 @@ pub(crate) enum MockBehavior {
         /// JSON arguments to supply to the tool.
         arguments: Value,
     },
+
+    /// Emits a caller-provided list of [`ModelStreamItem`]s verbatim when
+    /// streamed, so tests exercise truly incremental streaming (fine-grained
+    /// text/reasoning/tool-call deltas). See [`MockModel::streaming_script`].
+    /// `invoke` folds the same items through a
+    /// [`StreamAccumulator`][crate::harness::model::StreamAccumulator] to
+    /// produce the equivalent unary response.
+    StreamScript(Vec<crate::harness::model::ModelStreamItem>),
 }
 
 // ---------------------------------------------------------------------------

--- a/src/harness/subagent/mod.rs
+++ b/src/harness/subagent/mod.rs
@@ -185,7 +185,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> SubAgent<State, Ctx> {
     ) -> Result<AgentRun> {
         let config = self.child_config(parent_depth, None, None)?;
         let ctx = RunContext::new(config, ctx_data);
-        self.run_child(state, ctx, input.into()).await
+        self.run_child(state, ctx, input.into(), false).await
     }
 
     /// Like [`Self::invoke`] but routes the child run's events (and the
@@ -201,7 +201,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> SubAgent<State, Ctx> {
     ) -> Result<AgentRun> {
         let config = self.child_config(parent_depth, None, None)?;
         let ctx = RunContext::new(config, ctx_data).with_events(events.clone());
-        self.run_child(state, ctx, input.into()).await
+        self.run_child(state, ctx, input.into(), false).await
     }
 
     /// Runs the sub-agent as a child of the live `parent` context.
@@ -227,16 +227,24 @@ impl<State: Send + Sync, Ctx: Send + Sync> SubAgent<State, Ctx> {
             parent.config.max_turn_output_tokens,
         )?;
         let ctx = RunContext::new(config, ctx_data).with_events(parent.events.clone());
-        self.run_child(state, ctx, input.into()).await
+        self.run_child(state, ctx, input.into(), parent.streaming)
+            .await
     }
 
     /// Shared driver: emits the sub-agent lifecycle events around the child
     /// agent loop.
+    ///
+    /// When `streaming` is `true` the child runs through the streaming loop
+    /// path, so its per-token model/reasoning deltas are emitted onto the
+    /// shared [`EventSink`] and reach the parent's stream (stamped with the
+    /// child's own `run_id` and `depth`). When `false` the child runs the
+    /// unary path, leaving the parent's event stream unchanged.
     async fn run_child(
         &self,
         state: &State,
         ctx: RunContext<Ctx>,
         input: String,
+        streaming: bool,
     ) -> Result<AgentRun> {
         let depth = ctx.depth();
         let messages = self.seed_messages(input);
@@ -250,7 +258,13 @@ impl<State: Send + Sync, Ctx: Send + Sync> SubAgent<State, Ctx> {
             depth,
         });
 
-        let run = self.harness.invoke_in_context(state, ctx, messages).await?;
+        let run = if streaming {
+            self.harness
+                .invoke_streaming_in_context(state, ctx, messages)
+                .await?
+        } else {
+            self.harness.invoke_in_context(state, ctx, messages).await?
+        };
 
         events.emit(AgentEvent::SubAgentCompleted {
             name: self.name.clone(),
@@ -580,7 +594,14 @@ where
             }
         };
         let ctx = RunContext::new(config, Ctx::default()).with_events(context.events);
-        let run = match self.subagent.run_child(state, ctx, input).await {
+        // Match the parent's drive mode: when the parent run streams, the child
+        // streams too, so its deltas flow onto the shared sink and reach the
+        // parent's `invoke_stream` consumer with the child's own lineage.
+        let run = match self
+            .subagent
+            .run_child(state, ctx, input, context.streaming)
+            .await
+        {
             Ok(run) => run,
             Err(error) => {
                 if let Some(result) =

--- a/src/harness/subagent/test.rs
+++ b/src/harness/subagent/test.rs
@@ -654,3 +654,120 @@ fn subagent_tool_schema_uses_name_and_description() {
     assert_eq!(schema.description, "writes prose");
     assert_eq!(schema.parameters["required"][0], "input");
 }
+
+#[tokio::test]
+async fn subagent_deltas_propagate_to_parent_stream() {
+    use crate::harness::agent_loop::AgentStreamItem;
+    use futures::StreamExt;
+
+    // Child streams its answer; parent delegates to it via a tool then finishes.
+    let child = Arc::new(SubAgent::new(
+        "researcher",
+        "answers research questions",
+        Arc::new(child_harness("the streamed child answer")),
+    ));
+    let tool = Arc::new(SubAgentTool::new(child));
+
+    let mut parent: AgentHarness<()> = AgentHarness::new();
+    parent.register_tool(tool);
+    parent.register_model(
+        "parent-model",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("c1", "researcher", json!({ "input": "what is rust?" })),
+            text_response("parent final answer"),
+        ])),
+    );
+
+    let items: Vec<AgentStreamItem> = parent
+        .invoke_stream(
+            &(),
+            (),
+            RunConfig::new("parent"),
+            vec![Message::user("delegate")],
+        )
+        .collect()
+        .await;
+    let events: Vec<AgentEvent> = items
+        .iter()
+        .filter_map(|i| match i {
+            AgentStreamItem::Event(record) => Some(record.event.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // Sub-agent lifecycle at depth 1 is visible in the parent stream.
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::SubAgentStarted { depth: 1, .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::SubAgentCompleted { depth: 1, .. }))
+    );
+
+    // The CHILD's own model deltas propagate to the parent stream, stamped with
+    // the child's run id (lineage), not the parent's.
+    let child_delta_pos = events.iter().position(|e| {
+        matches!(e, AgentEvent::ModelDelta { run_id, .. } if run_id.as_str().starts_with("researcher-d1"))
+    });
+    assert!(
+        child_delta_pos.is_some(),
+        "child model deltas must appear in the parent stream"
+    );
+    // The parent's own deltas are stamped with the parent run id.
+    assert!(events.iter().any(
+        |e| matches!(e, AgentEvent::ModelDelta { run_id, .. } if run_id.as_str() == "parent")
+    ));
+    // The child delta arrives before the parent's run completes.
+    let parent_completed_pos = events.iter().position(
+        |e| matches!(e, AgentEvent::RunCompleted { run_id } if run_id.as_str() == "parent"),
+    );
+    assert!(child_delta_pos < parent_completed_pos);
+
+    match items.last() {
+        Some(AgentStreamItem::Completed(run)) => {
+            assert_eq!(run.text().as_deref(), Some("parent final answer"))
+        }
+        other => panic!("expected Completed terminal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_streaming_parent_does_not_stream_child_deltas() {
+    // A non-streaming parent (invoke, not invoke_stream) must leave the child on
+    // the unary path: no child ModelDelta events land on the shared sink.
+    let recorder = Arc::new(RecordingListener::new());
+    let child = Arc::new(SubAgent::new(
+        "researcher",
+        "answers",
+        Arc::new(child_harness("child answer")),
+    ));
+    let tool = Arc::new(SubAgentTool::new(child));
+
+    let mut parent: AgentHarness<()> = AgentHarness::new();
+    parent.register_tool(tool);
+    parent.register_model(
+        "parent-model",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("c1", "researcher", json!({ "input": "q" })),
+            text_response("done"),
+        ])),
+    );
+
+    let ctx: RunContext<()> = RunContext::new(RunConfig::new("parent"), ());
+    ctx.events.subscribe(recorder.clone());
+    parent
+        .invoke_in_context(&(), ctx, vec![Message::user("go")])
+        .await
+        .expect("run succeeds");
+
+    let child_deltas = recorder.events().into_iter().any(|record| {
+        matches!(record.event, AgentEvent::ModelDelta { ref run_id, .. } if run_id.as_str().starts_with("researcher-d1"))
+    });
+    assert!(
+        !child_deltas,
+        "a non-streaming parent must not emit child model deltas"
+    );
+}

--- a/src/harness/tool/types.rs
+++ b/src/harness/tool/types.rs
@@ -111,6 +111,10 @@ pub struct ToolExecutionContext {
     pub max_turn_output_tokens: Option<u32>,
     /// Shared event sink for nested run observability.
     pub events: EventSink,
+    /// Whether the caller run is being driven through the streaming loop path.
+    /// A sub-agent tool uses this to run its child in the matching mode so the
+    /// child's deltas propagate onto the shared [`EventSink`].
+    pub streaming: bool,
     /// The isolated workspace/sandbox the tool may operate in, when the run was
     /// configured with a
     /// [`WorkspaceIsolation`][crate::harness::workspace::WorkspaceIsolation]
@@ -128,6 +132,7 @@ impl ToolExecutionContext {
             depth: ctx.config.depth,
             max_turn_output_tokens: ctx.config.max_turn_output_tokens,
             events: ctx.events.clone(),
+            streaming: ctx.streaming,
             workspace: ctx.workspace.clone(),
         }
     }


### PR DESCRIPTION
## Summary

Adds a caller-consumable streaming API to the agent harness and the sub-agent
propagation + mock fidelity that make it useful.

### `invoke_stream` (Step 1)
`AgentHarness::invoke_stream(...)` returns an async `Stream<Item = AgentStreamItem>`
— live `Event(EventRecord)` items in emission order (model/reasoning deltas,
`ToolStarted`/`ToolCompleted` lifecycle, sub-agent lifecycle, usage, …), then
exactly one terminal `Completed(run)` / `Failed(err)`. It's a thin projection
over the existing ordered `EventSink::emit` fan-out — a `ChannelListener`
forwards each record into an unbounded channel the stream drains — not a
parallel event system. The run advances only while the stream is polled.

### Sub-agent model-delta propagation (Step 2)
A streaming parent now sees a child sub-agent's own model/reasoning deltas, not
just its start/complete bracket. The drive mode is threaded down: `RunContext`
gains a `streaming` flag (set by the loop driver), `ToolExecutionContext`
carries it, and `SubAgentTool` runs the child through the streaming path when
the parent is streaming. Because sub-agents already share the parent's
`EventSink`, child deltas land on the parent stream stamped with the child's
own `run_id` and `depth`. A non-streaming parent is unchanged (flag stays
`false`).

### `MockModel::streaming_script` (Step 4)
A `MockBehavior::StreamScript(Vec<ModelStreamItem>)` variant + constructor:
`stream()` emits the scripted items verbatim so tests exercise truly
incremental streaming (fine-grained text/reasoning/tool-call deltas), while
`invoke()` folds them through a `StreamAccumulator` into the equivalent unary
response.

Tool-call lifecycle events (Step 3 in the plan) already exist upstream and
surface through the stream unchanged.

## Tests
`invoke_stream` event-then-terminal ordering, tool-lifecycle surfacing, Failed
terminal; nested sub-agent asserts child deltas (child run id) arrive before
the parent completes, and that a non-streaming parent emits none; scripted
incremental deltas surface reasoning + multiple text deltas; invoke-fold.

## Commands run
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (939 lib + integration, green)

Ref: OpenHuman `docs/tinyagents-vendor-improvement-plan/03-streaming.md` (V3, Steps 1/2/4).
