### PR TITLE
harness(openai): surface the full transport error source chain

### DIFF
--- a/src/harness/providers/openai/mod.rs
+++ b/src/harness/providers/openai/mod.rs
@@ -75,7 +75,7 @@ use convert::*;
 use sse::*;
 #[cfg(test)]
 use transport::{
-    auth_headers, effective_temperature, glob_match, merge_provider_options,
+    auth_headers, effective_temperature, error_source_chain, glob_match, merge_provider_options,
     merge_system_into_user, request_timeout,
 };
 

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -1475,3 +1475,33 @@ fn merge_provider_options_prefers_overrides_and_handles_nulls() {
         json!(["top_k", 40])
     );
 }
+
+#[test]
+fn error_source_chain_walks_all_causes() {
+    use std::fmt;
+    // A transport error whose outer Display hides the actionable errno one link
+    // down the `source()` chain (the reqwest/hyper shape).
+    #[derive(Debug)]
+    struct Outer(std::io::Error);
+    impl fmt::Display for Outer {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "error sending request for url (http://localhost:1234/)")
+        }
+    }
+    impl std::error::Error for Outer {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+    let io = std::io::Error::new(
+        std::io::ErrorKind::ConnectionRefused,
+        "connection refused (os error 111)",
+    );
+    let chain = error_source_chain(&Outer(io));
+    assert!(chain.contains("error sending request for url (http://localhost:1234/)"));
+    assert!(chain.contains("connection refused (os error 111)"));
+    assert_eq!(
+        chain,
+        "error sending request for url (http://localhost:1234/): connection refused (os error 111)"
+    );
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -742,8 +742,12 @@ impl OpenAiModel {
         url: &str,
     ) -> Result<reqwest::Response> {
         let response = builder.send().await.map_err(|e| {
-            let error =
-                self.provider_error(format!("{what} to {url} failed: {e}"), None, None, None);
+            let error = self.provider_error(
+                format!("{what} to {url} failed: {}", error_source_chain(&e)),
+                None,
+                None,
+                None,
+            );
             TinyAgentsError::Model(self.provider_failure_message(&error))
         })?;
 
@@ -851,6 +855,27 @@ pub(super) fn request_timeout(timeout_ms: Option<u64>, streaming: bool) -> Optio
         None if streaming => None,
         None => Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
     }
+}
+
+/// Renders an error together with its full `source()` cause chain, joined by
+/// `": "`.
+///
+/// `reqwest`/`hyper` transport errors surface only their outermost context in
+/// `Display` (e.g. `error sending request for url (...)`), while the actionable
+/// detail — `connection refused (os error 111)`, a TLS failure, a DNS error —
+/// lives one or more links down the `source()` chain. A plain `{e}` drops it, so
+/// callers that classify on the message (loopback-offline detection, transport
+/// retryability) never see it. Walking the chain here keeps the whole shape in
+/// the `TinyAgentsError::Model` string. Pure, so it is unit-testable.
+pub(super) fn error_source_chain(err: &dyn std::error::Error) -> String {
+    let mut rendered = err.to_string();
+    let mut source = err.source();
+    while let Some(inner) = source {
+        rendered.push_str(": ");
+        rendered.push_str(&inner.to_string());
+        source = inner.source();
+    }
+    rendered
 }
 
 /// Merges baked `defaults` under a request's own `overrides` provider options.


### PR DESCRIPTION
## Summary

`send_checked` mapped a reqwest send failure with a plain `{e}`, which renders only the outermost context (`error sending request for url (...)`). The actionable cause — `connection refused (os error 111)`, a TLS failure, a DNS error — lives one or more links down the `source()` chain and was dropped.

Add `error_source_chain(err)` which walks the full `source()` chain joined by `": "`, and use it when mapping the transport failure. This lets a downstream host classify on the `TinyAgentsError::Model` message (loopback-offline detection, transport retryability) — parity with what a host that kept the raw `reqwest::Error` chain could do.

## Commands run
- `cargo fmt --check`
- `cargo test --lib openai::` — 62 pass
- `cargo clippy --lib -- -D warnings` — clean

## Behavior
Additive; the only change to existing output is a richer transport-error message (now includes the cause chain).