### PR TITLE
harness(openai): populate profile context window from the hint table

### DIFF
--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -753,10 +753,10 @@ impl StreamAccumulator {
     fn push_tool_chunk(&mut self, call_id: &str, content: &str, tool_name: Option<&str>) {
         if let Some(entry) = self.tool_chunks.iter_mut().find(|(id, ..)| id == call_id) {
             entry.1.push_str(content);
-            if entry.2.is_none() {
-                if let Some(name) = tool_name.filter(|n| !n.is_empty()) {
-                    entry.2 = Some(name.to_string());
-                }
+            if entry.2.is_none()
+                && let Some(name) = tool_name.filter(|n| !n.is_empty())
+            {
+                entry.2 = Some(name.to_string());
             }
         } else {
             self.tool_chunks.push((

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -1057,3 +1057,23 @@ fn parses_model_listing_envelope() {
     assert_eq!(listing.data[1].created, None);
     assert_eq!(listing.data[1].owned_by, None);
 }
+
+#[test]
+fn derive_profile_populates_known_context_windows() {
+    // A recognized id gets its context window from the shared provider-neutral
+    // hint table, so context-window-aware compaction has a real window to gate
+    // on instead of falling back to a fixed threshold.
+    assert_eq!(
+        super::transport::derive_profile("openai", "gpt-4o-mini").max_input_tokens,
+        Some(128_000)
+    );
+    assert_eq!(
+        super::transport::derive_profile("openai", "gpt-4.1").max_input_tokens,
+        Some(1_047_576)
+    );
+    // An unrecognized id stays `None` rather than guessing a window.
+    assert_eq!(
+        super::transport::derive_profile("openai", "totally-unknown-model").max_input_tokens,
+        None
+    );
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -38,6 +38,14 @@ pub(super) fn is_reasoning_model(model: &str) -> bool {
 /// All targets support tool calling, streaming (including tool-call chunks),
 /// and JSON Schema response formats. Modern OpenAI-family models additionally
 /// advertise native structured output and (for the o-series) reasoning output.
+///
+/// The context window is populated from the provider-neutral
+/// [`context_window_for_model_id`][crate::harness::model::context_window_for_model_id]
+/// hint table when the id is recognized (`None` otherwise), so downstream
+/// context-window-aware trimming/compaction
+/// ([`SummarizationPolicy::from_profile`][crate::harness::summarization::SummarizationPolicy::from_profile])
+/// engages on a real window instead of silently falling back to a fixed
+/// threshold.
 pub(super) fn derive_profile(provider: &str, model: &str) -> ModelProfile {
     let lower = model.to_ascii_lowercase();
     let reasoning = is_reasoning_model(model);
@@ -57,6 +65,7 @@ pub(super) fn derive_profile(provider: &str, model: &str) -> ModelProfile {
         native_structured_output: native_structured,
         json_schema: true,
         reasoning,
+        max_input_tokens: crate::harness::model::context_window_for_model_id(model),
         ..ModelProfile::default()
     }
 }

--- a/src/harness/stream/mod.rs
+++ b/src/harness/stream/mod.rs
@@ -144,5 +144,4 @@ pub fn stream(chunks: &[StreamChunk], modes: &[StreamMode]) -> Vec<StreamChunk> 
 }
 
 #[cfg(test)]
-#[cfg(test)]
 mod test;


### PR DESCRIPTION
## Summary
`derive_profile` never populated `max_input_tokens`, so every `OpenAiModel` / OpenAI-compatible preset advertised `max_input_tokens: None`. `SummarizationPolicy::from_profile` reads the window from that field, so context-window-aware compaction fell back to a fixed generic threshold instead of the model's real window — trimming on the wrong boundary or overflowing.

## Change
Populate `max_input_tokens` in `derive_profile` from the existing provider-neutral `context_window_for_model_id(model)` hint table (stays `None` for unrecognized ids, so nothing is guessed). No other profile fields change.

## Tests
`derive_profile_populates_known_context_windows` (known ids resolve their window; unknown stays `None`). `cargo fmt --check`, `cargo clippy --lib --tests -- -D warnings`, and `cargo test --lib` all pass.

Closes tinyhumansai/openhuman#4634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic handling of recognized OpenAI model IDs so the app now sets the correct input context size for supported models.
  * Unrecognized model IDs continue to be treated safely, avoiding incorrect profile assumptions.
  * Added coverage to prevent regressions in model profile detection and context window selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->