### PR TITLE
harness(agent_loop): let a model response keep the floor

### DIFF
--- a/examples/agent_loop_tools.rs
+++ b/examples/agent_loop_tools.rs
@@ -80,6 +80,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -96,6 +97,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/src/graph/subagent_node/test.rs
+++ b/src/graph/subagent_node/test.rs
@@ -38,6 +38,7 @@ fn tool_call_response(id: &str, name: &str) -> ModelResponse {
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/src/harness/agent_loop/run_loop.rs
+++ b/src/harness/agent_loop/run_loop.rs
@@ -333,6 +333,21 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
                     continue;
                 }
 
+                // The model says it is not finished (`ModelResponse::continue_turn`).
+                // Hand the floor back and ask for another reply instead of taking
+                // this response as the turn's answer. Checked after truncated-empty
+                // recovery — a truncated response is broken, not a deliberate
+                // continue — and before structured extraction, which would treat it
+                // as terminal.
+                //
+                // The assistant row is already on `messages` (appended above), so
+                // only the nudge is needed. `max_model_calls` bounds the resulting
+                // loop exactly as it bounds a tool-calling one.
+                if !structured_tool_hit && let Some(nudge) = response.continue_turn.clone() {
+                    messages.push(Message::user(nudge));
+                    continue;
+                }
+
                 // Final response: optionally extract structured output using the
                 // resolved plan (provider-native schema or tool-call arguments).
                 if let Some((strategy, name, schema)) = &structured_plan {

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -146,6 +146,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -169,6 +170,7 @@ fn invalid_tool_call_response(id: &str, name: &str, raw: &str) -> ModelResponse 
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -185,6 +187,7 @@ fn text_response(text: &str, input: u64, output: u64) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -205,6 +208,7 @@ fn truncated_empty_response(reasoning_tokens: u64) -> ModelResponse {
         finish_reason: Some("length".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -2346,6 +2350,7 @@ fn multi_tool_call_response(calls: Vec<(&str, &str)>) -> ModelResponse {
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -2841,4 +2846,92 @@ async fn tool_completed_event_carries_outcome() {
     );
     assert!(duration_ms.is_some(), "wall-clock duration present");
     assert_eq!(output_bytes, Some(4), "\"nope\".len() == 4");
+}
+
+// ── `ModelResponse::continue_turn` ───────────────────────────────────────────
+
+/// A tool-less response that keeps the floor by carrying `nudge`.
+fn continuing(text: &str, nudge: &str) -> ModelResponse {
+    let mut response = ModelResponse::assistant(text.to_string());
+    response.continue_turn = Some(nudge.to_string());
+    response
+}
+
+/// A tool-less response normally ends the turn. `continue_turn` overrides that:
+/// the loop appends the carried nudge as the next user turn and asks for another
+/// reply — which is what lets a model speak before it acts.
+#[tokio::test]
+async fn continue_turn_keeps_the_floor_and_appends_the_nudge() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            continuing("let me look that up", "(next)"),
+            ModelResponse::assistant("found it".to_string()),
+        ])),
+    );
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("hi")])
+        .await
+        .expect("run succeeds");
+
+    assert_eq!(
+        run.model_calls, 2,
+        "the continuing reply must not end the turn"
+    );
+    assert_eq!(run.text(), Some("found it".to_string()));
+    // user, assistant(continuing), user(nudge), assistant(final)
+    assert_eq!(run.messages.len(), 4);
+    assert_eq!(run.messages[2].text(), "(next)");
+}
+
+/// The default is `None`, which must leave the historical behaviour byte-for-byte
+/// intact: the first tool-less reply ends the turn.
+#[tokio::test]
+async fn no_continue_turn_ends_on_the_first_tool_less_reply() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            ModelResponse::assistant("done".to_string()),
+            ModelResponse::assistant("never reached".to_string()),
+        ])),
+    );
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("hi")])
+        .await
+        .expect("run succeeds");
+
+    assert_eq!(run.model_calls, 1);
+    assert_eq!(run.text(), Some("done".to_string()));
+}
+
+/// Continuing needs no cap of its own: each continue costs one model call, so a
+/// model that never stops is already bounded by `max_model_calls`.
+#[tokio::test]
+async fn an_endless_continue_is_bounded_by_max_model_calls() {
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            continuing("still going", "(next)"),
+            continuing("still going", "(next)"),
+            continuing("still going", "(next)"),
+            continuing("still going", "(next)"),
+            continuing("still going", "(next)"),
+        ])),
+    );
+
+    let config = RunConfig::new("continue-cap").with_max_model_calls(3);
+    let err = harness
+        .invoke_in_context(&(), RunContext::new(config, ()), vec![Message::user("hi")])
+        .await
+        .expect_err("an endless continue must hit the model-call cap");
+
+    assert!(
+        err.to_string().contains("max model calls"),
+        "expected the model-call cap to stop it, got: {err}"
+    );
 }

--- a/src/harness/middleware/test.rs
+++ b/src/harness/middleware/test.rs
@@ -38,6 +38,7 @@ fn response_with_usage(usage: Usage) -> ModelResponse {
         finish_reason: None,
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -997,6 +998,7 @@ fn response_text(text: &str) -> ModelResponse {
         finish_reason: None,
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/src/harness/model/mod.rs
+++ b/src/harness/model/mod.rs
@@ -425,6 +425,7 @@ impl ModelResponse {
             finish_reason: None,
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         }
     }
 
@@ -851,6 +852,7 @@ impl StreamAccumulator {
             finish_reason: None,
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         })
     }
 }

--- a/src/harness/model/types.rs
+++ b/src/harness/model/types.rs
@@ -422,6 +422,34 @@ pub struct ModelResponse {
     /// Model selected by the harness/registry for this response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_model: Option<ResolvedModel>,
+    /// When set, this response does **not** end the turn.
+    ///
+    /// A response carrying tool calls always continues the turn — the loop runs
+    /// them and asks for another reply. A response *without* tool calls is
+    /// otherwise the turn's final answer. This field lets a model adapter say
+    /// "not done" anyway: the loop appends the carried string as the next user
+    /// turn and requests another reply.
+    ///
+    /// `None` (the default) is the historical behaviour, so every existing
+    /// caller is unaffected.
+    ///
+    /// **Why it exists.** Text-mode protocols encode tool calls as prose, and a
+    /// model that wants to say something *before* acting has no tool call to
+    /// ride. Without this the loop ends its turn on the first sentence, so such
+    /// a protocol cannot narrate — it must either stay silent until the work is
+    /// done, or fake a tool call purely to keep the floor.
+    ///
+    /// The carried string is the nudge to hand back (e.g. `"(next)"`). It is a
+    /// string rather than a `bool` because most chat APIs reject two assistant
+    /// turns in a row, so *something* must be appended; letting the adapter
+    /// choose keeps the protocol's vocabulary out of the harness.
+    ///
+    /// A continuing turn stays bounded by
+    /// [`RunLimits::max_model_calls`](crate::harness::runtime::RunLimits) — it
+    /// costs one model call per continue, like any other loop iteration — so
+    /// this needs no cap of its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continue_turn: Option<String>,
 }
 
 /// An incremental streamed chunk of a model response.

--- a/src/harness/providers/mock.rs
+++ b/src/harness/providers/mock.rs
@@ -227,6 +227,7 @@ impl<State: Send + Sync> ChatModel<State> for MockModel {
                     finish_reason: Some("tool_calls".to_string()),
                     raw: None,
                     resolved_model: None,
+                    continue_turn: None,
                 }
             }
 
@@ -327,6 +328,7 @@ impl MockModel {
             finish_reason: Some("stop".to_string()),
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         }
     }
 }

--- a/src/harness/providers/openai/convert.rs
+++ b/src/harness/providers/openai/convert.rs
@@ -303,6 +303,7 @@ pub(super) fn parse_chat_response(
         finish_reason: choice.finish_reason,
         raw: Some(value),
         resolved_model: None,
+        continue_turn: None,
     })
 }
 

--- a/src/harness/providers/openai/responses.rs
+++ b/src/harness/providers/openai/responses.rs
@@ -199,6 +199,7 @@ pub(super) fn parse_responses_response(value: Value) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: Some(value),
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/src/harness/providers/openai/sse.rs
+++ b/src/harness/providers/openai/sse.rs
@@ -274,6 +274,7 @@ impl OpenAiStreamAcc {
             finish_reason: self.finish_reason,
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         }
     }
 }

--- a/src/harness/steering/test.rs
+++ b/src/harness/steering/test.rs
@@ -42,6 +42,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -82,6 +83,7 @@ impl ChatModel<()> for RecordingModel {
                 finish_reason: Some("tool_calls".to_string()),
                 raw: None,
                 resolved_model: None,
+                continue_turn: None,
             })
         } else {
             Ok(text_response("done"))

--- a/src/harness/subagent/test.rs
+++ b/src/harness/subagent/test.rs
@@ -40,6 +40,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -56,6 +57,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_agent_graph.rs
+++ b/tests/e2e_agent_graph.rs
@@ -50,6 +50,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -66,6 +67,7 @@ fn text_response(text: &str, input: u64, output: u64) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_budget.rs
+++ b/tests/e2e_budget.rs
@@ -58,6 +58,7 @@ fn tool_call_response(id: &str, name: &str, input: u64, output: u64) -> ModelRes
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -74,6 +75,7 @@ fn text_response(text: &str, input: u64, output: u64) -> ModelResponse {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -290,6 +292,7 @@ async fn cost_pricing_records_and_enforces_money_budget() {
             requested: None,
             source: ModelResolutionSource::RegistryDefault,
         }),
+        continue_turn: None,
     };
 
     stack
@@ -515,6 +518,7 @@ async fn cached_input_budget_blocks_next_call() {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     };
     stack
         .run_after_model(&mut ctx, &(), &mut resp)

--- a/tests/e2e_fuzz_graph_agents.rs
+++ b/tests/e2e_fuzz_graph_agents.rs
@@ -261,6 +261,7 @@ fn tool_call_response(calls: Vec<ToolCall>) -> ModelResponse {
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -276,6 +277,7 @@ fn text_response(text: impl Into<String>) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_graph_subagent_node.rs
+++ b/tests/e2e_graph_subagent_node.rs
@@ -31,6 +31,7 @@ fn tool_call_response(id: &str, name: &str) -> ModelResponse {
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_graph_todos.rs
+++ b/tests/e2e_graph_todos.rs
@@ -29,6 +29,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -44,6 +45,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_harness_provider_contracts.rs
+++ b/tests/e2e_harness_provider_contracts.rs
@@ -454,6 +454,7 @@ fn structured_output_supports_provider_schema_and_tool_fallbacks() {
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     };
     let tool_output = StructuredExtractor::new(StructuredStrategy::ToolCall, "score", schema)
         .extract(&tool_response)

--- a/tests/e2e_middleware.rs
+++ b/tests/e2e_middleware.rs
@@ -142,6 +142,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -158,6 +159,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_observability.rs
+++ b/tests/e2e_observability.rs
@@ -54,6 +54,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -69,6 +70,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_reasoning_and_selection.rs
+++ b/tests/e2e_reasoning_and_selection.rs
@@ -45,6 +45,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_subagents.rs
+++ b/tests/e2e_subagents.rs
@@ -46,6 +46,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -62,6 +63,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_tool_policy.rs
+++ b/tests/e2e_tool_policy.rs
@@ -48,6 +48,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -63,6 +64,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_unknown_tool_policy.rs
+++ b/tests/e2e_unknown_tool_policy.rs
@@ -38,6 +38,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -53,6 +54,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/e2e_workspace_and_registry.rs
+++ b/tests/e2e_workspace_and_registry.rs
@@ -231,6 +231,7 @@ async fn harness_run_threads_workspace_and_enforces_out_of_root() {
             finish_reason: Some("tool_calls".into()),
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         }
     }
     fn text_response(text: &str) -> ModelResponse {
@@ -245,6 +246,7 @@ async fn harness_run_threads_workspace_and_enforces_out_of_root() {
             finish_reason: Some("stop".into()),
             raw: None,
             resolved_model: None,
+            continue_turn: None,
         }
     }
 

--- a/tests/feature_harness_agent_loop.rs
+++ b/tests/feature_harness_agent_loop.rs
@@ -45,6 +45,7 @@ fn multi_tool_call_response(calls: Vec<ToolCall>) -> ModelResponse {
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -64,6 +65,7 @@ fn text_response(text: &str) -> ModelResponse {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 

--- a/tests/feature_harness_structured.rs
+++ b/tests/feature_harness_structured.rs
@@ -61,6 +61,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -161,6 +162,7 @@ async fn tool_call_strategy_reads_named_tool_arguments() {
         finish_reason: Some("tool_calls".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     };
 
     let output = extractor
@@ -334,6 +336,7 @@ async fn provider_schema_reads_text_content_blocks() {
         finish_reason: Some("stop".into()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     };
 
     let parsed: Answer = extractor

--- a/tests/harness_agent_loop.rs
+++ b/tests/harness_agent_loop.rs
@@ -66,6 +66,7 @@ fn tool_call_response(id: &str, name: &str, arguments: serde_json::Value) -> Mod
         finish_reason: Some("tool_calls".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 
@@ -81,6 +82,7 @@ fn text_response(text: &str, input: u64, output: u64) -> ModelResponse {
         finish_reason: Some("stop".to_string()),
         raw: None,
         resolved_model: None,
+        continue_turn: None,
     }
 }
 


### PR DESCRIPTION
## Summary

A response carrying tool calls continues the turn; one without them is taken as the turn's final answer. That leaves no way for a model to say something *before* it acts.

### The motivating case: a text-mode tool protocol

Some models can't use native tool calling — a large toolkit compiles to a provider grammar that blows the rule ceiling and gets rejected with a 400 before any generation, and local runtimes often reject the `tools` parameter outright. Those turns fall back to encoding tool calls as prose.

The one we drive looks like this. A reply is exactly **one tagged block**:

```text
T Let me check your inbox for that.
C GMAIL_FETCH_EMAILS[Colorado|50]
E
```

- `T` — say something to the user
- `C` — call a tool (positional or JSON body)
- `E` — done

The tag sits only at the very start of a reply and everything after it is payload verbatim, so a `T` block containing a line that begins with `C ` stays literal text. That property is the whole point of a distinct format: the parser never scans for tags, so it can't false-positive on prose.

The model adapter parses each reply and hands the loop an ordinary `ModelResponse`, which lines up with the existing loop almost exactly:

| block | `ModelResponse` | loop does |
|---|---|---|
| `C` | real `tool_calls` | runs them, feeds results back, continues — the native shape |
| `E` | no tool calls | finalizes the turn |
| `T` | no tool calls | **finalizes the turn** ← the problem |

`T` is the one block with no home. It means "I have something to say and I am not finished", but it carries no tool call, so the loop ends the turn on it. A model can therefore never narrate before doing slow work — it must stay silent until the work is done, which is exactly the moment a user most wants to hear something.

The only workaround is to synthesise a fake tool call — register a no-op tool, attach a call to it on every `T`, and let the loop "execute" nothing — purely to buy one more reply. That is a real no-op round-trip in the transcript, and a tool in the registry that exists to lie to the loop. This field is that workaround, done honestly.

### The change

Adds `ModelResponse::continue_turn: Option<String>`. When set, the loop appends the carried string as the next user turn and asks for another reply instead of finalizing:

```rust
if !structured_tool_hit && let Some(nudge) = response.continue_turn.clone() {
    messages.push(Message::user(nudge));
    continue;
}
```

Two placement details are deliberate:

- **After** truncated-empty recovery — a truncated response is broken, not a deliberate continue.
- **Before** structured extraction — which would otherwise treat the response as terminal.

Nothing in the harness knows what a `T` block is: it only learns that a given response does not end the turn. The protocol stays entirely in the adapter.

### Why a `String` and not a `bool`

Most chat APIs reject two assistant turns in a row, so *something* must be appended to continue. Letting the adapter supply that string keeps the calling protocol's vocabulary (ours is `"(next)"`) out of the harness — and it is the same token the protocol's system prompt teaches the model to expect, so the two can't drift.

### Why no new limit

Each continue costs exactly one model call, so `RunLimits::max_model_calls` already bounds a model that never stops. An earlier draft of this grew a second, protocol-specific block cap; having two independent ceilings on one turn made "how long is a turn?" unanswerable, and this needs none.

## API Or Behavior Changes

- **New public field** `ModelResponse::continue_turn: Option<String>` (`#[serde(default)]`).
- **Behavior: unchanged by default.** `None` is the default and preserves the existing loop exactly — covered by a test that pins it.
- **Breaking for struct-literal construction only.** Adding a public field means every `ModelResponse { .. }` literal must name it; the in-crate literals (tests, examples, providers) are updated here. Callers using `ModelResponse::assistant(..)` are unaffected.

## Tests

Three new tests in `src/harness/agent_loop/test.rs`:

- `continue_turn_keeps_the_floor_and_appends_the_nudge` — a continuing reply does not end the turn (`model_calls == 2`) and the nudge lands in the transcript.
- `no_continue_turn_ends_on_the_first_tool_less_reply` — pins the default `None` behavior.
- `an_endless_continue_is_bounded_by_max_model_calls` — a model that never stops trips the model-call cap.

All commands run locally on this branch:

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test`
- [x] `cargo test --all-features`

## Documentation

The field carries its own rustdoc: what it does, why it exists, why it's a `String`, and why it needs no cap of its own. The loop's branch carries the placement rationale. No architecture or example docs describe turn termination, so nothing else needed updating.