### PR TITLE
harness(openai): merge_system_into_user option for OpenAiModel

### DIFF
--- a/src/harness/providers/openai/mod.rs
+++ b/src/harness/providers/openai/mod.rs
@@ -74,7 +74,7 @@ pub use transport::{AuthStyle, OpenAiModel};
 use convert::*;
 use sse::*;
 #[cfg(test)]
-use transport::{auth_headers, request_timeout};
+use transport::{auth_headers, merge_system_into_user, request_timeout};
 
 #[cfg(test)]
 mod test;

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -1147,3 +1147,70 @@ fn derive_profile_populates_known_context_windows() {
         None
     );
 }
+
+// ── merge_system_into_user ────────────────────────────────────────────
+
+#[test]
+fn merge_system_folds_into_first_user_and_drops_system_role() {
+    let merged = merge_system_into_user(&[
+        Message::system("You are terse."),
+        Message::user("Hi"),
+        Message::assistant("Hello"),
+        Message::user("Bye"),
+    ]);
+    // System dropped; its text prefixes the FIRST user turn only.
+    assert_eq!(merged.len(), 3);
+    assert!(matches!(merged[0], Message::User(_)));
+    assert_eq!(merged[0].text(), "You are terse.\n\nHi");
+    assert!(matches!(merged[1], Message::Assistant(_)));
+    assert_eq!(merged[2].text(), "Bye");
+    assert!(!merged.iter().any(|m| matches!(m, Message::System(_))));
+}
+
+#[test]
+fn merge_system_concatenates_multiple_system_messages() {
+    let merged = merge_system_into_user(&[
+        Message::system("Rule 1."),
+        Message::system("Rule 2."),
+        Message::user("Go"),
+    ]);
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].text(), "Rule 1.\n\nRule 2.\n\nGo");
+}
+
+#[test]
+fn merge_system_promotes_to_user_when_no_user_message() {
+    let merged = merge_system_into_user(&[Message::system("Only system.")]);
+    assert_eq!(merged.len(), 1);
+    assert!(matches!(merged[0], Message::User(_)));
+    assert_eq!(merged[0].text(), "Only system.");
+}
+
+#[test]
+fn merge_system_preserves_user_image_blocks() {
+    use crate::harness::message::{ImageRef, UserMessage};
+    let user_with_image = Message::User(UserMessage {
+        content: vec![
+            ContentBlock::Text("caption".to_string()),
+            ContentBlock::Image(ImageRef {
+                url: "https://example.test/x.png".to_string(),
+                mime_type: None,
+            }),
+        ],
+    });
+    let merged = merge_system_into_user(&[Message::system("sys"), user_with_image]);
+    assert_eq!(merged.len(), 1);
+    if let Message::User(u) = &merged[0] {
+        assert_eq!(u.content.len(), 2); // text (merged) + image preserved
+        assert!(matches!(u.content[0], ContentBlock::Text(ref t) if t == "sys\n\ncaption"));
+        assert!(matches!(u.content[1], ContentBlock::Image(_)));
+    } else {
+        panic!("expected a user message");
+    }
+}
+
+#[test]
+fn merge_system_is_noop_without_system_messages() {
+    let input = vec![Message::user("just user")];
+    assert_eq!(merge_system_into_user(&input), input);
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -43,6 +43,10 @@ pub struct OpenAiModel {
     /// Extra static headers attached to every request (e.g. provider
     /// attribution headers). Applied after the auth header.
     extra_headers: Vec<(String, String)>,
+    /// When `true`, system messages are folded into the first user message and
+    /// the `system` role is dropped — for OpenAI-compatible endpoints that reject
+    /// a `system` role. `false` by default (system messages pass through).
+    merge_system_into_user: bool,
     /// Default model id used when a request does not override it.
     model: String,
     /// Provider family identifier used in profiles and normalized errors.
@@ -68,6 +72,85 @@ pub(super) fn auth_headers(auth: &AuthStyle, api_key: &str) -> Vec<(String, Stri
         ],
         AuthStyle::Custom(name) => vec![(name.clone(), api_key.to_string())],
     }
+}
+
+/// Concatenates the text of a message's content blocks (non-text blocks — images,
+/// json, thinking — are ignored). Used to gather system-prompt text for merging.
+fn content_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Folds all `system` messages into the first `user` message and drops the
+/// `system` role, for endpoints that reject a `system` role. The concatenated
+/// system text is prefixed to the first user message (`"{system}\n\n{user}"` —
+/// matching the common host behavior); image/other user content blocks are
+/// preserved. When there is no user message, the system text is promoted to a
+/// user turn. Pure, so the transform is unit-testable.
+pub(super) fn merge_system_into_user(messages: &[Message]) -> Vec<Message> {
+    use crate::harness::message::UserMessage;
+
+    let system_text = messages
+        .iter()
+        .filter_map(|m| match m {
+            Message::System(s) => {
+                let t = content_text(&s.content);
+                (!t.is_empty()).then_some(t)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    if system_text.is_empty() {
+        // Nothing to fold; drop any (empty) system messages if present, else pass
+        // through untouched.
+        if messages.iter().any(|m| matches!(m, Message::System(_))) {
+            return messages
+                .iter()
+                .filter(|m| !matches!(m, Message::System(_)))
+                .cloned()
+                .collect();
+        }
+        return messages.to_vec();
+    }
+
+    let mut merged: Vec<Message> = Vec::with_capacity(messages.len());
+    let mut folded = false;
+    for msg in messages {
+        match msg {
+            Message::System(_) => {} // dropped
+            Message::User(user) if !folded => {
+                folded = true;
+                let mut content = Vec::with_capacity(user.content.len() + 1);
+                match user.content.split_first() {
+                    Some((ContentBlock::Text(first), rest)) => {
+                        content.push(ContentBlock::Text(format!("{system_text}\n\n{first}")));
+                        content.extend(rest.iter().cloned());
+                    }
+                    _ => {
+                        content.push(ContentBlock::Text(format!("{system_text}\n\n")));
+                        content.extend(user.content.iter().cloned());
+                    }
+                }
+                merged.push(Message::User(UserMessage { content }));
+            }
+            other => merged.push(other.clone()),
+        }
+    }
+
+    if !folded {
+        // No user message to fold into — promote the system text to a user turn.
+        merged.insert(0, Message::user(system_text));
+    }
+
+    merged
 }
 
 /// Returns `true` for OpenAI o-series reasoning models (`o1`/`o3`/`o4`), which
@@ -126,6 +209,7 @@ impl OpenAiModel {
             api_key: api_key.into(),
             auth: AuthStyle::Bearer,
             extra_headers: Vec::new(),
+            merge_system_into_user: false,
             model: DEFAULT_MODEL.to_string(),
             provider: "openai".to_string(),
             base_url: DEFAULT_BASE_URL.to_string(),
@@ -147,6 +231,13 @@ impl OpenAiModel {
     /// auth header — e.g. provider attribution headers.
     pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra_headers.push((name.into(), value.into()));
+        self
+    }
+
+    /// Folds system messages into the first user message and drops the `system`
+    /// role, for OpenAI-compatible endpoints that reject a `system` role.
+    pub fn with_merge_system_into_user(mut self) -> Self {
+        self.merge_system_into_user = true;
         self
     }
 
@@ -415,8 +506,16 @@ impl OpenAiModel {
         &self,
         request: &ModelRequest,
     ) -> Result<ChatCompletionRequest> {
-        let messages = request
-            .messages
+        // Optionally fold system messages into the first user turn (for endpoints
+        // that reject a `system` role) before wire translation.
+        let merged_messages;
+        let source_messages: &[Message] = if self.merge_system_into_user {
+            merged_messages = merge_system_into_user(&request.messages);
+            &merged_messages
+        } else {
+            &request.messages
+        };
+        let messages = source_messages
             .iter()
             .map(translate_message)
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
## Summary

Adds `OpenAiModel::with_merge_system_into_user()` for OpenAI-compatible endpoints that reject a `system` role. When enabled, all system messages are folded into the first user message (`"{system}\n\n{user}"`, matching common host behavior) and the `system` role is dropped before wire translation.

- Multimodal-aware: image / other content blocks on the user turn are preserved (system text is prefixed to the first text block, or added as a leading text block).
- Multiple system messages concatenate in order; with no user message present, the system text is promoted to a user turn.
- The transform is a pure, unit-tested `merge_system_into_user` helper.

## Motivation

Part of consolidating a downstream host's bespoke OpenAI-compatible wire client onto `OpenAiModel` (follows #44, #47). The host's `new_merge_system_into_user` handles providers with no `system` role; the crate needs the same before the host can drop its client.

## Compatibility

Backward compatible — off by default; system messages pass through unchanged.

## Tests

5 new unit tests (fold-into-first-user, multi-system concat, promote-when-no-user, preserve-image-blocks, noop-without-system). `cargo fmt --check` clean; `cargo test --lib providers::openai` → 46 passed.
