### PR TITLE
Resolve bounded o1/o3 mid-name segments to the 200K context window

### DIFF
--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -32,9 +32,11 @@ pub use types::*;
 enum ContextPatternMatch {
     /// Pattern may appear anywhere in the lowercased model id.
     Substring,
-    /// Pattern must be a complete segment delimited by common provider/id
-    /// separators. This avoids false positives for short model ids such as
-    /// `o1` and `o3`.
+    /// Pattern must appear as a bounded segment: delimited by a non-alphanumeric
+    /// boundary (or the string start/end) on both sides. This lets short o-series
+    /// ids such as `o1` and `o3` resolve even when embedded mid-name (e.g.
+    /// `ollama/mistral-for-o1-benchmark`) while avoiding false positives for
+    /// substrings such as `solo1-7b`, `proto3-chat`, or `octo3thing`.
     Segment,
 }
 
@@ -75,11 +77,20 @@ fn matches_context_pattern(lower: &str, pattern: &str, mode: ContextPatternMatch
     match mode {
         ContextPatternMatch::Substring => lower.contains(pattern),
         ContextPatternMatch::Segment => {
-            let model_name = lower.rsplit(['/', ':']).next().unwrap_or(lower);
-            model_name
-                .split(['-', '_', '.'])
-                .next()
-                .is_some_and(|segment| segment == pattern)
+            // Match `pattern` as a bounded segment: every occurrence is accepted
+            // only when the byte before it and the byte after it are both
+            // non-alphanumeric (or absent at the string edge). Scanning the whole
+            // id — not just the final `/`- or `:`-delimited component — lets a
+            // token embedded mid-name (`ollama/mistral-for-o1-benchmark`) resolve,
+            // while the boundary guard keeps substrings like `solo1-7b`,
+            // `proto3-chat`, and `octo3thing` unmatched.
+            let bytes = lower.as_bytes();
+            lower.match_indices(pattern).any(|(start, matched)| {
+                let before_ok = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+                let end = start + matched.len();
+                let after_ok = end >= bytes.len() || !bytes[end].is_ascii_alphanumeric();
+                before_ok && after_ok
+            })
         }
     }
 }

--- a/src/harness/model/test.rs
+++ b/src/harness/model/test.rs
@@ -120,6 +120,7 @@ fn context_window_patterns_cover_common_provider_families() {
 
 #[test]
 fn o1_o3_context_patterns_require_segment_boundaries() {
+    // Canonical o-series ids still resolve to the 200K reasoning window.
     assert_eq!(context_window_for_model_id("o1"), Some(200_000));
     assert_eq!(context_window_for_model_id("o1-mini"), Some(200_000));
     assert_eq!(context_window_for_model_id("o3-mini"), Some(200_000));
@@ -128,13 +129,22 @@ fn o1_o3_context_patterns_require_segment_boundaries() {
         Some(200_000)
     );
 
+    // A bounded o1/o3 token embedded mid-name resolves too: it is delimited by
+    // non-alphanumeric boundaries on both sides.
+    assert_eq!(
+        context_window_for_model_id("ollama/mistral-for-o1-benchmark"),
+        Some(200_000)
+    );
+    assert_eq!(
+        context_window_for_model_id("vllm/qwen-o3-eval.bench"),
+        Some(200_000)
+    );
+
+    // The boundary guard keeps o1/o3 substrings from over-matching.
     assert_eq!(context_window_for_model_id("solo1-7b"), None);
     assert_eq!(context_window_for_model_id("proto3-chat"), None);
     assert_eq!(context_window_for_model_id("octo3thing"), None);
-    assert_eq!(
-        context_window_for_model_id("ollama/mistral-for-o1-benchmark"),
-        None
-    );
+    assert_eq!(context_window_for_model_id("totally-unknown-model"), None);
 }
 
 #[test]


### PR DESCRIPTION
Upstreams bounded o-series (o1/o3) mid-name segment matching for tinyhumansai/openhuman#4566 (Part 1 of 2; host cutover follows after release + pin bump).

## Problem

`context_window_for_model_id` resolves canonical o1/o3 ids (`o1`, `o1-mini`, `openai/o1-preview`, …) but returned `None` for a bounded `-o1-`/`-o3-` token embedded **mid-name** (e.g. `ollama/mistral-for-o1-benchmark`). `Segment`-mode matching only inspected the leading token of the final `/`- or `:`-delimited component, so any o-series token that wasn't at the start of the model name was missed.

## Change

`Segment` matching now scans the whole lowercased id and accepts any occurrence of the pattern that is delimited by a **non-alphanumeric boundary** (or the string start/end) on both sides. This mirrors the semantics of the host heuristic being retired (`o1_o3_segment_context` in openhuman's `model_context.rs`):

- Mid-name o1/o3 tokens now resolve to the **200K** reasoning-model window (`ollama/mistral-for-o1-benchmark`, `vllm/qwen-o3-eval.bench`).
- Canonical ids continue to resolve (`o1`, `o1-mini`, `o3-mini`, `openai/o1-preview`).
- The boundary guard keeps substrings from over-matching: `solo1-7b`, `proto3-chat`, `octo3thing` stay unmatched.

This is only the crate's own generic resolution; hosts keep their tier aliases / cost-catalog arms (out of scope here).

## Tests

Extended `o1_o3_context_patterns_require_segment_boundaries` in `src/harness/model/test.rs` with the new positive mid-name cases and the negative boundary cases.

## Commands run locally (all green)

- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo test --lib` — 1127 passed, 0 failed

## Follow-up (Part 2, not in this PR)

The host cutover — deleting `o1_o3_segment_context` from openhuman's `model_context.rs` and bumping the tinyagents pin — is blocked until this change is merged, released, and the pin bumped. Tracked under tinyhumansai/openhuman#4566.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model detection for context-window patterns embedded within model names.
  * Correctly recognizes valid o1/o3 patterns when surrounded by non-alphanumeric boundaries, including names with prefixes, suffixes, or provider paths.
  * Prevents false matches when o1/o3 appears within larger alphanumeric strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->