### PR TITLE
harness: opt-in token-budget gate for MicrocompactMiddleware (cache-prefix stability)

### DIFF
--- a/src/harness/middleware/library/context.rs
+++ b/src/harness/middleware/library/context.rs
@@ -226,6 +226,7 @@ impl MicrocompactMiddleware {
             keep_recent,
             placeholder: placeholder.into(),
             emit_events: false,
+            token_budget: None,
         }
     }
 
@@ -238,6 +239,22 @@ impl MicrocompactMiddleware {
         self
     }
 
+    /// Only blank stale tool bodies once the transcript's estimated tokens
+    /// exceed `budget`; below it the middleware is a no-op so the request stays
+    /// append-only and the provider KV-cache prefix is preserved (issue
+    /// tinyhumansai/openhuman#4755).
+    ///
+    /// Set this below the model's context window (leaving headroom for the reply
+    /// and the `keep_recent` verbatim results) so a run that fits the window is
+    /// never compacted — compaction only kicks in when it is actually needed to
+    /// stay under the window, which is the only time the cache-invalidation cost
+    /// of blanking an already-sent tool body pays for itself. `budget == 0`
+    /// disables the gate (equivalent to leaving it unset).
+    pub fn with_token_budget(mut self, budget: u64) -> Self {
+        self.token_budget = (budget > 0).then_some(budget);
+        self
+    }
+
     /// The number of most-recent tool-result bodies kept verbatim.
     pub fn keep_recent(&self) -> usize {
         self.keep_recent
@@ -246,6 +263,11 @@ impl MicrocompactMiddleware {
     /// The placeholder text swapped in for cleared tool-result bodies.
     pub fn placeholder(&self) -> &str {
         &self.placeholder
+    }
+
+    /// The estimated-token floor below which blanking is skipped, if configured.
+    pub fn token_budget(&self) -> Option<u64> {
+        self.token_budget
     }
 }
 
@@ -273,11 +295,31 @@ impl<State: Send + Sync, Ctx: Send + Sync> Middleware<State, Ctx> for Microcompa
             return Ok(());
         }
 
+        // Prompt-cache preservation (issue tinyhumansai/openhuman#4755): when a
+        // token budget is configured, skip blanking while the transcript still
+        // fits within it. Blanking a tool body that was sent verbatim on an
+        // earlier iteration mutates an already-transmitted prefix position and
+        // invalidates the provider KV-cache from there on; doing that every call
+        // (the boundary moves by one each turn) churns the cache to reclaim
+        // tokens the model still has room for. Gating on the *pre-blank* estimate
+        // — which grows monotonically as the run appends — keeps the request
+        // append-only (fully cache-eligible) below budget and can't oscillate.
+        // Reuse `from_tokens` when events are on so we never estimate twice.
         let from_tokens = if self.emit_events {
             total_message_tokens(&request.messages)
         } else {
             0
         };
+        if let Some(budget) = self.token_budget {
+            let tokens = if self.emit_events {
+                from_tokens
+            } else {
+                total_message_tokens(&request.messages)
+            };
+            if tokens <= budget {
+                return Ok(());
+            }
+        }
 
         let cut = tool_idxs.len() - self.keep_recent;
         let mut cleared = 0usize;

--- a/src/harness/middleware/test.rs
+++ b/src/harness/middleware/test.rs
@@ -758,6 +758,80 @@ async fn microcompact_is_idempotent() {
     assert_eq!(request.messages[1].text(), "SECOND");
 }
 
+// ── token-budget gate (issue tinyhumansai/openhuman#4755) ──────────────────────
+
+#[tokio::test]
+async fn microcompact_with_token_budget_is_a_noop_below_budget() {
+    // More than `keep_recent` tool results, but the whole transcript fits the
+    // configured budget: NOTHING is blanked, so the request stays byte-stable
+    // across iterations and the provider KV-cache prefix is preserved. This is
+    // the fix — the ungated middleware would have blanked the two oldest here
+    // (see `microcompact_clears_older_tool_bodies_and_keeps_recent`), churning
+    // the cache to reclaim tokens the model had ample room for.
+    let mw = MicrocompactMiddleware::new(1, CLEARED).with_token_budget(100_000);
+    assert_eq!(mw.token_budget(), Some(100_000));
+    let mut request = ModelRequest {
+        messages: vec![
+            Message::system("sys"),
+            Message::tool("t1", "FIRST_BODY"),
+            Message::tool("t2", "SECOND_BODY"),
+            Message::tool("t3", "THIRD_BODY"),
+        ],
+        ..Default::default()
+    };
+    mw.before_model(&mut ctx(), &(), &mut request)
+        .await
+        .unwrap();
+    assert_eq!(request.messages[1].text(), "FIRST_BODY");
+    assert_eq!(request.messages[2].text(), "SECOND_BODY");
+    assert_eq!(request.messages[3].text(), "THIRD_BODY");
+}
+
+#[tokio::test]
+async fn microcompact_with_token_budget_blanks_once_over_budget() {
+    // Same shape, but the (un-blanked) transcript exceeds the tiny budget, so
+    // compaction is genuinely needed to stay under the window: the gate lets the
+    // usual keep-recent blanking run and reclaims tokens.
+    let body = "x".repeat(400); // ~100 estimated tokens each (chars / 4)
+    let mw = MicrocompactMiddleware::new(1, CLEARED).with_token_budget(10);
+    let mut request = ModelRequest {
+        messages: vec![
+            Message::tool("t1", body.clone()),
+            Message::tool("t2", body.clone()),
+            Message::tool("t3", body.clone()),
+        ],
+        ..Default::default()
+    };
+    mw.before_model(&mut ctx(), &(), &mut request)
+        .await
+        .unwrap();
+    assert_eq!(request.messages[0].text(), CLEARED);
+    assert_eq!(request.messages[1].text(), CLEARED);
+    assert_eq!(request.messages[2].text(), body);
+}
+
+#[tokio::test]
+async fn microcompact_with_token_budget_zero_disables_the_gate() {
+    // `budget == 0` is an explicit opt-out: the gate is `None`, so blanking
+    // reverts to the legacy count-only behaviour even on a tiny transcript.
+    let mw = MicrocompactMiddleware::new(1, CLEARED).with_token_budget(0);
+    assert_eq!(mw.token_budget(), None);
+    let mut request = ModelRequest {
+        messages: vec![
+            Message::tool("t1", "A"),
+            Message::tool("t2", "B"),
+            Message::tool("t3", "C"),
+        ],
+        ..Default::default()
+    };
+    mw.before_model(&mut ctx(), &(), &mut request)
+        .await
+        .unwrap();
+    assert_eq!(request.messages[0].text(), CLEARED);
+    assert_eq!(request.messages[1].text(), CLEARED);
+    assert_eq!(request.messages[2].text(), "C");
+}
+
 #[tokio::test]
 async fn microcompact_emits_no_event_by_default() {
     // Default construction is silent: bodies are still cleared, but no

--- a/src/harness/middleware/types.rs
+++ b/src/harness/middleware/types.rs
@@ -566,11 +566,34 @@ pub struct ContextCompressionMiddleware {
 /// [`AgentEvent::Compressed`][crate::harness::events::AgentEvent::Compressed]
 /// event carrying the before/after token estimate is emitted; when disabled the
 /// middleware mutates the request silently.
+///
+/// # Prompt-cache stability ([`token_budget`](Self::with_token_budget))
+///
+/// Blanking a tool body that was sent *verbatim* on an earlier iteration mutates
+/// an already-transmitted prefix position, which invalidates the provider's
+/// KV-cache from that point on. Because "keep the newest `keep_recent`" is a
+/// *moving* boundary, the default (ungated) middleware rewrites one more
+/// tool-result full→placeholder on essentially every model call once a run has
+/// more than `keep_recent` tool results — churning the cache prefix even when
+/// the whole transcript still fits the model's context window (paying an
+/// uncached re-read to save tokens the model had room for).
+///
+/// [`with_token_budget`](Self::with_token_budget) gates the blanking on the
+/// transcript's estimated token count: below the budget the middleware is a
+/// no-op, so requests stay **append-only and fully cache-eligible**; only once
+/// the (un-blanked) transcript exceeds the budget does it start reclaiming
+/// tokens. The gate reads the pre-blank token estimate, which grows
+/// monotonically, so it never oscillates between blanked and full. Left unset
+/// (`None`, the default) the middleware behaves exactly as before.
 pub struct MicrocompactMiddleware {
     pub(crate) label: &'static str,
     pub(crate) keep_recent: usize,
     pub(crate) placeholder: String,
     pub(crate) emit_events: bool,
+    /// Optional estimated-token floor below which blanking is skipped so the
+    /// cache prefix stays stable. `None` = always blank once past `keep_recent`
+    /// (legacy behaviour). See [`MicrocompactMiddleware::with_token_budget`].
+    pub(crate) token_budget: Option<u64>,
 }
 
 // ── PromptCacheGuardMiddleware ────────────────────────────────────────────────

--- a/src/harness/prompt/mod.rs
+++ b/src/harness/prompt/mod.rs
@@ -308,14 +308,16 @@ impl PromptBuilder {
             "tools": self.tools,
         });
 
-        // Stream the canonical JSON straight into the digest; `Sha256`
-        // implements `std::io::Write`.
+        // Serialize the canonical JSON, then feed the bytes into the digest.
+        // (`Sha256` does not implement `std::io::Write`, so hash the
+        // serialized bytes directly instead of streaming via `to_writer`.)
         let mut hasher = Sha256::new();
-        if serde_json::to_writer(&mut hasher, &payload).is_err() {
-            // Serializing an already-materialized `Value` does not fail in
-            // practice; fall back to hashing empty data for a stable result.
-            hasher = Sha256::new();
+        if let Ok(bytes) = serde_json::to_vec(&payload) {
+            hasher.update(&bytes);
         }
+        // Serializing an already-materialized `Value` does not fail in
+        // practice; on the unexpected error path the digest hashes empty
+        // data for a stable result.
         let digest = hasher.finalize();
         digest.iter().map(|byte| format!("{byte:02x}")).collect()
     }


### PR DESCRIPTION
## Problem

`MicrocompactMiddleware` blanks older tool-result bodies (keeping the newest `keep_recent` verbatim) to bound a long, tool-heavy transcript. But it fires purely on **count**:

```rust
if tool_idxs.len() <= self.keep_recent { return Ok(()); }
```

Because "keep the newest `keep_recent`" is a **moving boundary**, once a run has more than `keep_recent` tool results the middleware rewrites *one more* tool result `full → placeholder` on essentially **every model call**. Blanking a body that was sent verbatim on an earlier iteration mutates an **already-transmitted prefix position**, which invalidates the provider KV-cache from that point onward — on every iteration — **even when the whole transcript still fits the model's context window**.

The result: the trimming churns the prompt cache to reclaim tokens the model still had room for, which is frequently a net cost *loss*. Downstream (tinyhumansai/openhuman#4755) this shows up as large input-token bloat on tool/delegated turns with only ~38% of input cached.

## Fix (minimal, opt-in, backward-compatible)

Add a token-budget gate to `MicrocompactMiddleware`:

- new field `token_budget: Option<u64>` (default `None`);
- builder `.with_token_budget(budget)` (`0` disables) + a `token_budget()` getter;
- in `before_model`, when a budget is set and the **pre-blank** transcript estimate is `<= budget`, return early without blanking.

Below the budget the request stays **append-only and fully cache-eligible**; compaction only kicks in once the transcript would exceed the window — the only time the cache-invalidation cost of blanking an already-sent body actually pays for itself. The gate reads the *un-blanked* estimate (which grows monotonically as the run appends), so it can never oscillate between blanked and full.

`token_budget = None` (the default) preserves the existing count-only behaviour **byte-for-byte** — every existing test is unchanged.

## Tests

- `microcompact_with_token_budget_is_a_noop_below_budget` — >`keep_recent` tool results but under budget → nothing blanked (the fix; contrast `microcompact_clears_older_tool_bodies_and_keeps_recent`).
- `microcompact_with_token_budget_blanks_once_over_budget` — still reclaims when genuinely over budget.
- `microcompact_with_token_budget_zero_disables_the_gate` — `0` opt-out reverts to legacy blanking.

## Activation in openhuman (follow-up on the vendored bump)

This lands the harness capability; it is inert until the host opts in. In `openhuman/src/openhuman/tinyagents/middleware.rs` (where `MicrocompactMiddleware::new(...)` is constructed, ~L340), add:

```rust
MicrocompactMiddleware::new(self.microcompact_keep_recent, CLEARED_PLACEHOLDER)
    .with_token_budget((context_window as f64 * 0.7) as u64)
```

`context_window` is already threaded into the turn seam, so a run that fits the window is never compacted (append-only, cacheable) while long runs still compact to stay under it.

Closes tinyhumansai/openhuman#4755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional token budget that controls when older tool-result content is compacted.
  * Content remains intact while the transcript fits within the configured budget, helping preserve prompt-cache stability.
  * Added configuration and inspection support for the token-budget setting.

* **Bug Fixes**
  * Avoids unnecessary transcript changes when compaction is not needed.
  * Preserves existing compaction behavior when no budget is configured or the budget is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->