### PR TITLE
harness: gate runtime fallback candidates by capability/lifecycle

### DIFF
--- a/src/harness/agent_loop/mod.rs
+++ b/src/harness/agent_loop/mod.rs
@@ -84,6 +84,7 @@ use crate::harness::middleware::{
 use crate::harness::model::{
     ChatModel, ModelDelta, ModelRequest, ModelResolutionSource, ModelResponse, ModelStreamItem,
     ResolvedModel, ResolvedModelBinding, ResponseFormat, StreamAccumulator, ToolChoice,
+    model_eligible,
 };
 use crate::harness::runtime::{AgentHarness, UnknownToolPolicy};
 use crate::harness::structured::{StructuredExtractor, StructuredStrategy};

--- a/src/harness/agent_loop/model_call.rs
+++ b/src/harness/agent_loop/model_call.rs
@@ -179,18 +179,45 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
                     if matches!(error, TinyAgentsError::Timeout(_)) {
                         return Err(error);
                     }
-                    // Retries exhausted (or non-retryable): try the next model
-                    // in the fallback chain, if any, skipping any name already
-                    // visited in this chain so a chain with a repeated name
-                    // cannot alternate between the same models forever.
-                    let next = self
-                        .policy
-                        .fallback
-                        .as_ref()
-                        .and_then(|fallback| fallback.next_after(&current_name))
-                        .map(str::to_owned)
-                        .filter(|name| !visited.contains(name));
-                    match next.and_then(|name| self.models.get(&name).map(|m| (name, m))) {
+                    // Retries exhausted (or non-retryable): walk the fallback
+                    // chain for the next model, skipping any name already
+                    // visited in this chain (so a chain with a repeated name
+                    // cannot alternate between the same models forever) and any
+                    // candidate that fails the request's capability/lifecycle
+                    // gate. Initial resolution gates the primary selection
+                    // through `model_eligible`; without the same gate here a
+                    // primary failure could silently fall back to a model that
+                    // can't call tools, lacks vision, or has a smaller context
+                    // window (issue #4641). `allow_retired` is `false` to match
+                    // `ModelRegistry::resolve_request`.
+                    let required = request.required_capabilities.as_ref();
+                    let mut cursor = current_name.clone();
+                    let selected = loop {
+                        let next = self
+                            .policy
+                            .fallback
+                            .as_ref()
+                            .and_then(|fallback| fallback.next_after(&cursor))
+                            .map(str::to_owned)
+                            .filter(|name| !visited.contains(name));
+                        let Some((name, next_model)) =
+                            next.and_then(|name| self.models.get(&name).map(|m| (name, m)))
+                        else {
+                            break None;
+                        };
+                        if !model_eligible(next_model.as_ref(), required, false) {
+                            // Ineligible candidate: record it as visited, make
+                            // the skip observable, and keep walking the chain.
+                            visited.insert(name.clone());
+                            ctx.emit(AgentEvent::FallbackSkipped {
+                                model: name.clone(),
+                            });
+                            cursor = name;
+                            continue;
+                        }
+                        break Some((name, next_model));
+                    };
+                    match selected {
                         Some((name, next_model)) => {
                             visited.insert(name.clone());
                             resolved = ResolvedModel {

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -23,8 +23,8 @@ use crate::harness::middleware::{
     ModelMiddleware, ToolHandler, ToolMiddleware,
 };
 use crate::harness::model::{
-    ChatModel, ModelProfile, ModelRequest, ModelResponse, ModelStreamItem, ResponseFormat,
-    ToolChoice,
+    CapabilitySet, ChatModel, ModelProfile, ModelRequest, ModelResponse, ModelStreamItem,
+    ResponseFormat, ToolChoice,
 };
 use crate::harness::providers::MockModel;
 use crate::harness::retry::{FallbackPolicy, RetryPolicy};
@@ -969,6 +969,151 @@ async fn fallback_chain_with_repeated_model_name_terminates() {
     // chain's repeated `primary` entry is skipped as already-visited.
     assert_eq!(*primary.attempts.lock().unwrap(), 1);
     assert_eq!(*backup.attempts.lock().unwrap(), 1);
+}
+
+/// A model with an explicit profile that always fails with a retryable error
+/// and counts attempts. Unlike [`FailingModel`] it advertises a profile, so it
+/// can be selected under a `required_capabilities` gate.
+struct ProfiledFailingModel {
+    profile: ModelProfile,
+    attempts: Mutex<usize>,
+}
+
+#[async_trait]
+impl ChatModel<()> for ProfiledFailingModel {
+    fn profile(&self) -> Option<&ModelProfile> {
+        Some(&self.profile)
+    }
+    async fn invoke(&self, _state: &(), _request: ModelRequest) -> Result<ModelResponse> {
+        *self.attempts.lock().unwrap() += 1;
+        Err(TinyAgentsError::Model("transient boom".to_string()))
+    }
+}
+
+/// A model with an explicit profile that returns fixed text and counts
+/// invocations, so a test can prove an ineligible fallback candidate is never
+/// invoked while a later eligible one is.
+struct ProfiledTextModel {
+    profile: ModelProfile,
+    text: &'static str,
+    attempts: Mutex<usize>,
+}
+
+#[async_trait]
+impl ChatModel<()> for ProfiledTextModel {
+    fn profile(&self) -> Option<&ModelProfile> {
+        Some(&self.profile)
+    }
+    async fn invoke(&self, _state: &(), _request: ModelRequest) -> Result<ModelResponse> {
+        *self.attempts.lock().unwrap() += 1;
+        Ok(ModelResponse::assistant(self.text))
+    }
+}
+
+/// Middleware that stamps an explicit model override and a required-capability
+/// set onto every request, so a test can drive resolution + fallback under a
+/// capability gate without a public request-building entry point.
+struct RequireCapsMiddleware {
+    model: &'static str,
+    caps: CapabilitySet,
+}
+
+#[async_trait]
+impl Middleware<(), ()> for RequireCapsMiddleware {
+    fn name(&self) -> &str {
+        "require_caps"
+    }
+    async fn before_model(
+        &self,
+        _ctx: &mut RunContext<()>,
+        _state: &(),
+        request: &mut ModelRequest,
+    ) -> Result<()> {
+        request.model = Some(self.model.to_string());
+        request.required_capabilities = Some(self.caps.clone());
+        Ok(())
+    }
+}
+
+/// Runtime fallback must apply the same capability/lifecycle gate that initial
+/// resolution does: on a primary failure, a fallback candidate that cannot
+/// satisfy the request's `required_capabilities` is skipped (never invoked) and
+/// the chain advances to the next eligible model, emitting `FallbackSkipped`
+/// for the skipped candidate (issue #4641).
+#[tokio::test]
+async fn runtime_fallback_skips_capability_ineligible_candidate() {
+    use crate::harness::testkit::EventRecorder;
+
+    let tool_capable = ModelProfile {
+        tool_calling: true,
+        ..ModelProfile::default()
+    };
+    let tool_incapable = ModelProfile {
+        tool_calling: false,
+        ..ModelProfile::default()
+    };
+
+    let primary = Arc::new(ProfiledFailingModel {
+        profile: tool_capable.clone(),
+        attempts: Mutex::new(0),
+    });
+    // Ineligible under the required `tool_calling` gate: must be skipped and
+    // never invoked.
+    let backup = Arc::new(ProfiledTextModel {
+        profile: tool_incapable,
+        text: "from backup",
+        attempts: Mutex::new(0),
+    });
+    // Eligible: the chain must reach and use this one.
+    let tertiary = Arc::new(ProfiledTextModel {
+        profile: tool_capable,
+        text: "recovered",
+        attempts: Mutex::new(0),
+    });
+
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model("primary", primary.clone());
+    harness.register_model("backup", backup.clone());
+    harness.register_model("tertiary", tertiary.clone());
+    harness.push_middleware(Arc::new(RequireCapsMiddleware {
+        model: "primary",
+        caps: CapabilitySet {
+            tool_calling: true,
+            ..CapabilitySet::default()
+        },
+    }));
+    harness.with_policy(RunPolicy {
+        retry: RetryPolicy::default().with_max_attempts(1),
+        fallback: Some(FallbackPolicy::new(["primary", "backup", "tertiary"])),
+        ..RunPolicy::default()
+    });
+
+    let recorder = EventRecorder::new();
+    let ctx = RunContext::new(RunConfig::new("fallback-caps-run"), ()).with_events(recorder.sink());
+    let run = harness
+        .invoke_in_context(&(), ctx, vec![Message::user("hi")])
+        .await
+        .expect("fallback reaches the eligible tertiary model");
+
+    // The ineligible `backup` was skipped; the eligible `tertiary` answered.
+    assert_eq!(run.text(), Some("recovered".to_string()));
+    assert_eq!(*primary.attempts.lock().unwrap(), 1, "primary tried once");
+    assert_eq!(
+        *backup.attempts.lock().unwrap(),
+        0,
+        "capability-ineligible fallback must never be invoked"
+    );
+    assert_eq!(*tertiary.attempts.lock().unwrap(), 1, "tertiary answered");
+
+    // The skip is observable as a diagnostic event naming the skipped model.
+    assert!(
+        recorder.events().iter().any(|e| matches!(
+            e,
+            AgentEvent::FallbackSkipped { model } if model == "backup"
+        )),
+        "skipped fallback candidate must be surfaced as FallbackSkipped; got kinds {:?}",
+        recorder.kinds()
+    );
 }
 
 #[tokio::test]

--- a/src/harness/events/types.rs
+++ b/src/harness/events/types.rs
@@ -295,6 +295,18 @@ pub enum AgentEvent {
         resolved: String,
     },
 
+    /// A runtime fallback candidate was skipped because it failed the request's
+    /// capability/lifecycle gate — it lacks a required capability or is
+    /// provider-retired — so the fallback chain advanced to the next candidate
+    /// instead. Initial resolution gates the primary selection the same way;
+    /// this makes the equivalent gate on the fallback path observable (issue
+    /// #4641), so a primary failure can never silently fall back to a model that
+    /// cannot satisfy the request.
+    FallbackSkipped {
+        /// The fallback model name that was skipped.
+        model: String,
+    },
+
     /// A sub-agent child run is about to be invoked from a parent run.
     SubAgentStarted {
         /// Name of the sub-agent being invoked.
@@ -591,6 +603,7 @@ impl AgentEvent {
             AgentEvent::RateLimitWaited { .. } => "rate_limit.waited",
             AgentEvent::FallbackSelected { .. } => "model.fallback_selected",
             AgentEvent::ModelOverrideSkipped { .. } => "model.override_skipped",
+            AgentEvent::FallbackSkipped { .. } => "model.fallback_skipped",
             AgentEvent::SubAgentStarted { .. } => "subagent.started",
             AgentEvent::SubAgentCompleted { .. } => "subagent.completed",
             AgentEvent::SubAgentReused { .. } => "subagent.reused",

--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -633,7 +633,11 @@ fn model_satisfies<State: Send + Sync>(
 /// provider-retired model is never selected. A model with no profile carries no
 /// lifecycle facts, so it is treated as usable (consistent with capability
 /// gating, which only rejects a model when a profile is present and fails).
-fn model_eligible<State: Send + Sync>(
+///
+/// Exposed to the crate so the agent loop's runtime fallback path can apply the
+/// same gate to fallback candidates that initial [`ModelRegistry::resolve`]
+/// applies to the primary selection (issue #4641).
+pub(crate) fn model_eligible<State: Send + Sync>(
     model: &dyn ChatModel<State>,
     required: Option<&CapabilitySet>,
     allow_retired: bool,

--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -757,10 +757,10 @@ impl StreamAccumulator {
     fn push_tool_chunk(&mut self, call_id: &str, content: &str, tool_name: Option<&str>) {
         if let Some(entry) = self.tool_chunks.iter_mut().find(|(id, ..)| id == call_id) {
             entry.1.push_str(content);
-            if entry.2.is_none() {
-                if let Some(name) = tool_name.filter(|n| !n.is_empty()) {
-                    entry.2 = Some(name.to_string());
-                }
+            if entry.2.is_none()
+                && let Some(name) = tool_name.filter(|n| !n.is_empty())
+            {
+                entry.2 = Some(name.to_string());
             }
         } else {
             self.tool_chunks.push((

--- a/src/harness/stream/mod.rs
+++ b/src/harness/stream/mod.rs
@@ -144,5 +144,4 @@ pub fn stream(chunks: &[StreamChunk], modes: &[StreamMode]) -> Vec<StreamChunk> 
 }
 
 #[cfg(test)]
-#[cfg(test)]
 mod test;


### PR DESCRIPTION
Runtime fallback fetched the next model by name only, so a primary failure could fall back to a model lacking a required capability or one that is provider-retired — gating that initial `resolve` applies but the fallback path skipped.

Thread the request's `required_capabilities` into `invoke_model_resolving` and skip fallback candidates that fail `model_eligible` (capabilities + retired-status), advancing to the next chain entry and emitting a new `AgentEvent::FallbackSkipped` so the skip is observable. Adds a regression test.

Ran locally: `cargo fmt`, `cargo test --lib` (996 passed). `cargo clippy --lib --tests -- -D warnings` is clean for this diff; two clippy errors (`stream/mod.rs:147` duplicated-attribute, a collapsible-if in `model/mod.rs`) pre-exist unchanged on `main` under newer clippy and are left untouched to keep this change focused.

Closes tinyhumansai/openhuman#4641