### PR TITLE
harness(openai): temperature suppression + override for OpenAiModel

### DIFF
--- a/src/harness/providers/openai/mod.rs
+++ b/src/harness/providers/openai/mod.rs
@@ -74,7 +74,7 @@ pub use transport::{AuthStyle, OpenAiModel};
 use convert::*;
 use sse::*;
 #[cfg(test)]
-use transport::{auth_headers, request_timeout};
+use transport::{auth_headers, effective_temperature, glob_match, request_timeout};
 
 #[cfg(test)]
 mod test;

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -1147,3 +1147,52 @@ fn derive_profile_populates_known_context_windows() {
         None
     );
 }
+
+// ── Temperature suppression / override ────────────────────────────────
+
+#[test]
+fn glob_match_handles_prefix_suffix_infix_and_exact() {
+    assert!(glob_match("o1*", "o1-mini"));
+    assert!(glob_match("o3*", "o3"));
+    assert!(glob_match("gpt-5*", "GPT-5-Turbo")); // case-insensitive
+    assert!(glob_match("*turbo", "gpt-4-turbo"));
+    assert!(glob_match("*mid*", "a-middle-b"));
+    assert!(glob_match("gpt-4o", "gpt-4o")); // no wildcard → exact
+    assert!(!glob_match("o1*", "gpt-4o"));
+    assert!(!glob_match("gpt-4o", "gpt-4o-mini")); // exact, not prefix
+    assert!(!glob_match("*turbo", "turbo-x"));
+}
+
+#[test]
+fn effective_temperature_omits_for_unsupported_models() {
+    let unsupported = vec!["o1*".to_string(), "gpt-5*".to_string()];
+    // Matching model → temperature omitted regardless of request/override.
+    assert_eq!(
+        effective_temperature("o1-mini", Some(0.7), Some(0.2), &unsupported),
+        None
+    );
+    // Non-matching model → request temperature passes through.
+    assert_eq!(
+        effective_temperature("gpt-4o", Some(0.7), None, &unsupported),
+        Some(0.7)
+    );
+}
+
+#[test]
+fn effective_temperature_override_wins_over_request() {
+    // Override applies when the model supports temperature.
+    assert_eq!(
+        effective_temperature("gpt-4o", Some(0.7), Some(0.2), &[]),
+        Some(0.2)
+    );
+    // No override, no request → None.
+    assert_eq!(effective_temperature("gpt-4o", None, None, &[]), None);
+}
+
+#[test]
+fn temperature_builders_compose() {
+    let _model = OpenAiModel::new("k")
+        .with_model("o1-mini")
+        .with_temperature_unsupported_models(["o1*", "o3*"])
+        .with_temperature_override(Some(0.0));
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -43,6 +43,12 @@ pub struct OpenAiModel {
     /// Extra static headers attached to every request (e.g. provider
     /// attribution headers). Applied after the auth header.
     extra_headers: Vec<(String, String)>,
+    /// Model-id glob patterns (`*` wildcard) whose targets reject a `temperature`
+    /// parameter; matching requests omit `temperature` entirely. Empty by default.
+    temperature_unsupported: Vec<String>,
+    /// When set, overrides the request's sampling temperature for every call
+    /// (unless the model is in [`Self::temperature_unsupported`]).
+    temperature_override: Option<f64>,
     /// Default model id used when a request does not override it.
     model: String,
     /// Provider family identifier used in profiles and normalized errors.
@@ -68,6 +74,56 @@ pub(super) fn auth_headers(auth: &AuthStyle, api_key: &str) -> Vec<(String, Stri
         ],
         AuthStyle::Custom(name) => vec![(name.clone(), api_key.to_string())],
     }
+}
+
+/// Case-insensitive glob match supporting the `*` wildcard (the only metacharacter
+/// used by model-id patterns). `"o1*"` matches `"o1-mini"`; `"*turbo"` matches
+/// `"gpt-4-turbo"`; a pattern with no `*` matches exactly.
+pub(super) fn glob_match(pattern: &str, value: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    let value = value.to_ascii_lowercase();
+    let segments: Vec<&str> = pattern.split('*').collect();
+    if segments.len() == 1 {
+        return pattern == value;
+    }
+    let mut cursor = 0usize;
+    for (idx, segment) in segments.iter().enumerate() {
+        if segment.is_empty() {
+            continue;
+        }
+        if idx == 0 {
+            // A non-empty leading segment must be a prefix.
+            if !value[cursor..].starts_with(segment) {
+                return false;
+            }
+            cursor += segment.len();
+        } else if idx == segments.len() - 1 {
+            // A non-empty trailing segment must be a suffix.
+            return value[cursor..].ends_with(segment);
+        } else {
+            match value[cursor..].find(segment) {
+                Some(offset) => cursor += offset + segment.len(),
+                None => return false,
+            }
+        }
+    }
+    // Trailing `*` (empty last segment) matches the remainder.
+    true
+}
+
+/// The `temperature` to send for `model`: `None` (omitted) when the model matches
+/// a temperature-unsupported pattern, else the override if set, else the request's
+/// temperature. Pure, so the policy is unit-testable without a request.
+pub(super) fn effective_temperature(
+    model: &str,
+    request_temperature: Option<f64>,
+    temperature_override: Option<f64>,
+    temperature_unsupported: &[String],
+) -> Option<f64> {
+    if temperature_unsupported.iter().any(|p| glob_match(p, model)) {
+        return None;
+    }
+    temperature_override.or(request_temperature)
 }
 
 /// Returns `true` for OpenAI o-series reasoning models (`o1`/`o3`/`o4`), which
@@ -126,6 +182,8 @@ impl OpenAiModel {
             api_key: api_key.into(),
             auth: AuthStyle::Bearer,
             extra_headers: Vec::new(),
+            temperature_unsupported: Vec::new(),
+            temperature_override: None,
             model: DEFAULT_MODEL.to_string(),
             provider: "openai".to_string(),
             base_url: DEFAULT_BASE_URL.to_string(),
@@ -147,6 +205,26 @@ impl OpenAiModel {
     /// auth header — e.g. provider attribution headers.
     pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra_headers.push((name.into(), value.into()));
+        self
+    }
+
+    /// Sets model-id glob patterns (`*` wildcard, case-insensitive) whose targets
+    /// reject a `temperature` parameter. A request whose model matches any pattern
+    /// omits `temperature` from the wire body (e.g. OpenAI o-series / some hosted
+    /// reasoning models that 400 on an explicit temperature).
+    pub fn with_temperature_unsupported_models(
+        mut self,
+        patterns: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.temperature_unsupported = patterns.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Overrides the sampling temperature for every request (unless the model is
+    /// temperature-unsupported). Useful for endpoints that require a fixed
+    /// temperature regardless of the caller's request.
+    pub fn with_temperature_override(mut self, temperature: Option<f64>) -> Self {
+        self.temperature_override = temperature;
         self
     }
 
@@ -457,13 +535,20 @@ impl OpenAiModel {
             (request.max_tokens, None)
         };
 
+        let temperature = effective_temperature(
+            &model,
+            request.temperature,
+            self.temperature_override,
+            &self.temperature_unsupported,
+        );
+
         Ok(ChatCompletionRequest {
             model,
             messages,
             tools,
             tool_choice,
             response_format,
-            temperature: request.temperature,
+            temperature,
             top_p: request.top_p,
             max_tokens,
             max_completion_tokens,


### PR DESCRIPTION
## Summary

Adds two request-shaping options to `OpenAiModel` so it can faithfully serve OpenAI-compatible endpoints with divergent temperature rules:

- `with_temperature_unsupported_models(patterns)` — model-id `*`-glob patterns (case-insensitive) whose targets reject an explicit `temperature`; matching requests omit the field from the wire body.
- `with_temperature_override(Some(t))` — pins the sampling temperature for every call (unless the model is temperature-unsupported).

The policy is a pure, unit-tested `effective_temperature` helper plus a small `glob_match`; `translate_request` applies it instead of forwarding `request.temperature` blindly.

## Motivation

Part of consolidating a downstream host's bespoke OpenAI-compatible wire client onto this crate's `OpenAiModel` (follow-up to #44). Some hosted reasoning models and BYOK endpoints `400` on an explicit `temperature`, and some deployments require a fixed temperature — the host expressed both, so the crate needs to as well before the host can drop its own client.

## Compatibility

Fully backward compatible — defaults are no suppression + no override, so a request's `temperature` passes through exactly as before. (The o-series `max_tokens`→`max_completion_tokens` routing is unchanged and independent.)

## Tests

Added 4 unit tests: `glob_match_handles_prefix_suffix_infix_and_exact`, `effective_temperature_omits_for_unsupported_models`, `effective_temperature_override_wins_over_request`, `temperature_builders_compose`. `cargo fmt --check` clean; `cargo test --lib providers::openai` → 45 passed.
