### PR TITLE
feat(harness): enforce tool timeout policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ export OPENAI_API_KEY=...
 cargo run --example openai_chat
 ```
 
+Bound individual tool calls by installing shared timeout settings on the
+harness. Tools return `ToolTimeout::Inherit` by default; they may instead opt
+out with `Unbounded` or request a clamped explicit `Millis` budget:
+
+```rust
+use tinyagents::{AgentHarness, ToolTimeoutSettings};
+
+let mut harness: AgentHarness<()> = AgentHarness::new();
+harness.with_tool_timeout_settings(ToolTimeoutSettings::new(
+    120_000, // inherited default
+    1_000,   // minimum explicit budget
+    3_600_000,
+    5_000,   // scheduling grace for explicit budgets
+));
+```
+
+A per-tool deadline produces a recoverable tool-error message and the agent
+loop continues, so the model can retry or choose another tool. The run's
+wall-clock deadline remains the outer hard abort. Clones of the settings share
+their inherited value, allowing a host to update it without rebuilding a
+harness.
+
 Export durable harness observations to Langfuse with the embedded client:
 
 ```rust

--- a/docs/modules/harness/README.md
+++ b/docs/modules/harness/README.md
@@ -214,6 +214,18 @@ Feature ownership:
 - `workspace`: per-agent filesystem/sandbox isolation, allowed-root descriptors,
   and fail-closed path enforcement for tools that touch real files.
 
+### Tool timeout policy
+
+Hosts enable per-tool deadlines with
+`AgentHarness::with_tool_timeout_settings(ToolTimeoutSettings)`. The setting is
+shared and dynamically updateable. Each tool supplies `ToolTimeout::Inherit`
+(the default), `Millis(budget)`, or `Unbounded`; resolution happens at the
+innermost tool call after wrap middleware has had a chance to rewrite its
+arguments. On expiry the loop appends a recoverable tool-error result and keeps
+running, allowing model repair. The independent run wall-clock limit remains a
+hard error. See [`tool.md`](tool.md) for the tool contract and
+[`runtime.md`](runtime.md) for harness assembly.
+
 Continued specification: [runtime.md](runtime.md) (tool registry, agent loop,
 middleware, memory/stores) and
 [observability-overview.md](observability-overview.md) (structured output,

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -127,6 +127,13 @@ output, observability, and testability), and
 [`docs/modules/harness/README.md`](../modules/harness/README.md) for the
 per-topic implementation docs.
 
+Per-tool deadlines are opt-in at the harness boundary through
+`AgentHarness::with_tool_timeout_settings`. A tool's `ToolTimeout` policy is
+resolved from the final post-middleware call: `Inherit` uses the shared dynamic
+default, `Millis` is clamped and padded with configured grace, and `Unbounded`
+has no per-tool deadline. Expiry is a recoverable tool result returned to the
+model; only the enclosing run wall-clock deadline aborts the run.
+
 ## Module 2: Graph
 
 The graph is the durable, typed state-graph runtime: `START`/`END`, nodes,

--- a/src/harness/agent_loop/model_call.rs
+++ b/src/harness/agent_loop/model_call.rs
@@ -446,6 +446,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> ModelBaseCall<State, Ctx>
 /// invocation.
 pub(super) struct ToolCallBase<State: Send + Sync> {
     pub(super) tool: Arc<dyn Tool<State>>,
+    pub(super) timeout_settings: Option<crate::harness::tool::ToolTimeoutSettings>,
 }
 
 impl<State: Send + Sync, Ctx: Send + Sync> ToolBaseCall<State, Ctx> for ToolCallBase<State> {
@@ -456,13 +457,23 @@ impl<State: Send + Sync, Ctx: Send + Sync> ToolBaseCall<State, Ctx> for ToolCall
         call: ToolCall,
     ) -> BoxToolFuture<'a> {
         Box::pin(async move {
-            self.tool
-                .call_with_context(
-                    state,
-                    call,
-                    crate::harness::tool::ToolExecutionContext::from_run_context(ctx),
-                )
-                .await
+            let timeout = self
+                .timeout_settings
+                .as_ref()
+                .map(|settings| settings.resolve(self.tool.timeout_policy(&call)));
+            let timeout_result = super::tools::timeout_result(&call, timeout);
+            let future = self.tool.call_with_context(
+                state,
+                call,
+                crate::harness::tool::ToolExecutionContext::from_run_context(ctx),
+            );
+            match timeout.and_then(|resolved| resolved.deadline) {
+                Some(deadline) => match tokio::time::timeout(deadline, future).await {
+                    Ok(result) => result,
+                    Err(_) => Ok(timeout_result),
+                },
+                None => future.await,
+            }
         })
     }
 }

--- a/src/harness/agent_loop/test.rs
+++ b/src/harness/agent_loop/test.rs
@@ -29,7 +29,9 @@ use crate::harness::model::{
 use crate::harness::providers::MockModel;
 use crate::harness::retry::{FallbackPolicy, RetryPolicy};
 use crate::harness::runtime::{AgentHarness, InvalidArgsPolicy, RunPolicy, UnknownToolPolicy};
-use crate::harness::tool::{Tool, ToolCall, ToolResult, ToolSchema};
+use crate::harness::tool::{
+    Tool, ToolCall, ToolResult, ToolSchema, ToolTimeout, ToolTimeoutSettings,
+};
 use crate::harness::usage::Usage;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -89,6 +91,47 @@ impl Tool<()> for SlowTool {
     async fn call(&self, _state: &(), call: ToolCall) -> Result<ToolResult> {
         tokio::time::sleep(self.delay).await;
         Ok(ToolResult::text(call.id, "slow", "too late"))
+    }
+}
+
+/// A slow tool with an explicit timeout policy, used to prove the runtime
+/// consumes the crate timeout vocabulary rather than only the run deadline.
+struct PolicySlowTool {
+    name: &'static str,
+    delay: std::time::Duration,
+    timeout: ToolTimeout,
+}
+
+#[async_trait]
+impl Tool<()> for PolicySlowTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        "policy-bounded slow tool"
+    }
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name,
+            "policy-bounded slow tool",
+            json!({"type": "object"}),
+        )
+    }
+    fn timeout_policy(&self, call: &ToolCall) -> ToolTimeout {
+        if call
+            .arguments
+            .get("unbounded")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            ToolTimeout::Unbounded
+        } else {
+            self.timeout
+        }
+    }
+    async fn call(&self, _state: &(), call: ToolCall) -> Result<ToolResult> {
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolResult::text(call.id, self.name, "too late"))
     }
 }
 
@@ -373,6 +416,27 @@ impl ToolMiddleware<()> for StampToolWrap {
         let mut result = next.run(ctx, state, call).await?.into_result();
         result.content = format!("[wrapped] {}", result.content);
         Ok(result.into())
+    }
+}
+
+/// Rewrites the call to opt out of the inherited timeout, proving timeout
+/// resolution observes the call that actually reaches the tool.
+struct UnboundToolWrap;
+
+#[async_trait]
+impl ToolMiddleware<()> for UnboundToolWrap {
+    fn name(&self) -> &str {
+        "unbound_tool"
+    }
+    async fn wrap_tool(
+        &self,
+        ctx: &mut RunContext<()>,
+        state: &(),
+        mut call: ToolCall,
+        next: ToolHandler<'_, (), ()>,
+    ) -> Result<MiddlewareToolOutcome> {
+        call.arguments["unbounded"] = json!(true);
+        next.run(ctx, state, call).await
     }
 }
 
@@ -1897,6 +1961,133 @@ async fn slow_tool_call_is_timed_out_by_remaining_budget() {
         .expect_err("a tool call slower than the budget must time out");
 
     assert!(matches!(err, TinyAgentsError::Timeout(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn inherited_tool_timeout_is_enforced_without_a_run_deadline() {
+    use std::time::Duration;
+
+    let settings = ToolTimeoutSettings::new(20, 1, 1_000, 0);
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.with_tool_timeout_settings(settings.clone());
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("call-1", "policy_slow", json!({})),
+            text_response("recovered", 2, 1),
+        ])),
+    );
+    harness.register_tool(Arc::new(PolicySlowTool {
+        name: "policy_slow",
+        delay: Duration::from_millis(200),
+        timeout: ToolTimeout::Inherit,
+    }));
+
+    let run = harness
+        .invoke(
+            &(),
+            (),
+            RunConfig::new("inherited-tool-timeout-run"),
+            vec![Message::user("go")],
+        )
+        .await
+        .expect("a per-tool timeout should be recoverable by the model");
+
+    assert_eq!(run.text(), Some("recovered".to_string()));
+    assert!(run.messages[2].text().contains("timed out after 20 ms"));
+
+    settings.set_inherited_timeout_ms(5);
+    assert_eq!(settings.inherited_timeout(), Some(Duration::from_millis(5)));
+}
+
+#[tokio::test]
+async fn tool_timeout_unwinds_wrap_middleware() {
+    use std::time::Duration;
+
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.with_tool_timeout_settings(ToolTimeoutSettings::new(10, 1, 1_000, 0));
+    harness.push_tool_middleware(Arc::new(StampToolWrap));
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("call-1", "policy_slow", json!({})),
+            text_response("recovered", 2, 1),
+        ])),
+    );
+    harness.register_tool(Arc::new(PolicySlowTool {
+        name: "policy_slow",
+        delay: Duration::from_millis(200),
+        timeout: ToolTimeout::Inherit,
+    }));
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("go")])
+        .await
+        .expect("middleware should unwind after the inner tool times out");
+
+    assert_eq!(run.text(), Some("recovered".to_string()));
+    assert!(run.messages[2].text().starts_with("[wrapped]"));
+    assert!(run.messages[2].text().contains("timed out after 10 ms"));
+}
+
+#[tokio::test]
+async fn tool_timeout_resolves_after_wrap_middleware_mutation() {
+    use std::time::Duration;
+
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.with_tool_timeout_settings(ToolTimeoutSettings::new(10, 1, 1_000, 0));
+    harness.push_tool_middleware(Arc::new(UnboundToolWrap));
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            tool_call_response("call-1", "policy_slow", json!({})),
+            text_response("done", 2, 1),
+        ])),
+    );
+    harness.register_tool(Arc::new(PolicySlowTool {
+        name: "policy_slow",
+        delay: Duration::from_millis(30),
+        timeout: ToolTimeout::Inherit,
+    }));
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("go")])
+        .await
+        .expect("the middleware-mutated unbounded policy should reach the tool");
+
+    assert_eq!(run.text(), Some("done".to_string()));
+    assert_eq!(run.messages[2].text(), "too late");
+}
+
+#[tokio::test]
+async fn parallel_tool_timeouts_return_ordered_recoverable_errors() {
+    use std::time::Duration;
+
+    let mut harness: AgentHarness<()> = AgentHarness::new();
+    harness.with_tool_timeout_settings(ToolTimeoutSettings::new(10, 1, 1_000, 0));
+    harness.register_model(
+        "mock",
+        Arc::new(MockModel::with_responses(vec![
+            multi_tool_call_response(vec![("call-a", "slow_a"), ("call-b", "slow_b")]),
+            text_response("recovered", 2, 1),
+        ])),
+    );
+    for name in ["slow_a", "slow_b"] {
+        harness.register_tool(Arc::new(PolicySlowTool {
+            name,
+            delay: Duration::from_millis(200),
+            timeout: ToolTimeout::Inherit,
+        }));
+    }
+
+    let run = harness
+        .invoke_default(&(), vec![Message::user("go")])
+        .await
+        .expect("parallel tool timeouts should be recoverable");
+
+    assert_eq!(run.text(), Some("recovered".to_string()));
+    assert!(run.messages[2].text().contains("slow_a"));
+    assert!(run.messages[3].text().contains("slow_b"));
 }
 
 // ── Response caching ──────────────────────────────────────────────────────────

--- a/src/harness/agent_loop/tools.rs
+++ b/src/harness/agent_loop/tools.rs
@@ -83,6 +83,36 @@ struct PreparedToolCall {
 }
 
 impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
+    /// Resolves this tool's own timeout policy. The separate run wall-clock
+    /// budget remains the outer hard deadline: a per-tool timeout becomes a
+    /// recoverable tool-error result, while exhausting the run budget aborts.
+    fn resolved_tool_timeout(
+        &self,
+        tool: &dyn Tool<State>,
+        call: &ToolCall,
+    ) -> Option<crate::harness::tool::ResolvedToolTimeout> {
+        self.tool_timeouts
+            .as_ref()
+            .map(|settings| settings.resolve(tool.timeout_policy(call)))
+    }
+
+    async fn with_tool_policy_timeout<T, F>(
+        timeout: Option<crate::harness::tool::ResolvedToolTimeout>,
+        timeout_value: T,
+        fut: F,
+    ) -> Result<T>
+    where
+        F: Future<Output = Result<T>>,
+    {
+        match timeout.and_then(|resolved| resolved.deadline) {
+            Some(deadline) => match tokio::time::timeout(deadline, fut).await {
+                Ok(result) => result,
+                Err(_) => Ok(timeout_value),
+            },
+            None => fut.await,
+        }
+    }
+
     /// Executes one assistant turn's requested tool calls, appending each
     /// result to `messages` in the calls' original order.
     ///
@@ -365,14 +395,17 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
             // The real tool call is the innermost base of the tool-wrap
             // onion (same before -> wrap -> after ordering as the model
             // path): lifecycle `before_tool` ran in admission, the wrap onion
-            // runs here, and lifecycle `after_tool` runs in the fold. Bounded
-            // by the same remaining wall-clock budget as a model call, so a
-            // hanging tool cannot block the run past its deadline either.
-            let base = ToolCallBase { tool };
-            let remaining = self.call_budget(ctx);
+            // runs here, and lifecycle `after_tool` runs in the fold. The
+            // crate-owned tool policy returns a recoverable tool error; the
+            // outer run budget still aborts when the whole run is exhausted.
+            let run_budget = self.call_budget(ctx);
+            let base = ToolCallBase {
+                tool,
+                timeout_settings: self.tool_timeouts.clone(),
+            };
             let run_id = ctx.run_id().as_str().to_string();
             let fut = self.middleware.run_wrapped_tool(ctx, state, call, &base);
-            let result = Self::with_call_budget(remaining, &run_id, "tool call", fut)
+            let result = Self::with_call_budget(run_budget, &run_id, "tool call", fut)
                 .await?
                 .into_result();
 
@@ -417,17 +450,20 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
             prepared.push(self.start_tool_call(ctx, status, &call));
             slots.push(ToolSlot::Execute);
 
-            // Each call is individually bounded by the run's remaining
-            // wall-clock budget *at admission*, mirroring the serial path.
+            // Each call is bounded by its recoverable tool policy inside the
+            // run's hard remaining wall-clock budget, mirroring serial mode.
             // The future owns everything it needs (tool Arc, call, a
             // non-generic `ToolExecutionContext` snapshot), so it does not
             // borrow the `RunContext` and can run alongside its siblings.
-            let remaining = self.call_budget(ctx);
+            let tool_timeout = self.resolved_tool_timeout(tool.as_ref(), &call);
+            let timeout_result = timeout_result(&call, tool_timeout);
+            let run_budget = self.call_budget(ctx);
             let run_id = ctx.run_id().as_str().to_string();
             let exec_ctx = ToolExecutionContext::from_run_context(ctx);
             futures.push(async move {
                 let fut = tool.call_with_context(state, call, exec_ctx);
-                Self::with_call_budget(remaining, &run_id, "tool call", fut).await
+                let fut = Self::with_tool_policy_timeout(tool_timeout, timeout_result, fut);
+                Self::with_call_budget(run_budget, &run_id, "tool call", fut).await
             });
         }
 
@@ -455,4 +491,20 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
         }
         Ok(())
     }
+}
+
+pub(super) fn timeout_result(
+    call: &ToolCall,
+    timeout: Option<crate::harness::tool::ResolvedToolTimeout>,
+) -> crate::harness::tool::ToolResult {
+    let budget_ms = timeout.map_or(0, |resolved| resolved.budget_ms);
+    let mut result = crate::harness::tool::ToolResult::error(
+        call.id.clone(),
+        call.name.clone(),
+        format!("tool `{}` timed out after {budget_ms} ms", call.name),
+    );
+    result.elapsed_ms = timeout
+        .and_then(|resolved| resolved.deadline)
+        .map_or(0, |deadline| deadline.as_millis() as u64);
+    result
 }

--- a/src/harness/runtime/mod.rs
+++ b/src/harness/runtime/mod.rs
@@ -8,6 +8,11 @@
 //! workflows recurse on one consistent set of capabilities rather than spinning
 //! up disjoint engines.
 //!
+//! Per-tool deadlines are enabled separately from [`RunPolicy`] through
+//! [`AgentHarness::with_tool_timeout_settings`]. Expiry becomes a recoverable
+//! tool-error result so the model can repair its plan, while the run wall-clock
+//! limit remains the outer hard abort.
+//!
 //! Owns the high-level [`AgentHarness`] builder and the [`RunPolicy`] bundle
 //! that wires registries, middleware, and run policy into a single ergonomic
 //! entry point. The agent loop driven by this facade lives in the sibling
@@ -29,7 +34,7 @@ use std::sync::Arc;
 use crate::harness::cache::ResponseCache;
 use crate::harness::middleware::{Middleware, MiddlewareStack, ModelMiddleware, ToolMiddleware};
 use crate::harness::model::{ChatModel, ModelRegistry};
-use crate::harness::tool::{Tool, ToolRegistry};
+use crate::harness::tool::{Tool, ToolRegistry, ToolTimeoutSettings};
 
 impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
     /// Creates an empty harness with default policy and no models, tools, or
@@ -40,6 +45,7 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
             tools: ToolRegistry::new(),
             middleware: MiddlewareStack::new(),
             policy: RunPolicy::default(),
+            tool_timeouts: None,
             response_cache: None,
         }
     }
@@ -103,6 +109,20 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
     pub fn with_policy(&mut self, policy: RunPolicy) -> &mut Self {
         self.policy = policy;
         self
+    }
+
+    /// Installs the shared resolver used for per-tool timeout policies.
+    ///
+    /// Keeping this runtime concern on the harness leaves [`RunPolicy`]
+    /// source-compatible for callers that construct it with struct literals.
+    pub fn with_tool_timeout_settings(&mut self, settings: ToolTimeoutSettings) -> &mut Self {
+        self.tool_timeouts = Some(settings);
+        self
+    }
+
+    /// Returns the installed per-tool timeout settings, if any.
+    pub fn tool_timeout_settings(&self) -> Option<&ToolTimeoutSettings> {
+        self.tool_timeouts.as_ref()
     }
 
     /// Attaches a [`ResponseCache`] shared across every run this harness drives.

--- a/src/harness/runtime/types.rs
+++ b/src/harness/runtime/types.rs
@@ -24,7 +24,7 @@ use crate::harness::limits::RunLimits;
 use crate::harness::middleware::MiddlewareStack;
 use crate::harness::model::{ModelRegistry, ResponseFormat};
 use crate::harness::retry::{FallbackPolicy, RetryPolicy};
-use crate::harness::tool::ToolRegistry;
+use crate::harness::tool::{ToolRegistry, ToolTimeoutSettings};
 
 /// Declarative, run-scoped policy shared by every invocation of an
 /// [`AgentHarness`].
@@ -258,6 +258,8 @@ pub struct AgentHarness<State: Send + Sync, Ctx: Send + Sync = ()> {
     pub(crate) middleware: MiddlewareStack<State, Ctx>,
     /// Cross-cutting run policy (limits, retry, fallback, response format).
     pub(crate) policy: RunPolicy,
+    /// Optional per-tool timeout resolver shared across harness runs.
+    pub(crate) tool_timeouts: Option<ToolTimeoutSettings>,
     /// Optional local response cache shared across runs of this harness.
     ///
     /// When set, the agent loop consults it before each provider call (subject

--- a/src/harness/tool/mod.rs
+++ b/src/harness/tool/mod.rs
@@ -11,6 +11,7 @@
 //! [`ToolRegistry`] logic for registering and looking up tools by name.
 
 mod schema;
+mod timeout;
 mod types;
 
 use std::sync::Arc;
@@ -20,6 +21,7 @@ use serde_json::Value;
 use crate::error::{Result, TinyAgentsError};
 
 pub use schema::*;
+pub use timeout::*;
 pub use types::*;
 
 impl ToolSchema {
@@ -542,3 +544,6 @@ fn json_value_kind(value: &Value) -> &'static str {
 mod schema_test;
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod timeout_test;

--- a/src/harness/tool/timeout.rs
+++ b/src/harness/tool/timeout.rs
@@ -1,0 +1,135 @@
+//! Shared, dynamically updateable tool-timeout resolution.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use super::ToolTimeout;
+
+#[derive(Debug)]
+struct ToolTimeoutSettingsInner {
+    inherited_ms: AtomicU64,
+    min_ms: u64,
+    max_ms: u64,
+    grace_ms: u64,
+}
+
+/// Runtime tool-timeout settings shared by every settings clone installed on a
+/// harness.
+///
+/// The inherited timeout is stored atomically, so a host can apply a config or
+/// operator override without rebuilding active harnesses. A value of `0`
+/// disables the inherited per-tool deadline; explicit [`ToolTimeout::Millis`]
+/// policies remain bounded. Explicit budgets are clamped to `min_ms..=max_ms`
+/// and receive `grace_ms` of scheduling slack on the enforced deadline.
+#[derive(Clone)]
+pub struct ToolTimeoutSettings {
+    inner: Arc<ToolTimeoutSettingsInner>,
+}
+
+impl ToolTimeoutSettings {
+    /// Creates shared timeout settings.
+    ///
+    /// Bounds are normalized defensively: `min_ms` is at least one and
+    /// `max_ms` is at least the normalized minimum. A non-zero inherited value
+    /// is clamped into those bounds.
+    pub fn new(inherited_ms: u64, min_ms: u64, max_ms: u64, grace_ms: u64) -> Self {
+        let min_ms = min_ms.max(1);
+        let max_ms = max_ms.max(min_ms);
+        let inherited_ms = clamp_or_disabled(inherited_ms, min_ms, max_ms);
+        Self {
+            inner: Arc::new(ToolTimeoutSettingsInner {
+                inherited_ms: AtomicU64::new(inherited_ms),
+                min_ms,
+                max_ms,
+                grace_ms,
+            }),
+        }
+    }
+
+    /// Replaces the inherited timeout for all settings clones.
+    ///
+    /// `0` disables inherited per-tool deadlines. Other values are clamped to
+    /// the configured bounds. Returns the stored value.
+    pub fn set_inherited_timeout_ms(&self, timeout_ms: u64) -> u64 {
+        let timeout_ms = clamp_or_disabled(timeout_ms, self.inner.min_ms, self.inner.max_ms);
+        self.inner.inherited_ms.store(timeout_ms, Ordering::Relaxed);
+        timeout_ms
+    }
+
+    /// Returns the current inherited timeout, or `None` when it is disabled.
+    pub fn inherited_timeout(&self) -> Option<Duration> {
+        match self.inner.inherited_ms.load(Ordering::Relaxed) {
+            0 => None,
+            timeout_ms => Some(Duration::from_millis(timeout_ms)),
+        }
+    }
+
+    /// Resolves a tool policy into an enforced deadline and reported budget.
+    pub fn resolve(&self, policy: ToolTimeout) -> ResolvedToolTimeout {
+        match policy {
+            ToolTimeout::Inherit => {
+                let budget_ms = self.inner.inherited_ms.load(Ordering::Relaxed);
+                ResolvedToolTimeout {
+                    deadline: (budget_ms != 0).then(|| Duration::from_millis(budget_ms)),
+                    budget_ms,
+                }
+            }
+            ToolTimeout::Unbounded => ResolvedToolTimeout {
+                deadline: None,
+                budget_ms: 0,
+            },
+            ToolTimeout::Millis(requested_ms) => {
+                let budget_ms = requested_ms.clamp(self.inner.min_ms, self.inner.max_ms);
+                ResolvedToolTimeout {
+                    deadline: Some(Duration::from_millis(
+                        budget_ms.saturating_add(self.inner.grace_ms),
+                    )),
+                    budget_ms,
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Debug for ToolTimeoutSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ToolTimeoutSettings")
+            .field(
+                "inherited_ms",
+                &self.inner.inherited_ms.load(Ordering::Relaxed),
+            )
+            .field("min_ms", &self.inner.min_ms)
+            .field("max_ms", &self.inner.max_ms)
+            .field("grace_ms", &self.inner.grace_ms)
+            .finish()
+    }
+}
+
+impl PartialEq for ToolTimeoutSettings {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.inherited_ms.load(Ordering::Relaxed)
+            == other.inner.inherited_ms.load(Ordering::Relaxed)
+            && self.inner.min_ms == other.inner.min_ms
+            && self.inner.max_ms == other.inner.max_ms
+            && self.inner.grace_ms == other.inner.grace_ms
+    }
+}
+
+/// A resolved tool-call timeout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResolvedToolTimeout {
+    /// Deadline enforced around the call, including explicit-budget grace.
+    pub deadline: Option<Duration>,
+    /// Unpadded budget reported to callers and observability surfaces.
+    pub budget_ms: u64,
+}
+
+fn clamp_or_disabled(timeout_ms: u64, min_ms: u64, max_ms: u64) -> u64 {
+    if timeout_ms == 0 {
+        0
+    } else {
+        timeout_ms.clamp(min_ms, max_ms)
+    }
+}

--- a/src/harness/tool/timeout_test.rs
+++ b/src/harness/tool/timeout_test.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use super::{ToolTimeout, ToolTimeoutSettings};
+
+#[test]
+fn inherited_timeout_updates_across_clones() {
+    let settings = ToolTimeoutSettings::new(2_000, 1_000, 10_000, 250);
+    let clone = settings.clone();
+
+    assert_eq!(
+        clone.resolve(ToolTimeout::Inherit).deadline,
+        Some(Duration::from_millis(2_000))
+    );
+    assert_eq!(settings.set_inherited_timeout_ms(4_000), 4_000);
+    assert_eq!(
+        clone.resolve(ToolTimeout::Inherit).deadline,
+        Some(Duration::from_millis(4_000))
+    );
+}
+
+#[test]
+fn zero_disables_only_the_inherited_deadline() {
+    let settings = ToolTimeoutSettings::new(0, 1_000, 10_000, 250);
+
+    assert_eq!(settings.inherited_timeout(), None);
+    assert_eq!(settings.resolve(ToolTimeout::Inherit).deadline, None);
+    assert_eq!(settings.resolve(ToolTimeout::Unbounded).deadline, None);
+    assert_eq!(
+        settings.resolve(ToolTimeout::Millis(2_000)).deadline,
+        Some(Duration::from_millis(2_250))
+    );
+}
+
+#[test]
+fn explicit_timeout_clamps_and_reports_unpadded_budget() {
+    let settings = ToolTimeoutSettings::new(5_000, 1_000, 10_000, 250);
+
+    let below = settings.resolve(ToolTimeout::Millis(1));
+    assert_eq!(below.budget_ms, 1_000);
+    assert_eq!(below.deadline, Some(Duration::from_millis(1_250)));
+
+    let above = settings.resolve(ToolTimeout::Millis(99_000));
+    assert_eq!(above.budget_ms, 10_000);
+    assert_eq!(above.deadline, Some(Duration::from_millis(10_250)));
+}
+
+#[test]
+fn invalid_bounds_are_normalized() {
+    let settings = ToolTimeoutSettings::new(9, 0, 0, 0);
+    let resolved = settings.resolve(ToolTimeout::Inherit);
+    assert_eq!(resolved.budget_ms, 1);
+    assert_eq!(resolved.deadline, Some(Duration::from_millis(1)));
+}


### PR DESCRIPTION
## Summary
- add shared, atomically updateable ToolTimeoutSettings with inherited, explicit, unbounded, clamp, and grace semantics
- let RunPolicy opt into those settings without changing default behavior
- enforce the tighter of the tool deadline and remaining run wall-clock budget in serial and parallel tool execution

This closes the gap where Tool::timeout_policy existed as metadata but the harness loop did not consume it.

## Validation
- cargo test timeout
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings