### PR TITLE
Release v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "tinyagents"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyagents"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "A recursive language-model (RLM) harness for Rust."


### PR DESCRIPTION
## Summary
- bump crate version from 1.6.0 to 1.7.0 after the Phase 1 TinyAgents port PRs
- update Cargo.lock local package entry

## Validation
- `cargo metadata --no-deps --format-version 1`