### PR TITLE
[codex] Add tool schema cleaning helpers

### DIFF
--- a/src/harness/tool/mod.rs
+++ b/src/harness/tool/mod.rs
@@ -10,6 +10,7 @@
 //! See [`types`] for definitions. This module provides constructors and the
 //! [`ToolRegistry`] logic for registering and looking up tools by name.
 
+mod schema;
 mod types;
 
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use serde_json::Value;
 
 use crate::error::{Result, TinyAgentsError};
 
+pub use schema::*;
 pub use types::*;
 
 impl ToolSchema {
@@ -364,5 +366,7 @@ fn json_value_kind(value: &Value) -> &'static str {
     }
 }
 
+#[cfg(test)]
+mod schema_test;
 #[cfg(test)]
 mod test;

--- a/src/harness/tool/schema.rs
+++ b/src/harness/tool/schema.rs
@@ -1,0 +1,430 @@
+//! JSON Schema cleaning and validation for LLM tool-calling compatibility.
+//!
+//! Different providers accept different JSON Schema subsets for model-visible
+//! tool declarations. This module normalizes schemas while preserving semantic
+//! intent: it resolves local refs, removes provider-rejected keywords, flattens
+//! simple literal unions, strips nullable variants, converts `const` to `enum`,
+//! and breaks circular local refs safely.
+
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Map, Value, json};
+
+use crate::{Result, TinyAgentsError};
+
+/// Keywords that Gemini rejects for tool schemas.
+pub const GEMINI_UNSUPPORTED_KEYWORDS: &[&str] = &[
+    "$ref",
+    "$schema",
+    "$id",
+    "$defs",
+    "definitions",
+    "additionalProperties",
+    "patternProperties",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "format",
+    "minimum",
+    "maximum",
+    "multipleOf",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "minProperties",
+    "maxProperties",
+    "examples",
+];
+
+const SCHEMA_META_KEYS: &[&str] = &["description", "title", "default"];
+
+/// Schema cleaning strategies for different LLM providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleaningStrategy {
+    /// Gemini / Google AI / Vertex AI: most restrictive.
+    Gemini,
+    /// Anthropic Claude: moderately permissive, but local refs must be resolved.
+    Anthropic,
+    /// OpenAI: most permissive.
+    OpenAI,
+    /// Conservative common subset.
+    Conservative,
+}
+
+impl CleaningStrategy {
+    /// Returns the schema keywords rejected by this strategy.
+    pub fn unsupported_keywords(self) -> &'static [&'static str] {
+        match self {
+            Self::Gemini => GEMINI_UNSUPPORTED_KEYWORDS,
+            Self::Anthropic => &["$ref", "$defs", "definitions"],
+            Self::OpenAI => &[],
+            Self::Conservative => &["$ref", "$defs", "definitions", "additionalProperties"],
+        }
+    }
+}
+
+/// JSON Schema cleaner optimized for model tool-calling declarations.
+pub struct SchemaCleanr;
+
+impl SchemaCleanr {
+    /// Cleans a schema for Gemini compatibility.
+    pub fn clean_for_gemini(schema: Value) -> Value {
+        Self::clean(schema, CleaningStrategy::Gemini)
+    }
+
+    /// Cleans a schema for Anthropic compatibility.
+    pub fn clean_for_anthropic(schema: Value) -> Value {
+        Self::clean(schema, CleaningStrategy::Anthropic)
+    }
+
+    /// Cleans a schema for OpenAI compatibility.
+    pub fn clean_for_openai(schema: Value) -> Value {
+        Self::clean(schema, CleaningStrategy::OpenAI)
+    }
+
+    /// Cleans a schema with the specified strategy.
+    pub fn clean(schema: Value, strategy: CleaningStrategy) -> Value {
+        let defs = if let Some(obj) = schema.as_object() {
+            Self::extract_defs(obj)
+        } else {
+            HashMap::new()
+        };
+
+        Self::clean_with_defs(schema, &defs, strategy, &mut HashSet::new())
+    }
+
+    /// Validates that a schema is suitable for model tool calling.
+    pub fn validate(schema: &Value) -> Result<()> {
+        let obj = schema
+            .as_object()
+            .ok_or_else(|| TinyAgentsError::Validation("schema must be an object".to_string()))?;
+
+        if !obj.contains_key("type") {
+            return Err(TinyAgentsError::Validation(
+                "schema missing required `type` field".to_string(),
+            ));
+        }
+
+        if let Some(Value::String(schema_type)) = obj.get("type") {
+            if schema_type == "object" && !obj.contains_key("properties") {
+                // Valid but often rejected by providers; callers can decide how
+                // strict they want to be after validation succeeds.
+            }
+        }
+
+        Ok(())
+    }
+
+    fn extract_defs(obj: &Map<String, Value>) -> HashMap<String, Value> {
+        let mut defs = HashMap::new();
+
+        if let Some(Value::Object(defs_obj)) = obj.get("$defs") {
+            for (key, value) in defs_obj {
+                defs.insert(key.clone(), value.clone());
+            }
+        }
+
+        if let Some(Value::Object(defs_obj)) = obj.get("definitions") {
+            for (key, value) in defs_obj {
+                defs.insert(key.clone(), value.clone());
+            }
+        }
+
+        defs
+    }
+
+    fn clean_with_defs(
+        schema: Value,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Value {
+        match schema {
+            Value::Object(obj) => Self::clean_object(obj, defs, strategy, ref_stack),
+            Value::Array(arr) => Value::Array(
+                arr.into_iter()
+                    .map(|value| Self::clean_with_defs(value, defs, strategy, ref_stack))
+                    .collect(),
+            ),
+            other => other,
+        }
+    }
+
+    fn clean_object(
+        obj: Map<String, Value>,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Value {
+        if let Some(Value::String(ref_value)) = obj.get("$ref") {
+            return Self::resolve_ref(ref_value, &obj, defs, strategy, ref_stack);
+        }
+
+        if (obj.contains_key("anyOf") || obj.contains_key("oneOf"))
+            && let Some(simplified) = Self::try_simplify_union(&obj, defs, strategy, ref_stack)
+        {
+            return simplified;
+        }
+
+        let mut cleaned = Map::new();
+        let unsupported: HashSet<&str> = strategy.unsupported_keywords().iter().copied().collect();
+        let has_union = obj.contains_key("anyOf") || obj.contains_key("oneOf");
+
+        for (key, value) in obj {
+            if unsupported.contains(key.as_str()) {
+                continue;
+            }
+
+            match key.as_str() {
+                "const" => {
+                    cleaned.insert("enum".to_string(), json!([value]));
+                }
+                "type" if has_union => {}
+                "type" if matches!(value, Value::Array(_)) => {
+                    cleaned.insert(key, Self::clean_type_array(value));
+                }
+                "properties" => {
+                    cleaned.insert(
+                        key,
+                        Self::clean_properties(value, defs, strategy, ref_stack),
+                    );
+                }
+                "items" => {
+                    cleaned.insert(key, Self::clean_with_defs(value, defs, strategy, ref_stack));
+                }
+                "anyOf" | "oneOf" | "allOf" => {
+                    cleaned.insert(key, Self::clean_union(value, defs, strategy, ref_stack));
+                }
+                _ => {
+                    let cleaned_value = match value {
+                        Value::Object(_) | Value::Array(_) => {
+                            Self::clean_with_defs(value, defs, strategy, ref_stack)
+                        }
+                        other => other,
+                    };
+                    cleaned.insert(key, cleaned_value);
+                }
+            }
+        }
+
+        Value::Object(cleaned)
+    }
+
+    fn resolve_ref(
+        ref_value: &str,
+        obj: &Map<String, Value>,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Value {
+        if ref_stack.contains(ref_value) {
+            return Self::preserve_meta(obj, Value::Object(Map::new()));
+        }
+
+        if let Some(def_name) = Self::parse_local_ref(ref_value) {
+            if let Some(definition) = defs.get(def_name.as_str()) {
+                ref_stack.insert(ref_value.to_string());
+                let cleaned = Self::clean_with_defs(definition.clone(), defs, strategy, ref_stack);
+                ref_stack.remove(ref_value);
+                return Self::preserve_meta(obj, cleaned);
+            }
+        }
+
+        Self::preserve_meta(obj, Value::Object(Map::new()))
+    }
+
+    fn parse_local_ref(ref_value: &str) -> Option<String> {
+        ref_value
+            .strip_prefix("#/$defs/")
+            .or_else(|| ref_value.strip_prefix("#/definitions/"))
+            .map(Self::decode_json_pointer)
+    }
+
+    fn decode_json_pointer(segment: &str) -> String {
+        if !segment.contains('~') {
+            return segment.to_string();
+        }
+
+        let mut decoded = String::with_capacity(segment.len());
+        let mut chars = segment.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if ch == '~' {
+                match chars.peek().copied() {
+                    Some('0') => {
+                        chars.next();
+                        decoded.push('~');
+                    }
+                    Some('1') => {
+                        chars.next();
+                        decoded.push('/');
+                    }
+                    _ => decoded.push('~'),
+                }
+            } else {
+                decoded.push(ch);
+            }
+        }
+
+        decoded
+    }
+
+    fn try_simplify_union(
+        obj: &Map<String, Value>,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Option<Value> {
+        let union_key = if obj.contains_key("anyOf") {
+            "anyOf"
+        } else if obj.contains_key("oneOf") {
+            "oneOf"
+        } else {
+            return None;
+        };
+
+        let variants = obj.get(union_key)?.as_array()?;
+        let cleaned_variants: Vec<Value> = variants
+            .iter()
+            .map(|value| Self::clean_with_defs(value.clone(), defs, strategy, ref_stack))
+            .collect();
+        let non_null: Vec<Value> = cleaned_variants
+            .into_iter()
+            .filter(|value| !Self::is_null_schema(value))
+            .collect();
+
+        if non_null.len() == 1 {
+            return Some(Self::preserve_meta(obj, non_null[0].clone()));
+        }
+
+        if let Some(enum_value) = Self::try_flatten_literal_union(&non_null) {
+            return Some(Self::preserve_meta(obj, enum_value));
+        }
+
+        None
+    }
+
+    fn is_null_schema(value: &Value) -> bool {
+        if let Some(obj) = value.as_object() {
+            if let Some(Value::Null) = obj.get("const") {
+                return true;
+            }
+            if let Some(Value::Array(arr)) = obj.get("enum") {
+                if arr.len() == 1 && matches!(arr[0], Value::Null) {
+                    return true;
+                }
+            }
+            if let Some(Value::String(schema_type)) = obj.get("type") {
+                if schema_type == "null" {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn try_flatten_literal_union(variants: &[Value]) -> Option<Value> {
+        if variants.is_empty() {
+            return None;
+        }
+
+        let mut values = Vec::new();
+        let mut common_type: Option<String> = None;
+
+        for variant in variants {
+            let obj = variant.as_object()?;
+            let literal = if let Some(const_value) = obj.get("const") {
+                const_value.clone()
+            } else if let Some(Value::Array(arr)) = obj.get("enum") {
+                if arr.len() == 1 {
+                    arr[0].clone()
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            };
+
+            let variant_type = obj.get("type")?.as_str()?;
+            match &common_type {
+                None => common_type = Some(variant_type.to_string()),
+                Some(existing) if existing != variant_type => return None,
+                _ => {}
+            }
+
+            values.push(literal);
+        }
+
+        common_type.map(|schema_type| {
+            json!({
+                "type": schema_type,
+                "enum": values
+            })
+        })
+    }
+
+    fn clean_type_array(value: Value) -> Value {
+        if let Value::Array(types) = value {
+            let non_null: Vec<Value> = types
+                .into_iter()
+                .filter(|value| value.as_str() != Some("null"))
+                .collect();
+
+            match non_null.len() {
+                0 => Value::String("null".to_string()),
+                1 => non_null
+                    .into_iter()
+                    .next()
+                    .unwrap_or(Value::String("null".to_string())),
+                _ => Value::Array(non_null),
+            }
+        } else {
+            value
+        }
+    }
+
+    fn clean_properties(
+        value: Value,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Value {
+        if let Value::Object(props) = value {
+            let cleaned: Map<String, Value> = props
+                .into_iter()
+                .map(|(key, value)| (key, Self::clean_with_defs(value, defs, strategy, ref_stack)))
+                .collect();
+            Value::Object(cleaned)
+        } else {
+            value
+        }
+    }
+
+    fn clean_union(
+        value: Value,
+        defs: &HashMap<String, Value>,
+        strategy: CleaningStrategy,
+        ref_stack: &mut HashSet<String>,
+    ) -> Value {
+        if let Value::Array(variants) = value {
+            let cleaned: Vec<Value> = variants
+                .into_iter()
+                .map(|value| Self::clean_with_defs(value, defs, strategy, ref_stack))
+                .collect();
+            Value::Array(cleaned)
+        } else {
+            value
+        }
+    }
+
+    fn preserve_meta(source: &Map<String, Value>, mut target: Value) -> Value {
+        if let Value::Object(target_obj) = &mut target {
+            for &key in SCHEMA_META_KEYS {
+                if let Some(value) = source.get(key) {
+                    target_obj.insert(key.to_string(), value.clone());
+                }
+            }
+        }
+        target
+    }
+}

--- a/src/harness/tool/schema.rs
+++ b/src/harness/tool/schema.rs
@@ -105,11 +105,12 @@ impl SchemaCleanr {
             ));
         }
 
-        if let Some(Value::String(schema_type)) = obj.get("type") {
-            if schema_type == "object" && !obj.contains_key("properties") {
-                // Valid but often rejected by providers; callers can decide how
-                // strict they want to be after validation succeeds.
-            }
+        if let Some(Value::String(schema_type)) = obj.get("type")
+            && schema_type == "object"
+            && !obj.contains_key("properties")
+        {
+            // Valid but often rejected by providers; callers can decide how
+            // strict they want to be after validation succeeds.
         }
 
         Ok(())
@@ -221,13 +222,13 @@ impl SchemaCleanr {
             return Self::preserve_meta(obj, Value::Object(Map::new()));
         }
 
-        if let Some(def_name) = Self::parse_local_ref(ref_value) {
-            if let Some(definition) = defs.get(def_name.as_str()) {
-                ref_stack.insert(ref_value.to_string());
-                let cleaned = Self::clean_with_defs(definition.clone(), defs, strategy, ref_stack);
-                ref_stack.remove(ref_value);
-                return Self::preserve_meta(obj, cleaned);
-            }
+        if let Some(def_name) = Self::parse_local_ref(ref_value)
+            && let Some(definition) = defs.get(def_name.as_str())
+        {
+            ref_stack.insert(ref_value.to_string());
+            let cleaned = Self::clean_with_defs(definition.clone(), defs, strategy, ref_stack);
+            ref_stack.remove(ref_value);
+            return Self::preserve_meta(obj, cleaned);
         }
 
         Self::preserve_meta(obj, Value::Object(Map::new()))
@@ -309,15 +310,16 @@ impl SchemaCleanr {
             if let Some(Value::Null) = obj.get("const") {
                 return true;
             }
-            if let Some(Value::Array(arr)) = obj.get("enum") {
-                if arr.len() == 1 && matches!(arr[0], Value::Null) {
-                    return true;
-                }
+            if let Some(Value::Array(arr)) = obj.get("enum")
+                && arr.len() == 1
+                && matches!(arr[0], Value::Null)
+            {
+                return true;
             }
-            if let Some(Value::String(schema_type)) = obj.get("type") {
-                if schema_type == "null" {
-                    return true;
-                }
+            if let Some(Value::String(schema_type)) = obj.get("type")
+                && schema_type == "null"
+            {
+                return true;
             }
         }
         false

--- a/src/harness/tool/schema_test.rs
+++ b/src/harness/tool/schema_test.rs
@@ -1,0 +1,298 @@
+//! Tests for provider-oriented JSON Schema cleaning.
+
+use super::*;
+use serde_json::json;
+
+#[test]
+fn removes_unsupported_keywords() {
+    let schema = json!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 100,
+        "pattern": "^[a-z]+$",
+        "description": "A lowercase string"
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+    assert_eq!(cleaned["description"], "A lowercase string");
+    assert!(cleaned.get("minLength").is_none());
+    assert!(cleaned.get("maxLength").is_none());
+    assert!(cleaned.get("pattern").is_none());
+}
+
+#[test]
+fn resolves_local_refs() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "age": {
+                "$ref": "#/$defs/Age"
+            }
+        },
+        "$defs": {
+            "Age": {
+                "type": "integer",
+                "minimum": 0
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["properties"]["age"]["type"], "integer");
+    assert!(cleaned["properties"]["age"].get("minimum").is_none());
+    assert!(cleaned.get("$defs").is_none());
+}
+
+#[test]
+fn flattens_literal_union() {
+    let schema = json!({
+        "anyOf": [
+            { "const": "admin", "type": "string" },
+            { "const": "user", "type": "string" },
+            { "const": "guest", "type": "string" }
+        ]
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+    let enum_values = cleaned["enum"].as_array().unwrap();
+    assert_eq!(enum_values.len(), 3);
+    assert!(enum_values.contains(&json!("admin")));
+    assert!(enum_values.contains(&json!("user")));
+    assert!(enum_values.contains(&json!("guest")));
+}
+
+#[test]
+fn strips_null_from_union() {
+    let schema = json!({
+        "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+        ]
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+    assert!(cleaned.get("oneOf").is_none());
+}
+
+#[test]
+fn converts_const_to_enum() {
+    let schema = json!({
+        "const": "fixed_value",
+        "description": "A constant"
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["enum"], json!(["fixed_value"]));
+    assert_eq!(cleaned["description"], "A constant");
+    assert!(cleaned.get("const").is_none());
+}
+
+#[test]
+fn preserves_metadata_across_ref_resolution() {
+    let schema = json!({
+        "$ref": "#/$defs/Name",
+        "description": "User's name",
+        "title": "Name Field",
+        "default": "Anonymous",
+        "$defs": {
+            "Name": {
+                "type": "string"
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+    assert_eq!(cleaned["description"], "User's name");
+    assert_eq!(cleaned["title"], "Name Field");
+    assert_eq!(cleaned["default"], "Anonymous");
+}
+
+#[test]
+fn breaks_circular_refs_without_panicking() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "parent": {
+                "$ref": "#/$defs/Node"
+            }
+        },
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "child": {
+                        "$ref": "#/$defs/Node"
+                    }
+                }
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["properties"]["parent"]["type"], "object");
+}
+
+#[test]
+fn validates_schema_shape() {
+    let valid = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        }
+    });
+
+    assert!(SchemaCleanr::validate(&valid).is_ok());
+
+    let invalid = json!({
+        "properties": {
+            "name": { "type": "string" }
+        }
+    });
+
+    assert!(SchemaCleanr::validate(&invalid).is_err());
+}
+
+#[test]
+fn strategies_preserve_expected_keywords() {
+    let schema = json!({
+        "type": "string",
+        "minLength": 1,
+        "description": "A string field"
+    });
+
+    let gemini = SchemaCleanr::clean_for_gemini(schema.clone());
+    assert!(gemini.get("minLength").is_none());
+    assert_eq!(gemini["type"], "string");
+    assert_eq!(gemini["description"], "A string field");
+
+    let openai = SchemaCleanr::clean_for_openai(schema.clone());
+    assert_eq!(openai["minLength"], 1);
+    assert_eq!(openai["type"], "string");
+}
+
+#[test]
+fn cleans_nested_properties() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "user": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert!(
+        cleaned["properties"]["user"]["properties"]["name"]
+            .get("minLength")
+            .is_none()
+    );
+    assert!(
+        cleaned["properties"]["user"]
+            .get("additionalProperties")
+            .is_none()
+    );
+}
+
+#[test]
+fn removes_null_from_type_array() {
+    let schema = json!({
+        "type": ["string", "null"]
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+}
+
+#[test]
+fn preserves_only_null_type_array() {
+    let schema = json!({
+        "type": ["null"]
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "null");
+}
+
+#[test]
+fn decodes_json_pointer_escapes_in_refs() {
+    let schema = json!({
+        "$ref": "#/$defs/Foo~1Bar",
+        "$defs": {
+            "Foo/Bar": {
+                "type": "string"
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["type"], "string");
+}
+
+#[test]
+fn skips_type_when_non_simplifiable_union_exists() {
+    let schema = json!({
+        "type": "object",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "number" }
+                }
+            }
+        ]
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert!(cleaned.get("type").is_none());
+    assert!(cleaned.get("oneOf").is_some());
+}
+
+#[test]
+fn cleans_nested_unknown_schema_keyword() {
+    let schema = json!({
+        "not": {
+            "$ref": "#/$defs/Age"
+        },
+        "$defs": {
+            "Age": {
+                "type": "integer",
+                "minimum": 0
+            }
+        }
+    });
+
+    let cleaned = SchemaCleanr::clean_for_gemini(schema);
+
+    assert_eq!(cleaned["not"]["type"], "integer");
+    assert!(cleaned["not"].get("minimum").is_none());
+}


### PR DESCRIPTION
## Summary

Adds provider-oriented JSON Schema cleaning helpers to `harness::tool` so tool schemas can be normalized for model tool-calling compatibility before provider dispatch.

This ports the OpenHuman `SchemaCleanr` behavior into TinyAgents with crate-native errors and tests. The cleaner resolves local `$ref`s, strips provider-unsupported keywords, flattens literal unions, removes nullable variants, converts `const` to `enum`, and breaks circular local refs safely.

## Validation

- `cargo fmt --check`
- `timeout 180s cargo clippy --all-targets -- -D warnings`
- `timeout 120s cargo test schema_`

Full CI is left to GitHub runners.
