### PR TITLE
feat(harness): track successful no-progress loops

### DIFF
--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -52,7 +52,9 @@ pub use model::{
     collect_model_stream, context_window_for_model_id,
 };
 pub use no_progress::{
-    DEFAULT_IDENTICAL_HALT_THRESHOLD, NoProgress, NoProgressTracker, ToolAttempt,
+    DEFAULT_IDENTICAL_HALT_THRESHOLD, DEFAULT_REPEAT_CALL_THRESHOLD,
+    DEFAULT_REPEAT_OUTPUT_THRESHOLD, NoProgress, NoProgressTracker, SuccessfulRepeat,
+    SuccessfulRepeatTracker, ToolAttempt,
 };
 pub use tool::{
     Tool as HarnessTool, ToolCall as HarnessToolCall, ToolFormat, ToolRegistry,

--- a/src/harness/no_progress/mod.rs
+++ b/src/harness/no_progress/mod.rs
@@ -22,12 +22,11 @@
 mod successful_repeat;
 mod types;
 
-pub use successful_repeat::{
-    DEFAULT_REPEAT_CALL_THRESHOLD, DEFAULT_REPEAT_OUTPUT_THRESHOLD, SuccessfulRepeat,
-    SuccessfulRepeatTracker,
-};
+pub use successful_repeat::{DEFAULT_REPEAT_CALL_THRESHOLD, DEFAULT_REPEAT_OUTPUT_THRESHOLD};
 use types::LadderState;
-pub use types::{NoProgress, NoProgressTracker, ToolAttempt};
+pub use types::{
+    NoProgress, NoProgressTracker, SuccessfulRepeat, SuccessfulRepeatTracker, ToolAttempt,
+};
 
 use std::sync::Mutex;
 

--- a/src/harness/no_progress/mod.rs
+++ b/src/harness/no_progress/mod.rs
@@ -19,8 +19,13 @@
 //! and turns the returned [`NoProgress`] verdict into a steering nudge
 //! (`Nudge`) or a halt (`Halt`).
 
+mod successful_repeat;
 mod types;
 
+pub use successful_repeat::{
+    DEFAULT_REPEAT_CALL_THRESHOLD, DEFAULT_REPEAT_OUTPUT_THRESHOLD, SuccessfulRepeat,
+    SuccessfulRepeatTracker,
+};
 use types::LadderState;
 pub use types::{NoProgress, NoProgressTracker, ToolAttempt};
 

--- a/src/harness/no_progress/successful_repeat.rs
+++ b/src/harness/no_progress/successful_repeat.rs
@@ -86,9 +86,11 @@ impl SuccessfulRepeatTracker {
         if exempt || !all_successful {
             calls.reset();
             drop(calls);
-            if !all_successful {
-                self.output.lock().unwrap().reset();
-            }
+            // Output is observed before the completed batch can be classified.
+            // An exempt polling batch or a failure therefore resets both
+            // trackers so its preceding output cannot leak into the next
+            // progress-eligible iteration.
+            self.output.lock().unwrap().reset();
             return SuccessfulRepeat::Continue;
         }
         let consecutive = calls.record(signature);
@@ -104,113 +106,5 @@ impl SuccessfulRepeatTracker {
     pub fn reset(&self) {
         self.output.lock().unwrap().reset();
         self.calls.lock().unwrap().reset();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn identical_output_halts_at_threshold_and_changes_reset() {
-        let tracker = SuccessfulRepeatTracker::new(3, 3);
-        assert_eq!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Continue
-        );
-        assert!(matches!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Halt(message) if message.contains("3 iterations")
-        ));
-        assert_eq!(
-            tracker.record_output("different", false),
-            SuccessfulRepeat::Continue
-        );
-    }
-
-    #[test]
-    fn successful_call_batches_halt_but_failures_reset() {
-        let tracker = SuccessfulRepeatTracker::new(4, 2);
-        assert_eq!(
-            tracker.record_call_batch("tool:args", true, false),
-            SuccessfulRepeat::Continue
-        );
-        assert!(matches!(
-            tracker.record_call_batch("tool:args", true, false),
-            SuccessfulRepeat::Halt(message) if message.contains("2 times")
-        ));
-        assert_eq!(
-            tracker.record_call_batch("tool:args", false, false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_call_batch("tool:args", true, false),
-            SuccessfulRepeat::Continue
-        );
-    }
-
-    #[test]
-    fn failed_call_batches_reset_output_repeats() {
-        let tracker = SuccessfulRepeatTracker::new(2, 2);
-        assert_eq!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_call_batch("same-call", false, false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Continue,
-            "a failed prior batch must not count toward a successful output loop"
-        );
-    }
-
-    #[test]
-    fn exempt_batches_reset_both_streaks() {
-        let tracker = SuccessfulRepeatTracker::new(2, 2);
-        assert_eq!(
-            tracker.record_output("poll", false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_output("poll", true),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_output("poll", false),
-            SuccessfulRepeat::Continue
-        );
-
-        assert_eq!(
-            tracker.record_call_batch("poll", true, false),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_call_batch("poll", true, true),
-            SuccessfulRepeat::Continue
-        );
-        assert_eq!(
-            tracker.record_call_batch("poll", true, false),
-            SuccessfulRepeat::Continue
-        );
-    }
-
-    #[test]
-    fn zero_thresholds_are_fail_safe() {
-        let tracker = SuccessfulRepeatTracker::new(0, 0);
-        assert!(matches!(
-            tracker.record_output("same", false),
-            SuccessfulRepeat::Halt(_)
-        ));
-        assert!(matches!(
-            tracker.record_call_batch("same", true, false),
-            SuccessfulRepeat::Halt(_)
-        ));
     }
 }

--- a/src/harness/no_progress/successful_repeat.rs
+++ b/src/harness/no_progress/successful_repeat.rs
@@ -57,21 +57,18 @@ impl SuccessfulRepeatTracker {
         }
     }
 
-    /// Records the canonical visible-output plus tool-call signature produced
-    /// by one assistant iteration.
+    /// Stages the canonical visible-output plus tool-call signature produced
+    /// by one assistant iteration. A threshold crossing is not reported until
+    /// [`record_call_batch`](Self::record_call_batch) confirms that the
+    /// associated batch succeeded and is not exempt.
     pub fn record_output(&self, signature: &str, exempt: bool) -> SuccessfulRepeat {
         let mut output = self.output.lock().unwrap();
         if exempt {
             output.reset();
             return SuccessfulRepeat::Continue;
         }
-        let consecutive = output.record(signature);
-        if consecutive < self.output_threshold {
-            return SuccessfulRepeat::Continue;
-        }
-        SuccessfulRepeat::Halt(format!(
-            "Stopping: the last {consecutive} iterations produced the identical response and tool call with no change; the run is stuck repeating the same step without making progress."
-        ))
+        output.record(signature);
+        SuccessfulRepeat::Continue
     }
 
     /// Records the canonical tool-name/arguments signature after the whole
@@ -82,17 +79,22 @@ impl SuccessfulRepeatTracker {
         all_successful: bool,
         exempt: bool,
     ) -> SuccessfulRepeat {
-        let mut calls = self.calls.lock().unwrap();
         if exempt || !all_successful {
-            calls.reset();
-            drop(calls);
             // Output is observed before the completed batch can be classified.
             // An exempt polling batch or a failure therefore resets both
             // trackers so its preceding output cannot leak into the next
             // progress-eligible iteration.
             self.output.lock().unwrap().reset();
+            self.calls.lock().unwrap().reset();
             return SuccessfulRepeat::Continue;
         }
+        let output_consecutive = self.output.lock().unwrap().consecutive;
+        if output_consecutive >= self.output_threshold {
+            return SuccessfulRepeat::Halt(format!(
+                "Stopping: the last {output_consecutive} iterations produced the identical response and tool call with no change; the run is stuck repeating the same step without making progress."
+            ));
+        }
+        let mut calls = self.calls.lock().unwrap();
         let consecutive = calls.record(signature);
         if consecutive < self.call_threshold {
             return SuccessfulRepeat::Continue;

--- a/src/harness/no_progress/successful_repeat.rs
+++ b/src/harness/no_progress/successful_repeat.rs
@@ -10,9 +10,9 @@
 use std::hash::{Hash, Hasher};
 use std::sync::Mutex;
 
-/// Identical assistant-output batches allowed before halting.
+/// Consecutive identical assistant-output batches required to halt.
 pub const DEFAULT_REPEAT_OUTPUT_THRESHOLD: u32 = 4;
-/// Identical successful tool-call batches allowed before halting.
+/// Consecutive identical successful tool-call batches required to halt.
 pub const DEFAULT_REPEAT_CALL_THRESHOLD: u32 = 3;
 
 /// Verdict returned after recording a successful-repeat signal.
@@ -113,6 +113,10 @@ impl SuccessfulRepeatTracker {
         let mut calls = self.calls.lock().unwrap();
         if exempt || !all_successful {
             calls.reset();
+            drop(calls);
+            if !all_successful {
+                self.output.lock().unwrap().reset();
+            }
             return SuccessfulRepeat::Continue;
         }
         let consecutive = calls.record(signature);
@@ -174,6 +178,24 @@ mod tests {
         assert_eq!(
             tracker.record_call_batch("tool:args", true, false),
             SuccessfulRepeat::Continue
+        );
+    }
+
+    #[test]
+    fn failed_call_batches_reset_output_repeats() {
+        let tracker = SuccessfulRepeatTracker::new(2, 2);
+        assert_eq!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_call_batch("same-call", false, false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Continue,
+            "a failed prior batch must not count toward a successful output loop"
         );
     }
 

--- a/src/harness/no_progress/successful_repeat.rs
+++ b/src/harness/no_progress/successful_repeat.rs
@@ -1,0 +1,222 @@
+//! Successful-repeat progress detection.
+//!
+//! [`NoProgressTracker`] handles failing tool calls, but deliberately resets on
+//! success. That leaves a second loop shape undetected: a model can repeatedly
+//! emit the same response and successfully invoke the same no-op tool call.
+//! This tracker owns the provider- and product-neutral streak accounting for
+//! those loops; a harness middleware remains responsible for building canonical
+//! signatures and deciding which polling tools are exempt.
+
+use std::hash::{Hash, Hasher};
+use std::sync::Mutex;
+
+/// Identical assistant-output batches allowed before halting.
+pub const DEFAULT_REPEAT_OUTPUT_THRESHOLD: u32 = 4;
+/// Identical successful tool-call batches allowed before halting.
+pub const DEFAULT_REPEAT_CALL_THRESHOLD: u32 = 3;
+
+/// Verdict returned after recording a successful-repeat signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SuccessfulRepeat {
+    /// The signature changed, is exempt, failed, or remains below its threshold.
+    Continue,
+    /// The same successful action has repeated enough times to be considered
+    /// stuck. The message is suitable for steering or a halt summary.
+    Halt(String),
+}
+
+#[derive(Default)]
+struct Streak {
+    last_hash: Option<u64>,
+    consecutive: u32,
+}
+
+impl Streak {
+    fn record(&mut self, signature: &str) -> u32 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        signature.hash(&mut hasher);
+        let hash = hasher.finish();
+        if self.last_hash == Some(hash) {
+            self.consecutive += 1;
+        } else {
+            self.last_hash = Some(hash);
+            self.consecutive = 1;
+        }
+        self.consecutive
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Tracks identical assistant-output and successful tool-call batches.
+///
+/// The two streaks are independent: output is observed before tools execute,
+/// while a call batch is recorded only after every result is known. Exempt
+/// polling batches reset their streak; a failed call batch also resets the
+/// successful-call streak so the failure ladder remains authoritative.
+pub struct SuccessfulRepeatTracker {
+    output_threshold: u32,
+    call_threshold: u32,
+    output: Mutex<Streak>,
+    calls: Mutex<Streak>,
+}
+
+impl Default for SuccessfulRepeatTracker {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_REPEAT_OUTPUT_THRESHOLD,
+            DEFAULT_REPEAT_CALL_THRESHOLD,
+        )
+    }
+}
+
+impl SuccessfulRepeatTracker {
+    /// Builds a tracker. Thresholds are clamped to one so `0` cannot disable a
+    /// safety guard accidentally; callers that do not want this guard should
+    /// omit the tracker.
+    pub fn new(output_threshold: u32, call_threshold: u32) -> Self {
+        Self {
+            output_threshold: output_threshold.max(1),
+            call_threshold: call_threshold.max(1),
+            output: Mutex::new(Streak::default()),
+            calls: Mutex::new(Streak::default()),
+        }
+    }
+
+    /// Records the canonical visible-output plus tool-call signature produced
+    /// by one assistant iteration.
+    pub fn record_output(&self, signature: &str, exempt: bool) -> SuccessfulRepeat {
+        let mut output = self.output.lock().unwrap();
+        if exempt {
+            output.reset();
+            return SuccessfulRepeat::Continue;
+        }
+        let consecutive = output.record(signature);
+        if consecutive < self.output_threshold {
+            return SuccessfulRepeat::Continue;
+        }
+        SuccessfulRepeat::Halt(format!(
+            "Stopping: the last {consecutive} iterations produced the identical response and tool call with no change; the run is stuck repeating the same step without making progress."
+        ))
+    }
+
+    /// Records the canonical tool-name/arguments signature after the whole
+    /// batch completes. Failed or exempt batches reset the successful streak.
+    pub fn record_call_batch(
+        &self,
+        signature: &str,
+        all_successful: bool,
+        exempt: bool,
+    ) -> SuccessfulRepeat {
+        let mut calls = self.calls.lock().unwrap();
+        if exempt || !all_successful {
+            calls.reset();
+            return SuccessfulRepeat::Continue;
+        }
+        let consecutive = calls.record(signature);
+        if consecutive < self.call_threshold {
+            return SuccessfulRepeat::Continue;
+        }
+        SuccessfulRepeat::Halt(format!(
+            "Stopping: the same successful tool-call batch was issued {consecutive} times in a row with identical arguments and no new information; the run is stuck repeating one action without making progress."
+        ))
+    }
+
+    /// Clears both streaks, for example when a paused run is resumed.
+    pub fn reset(&self) {
+        self.output.lock().unwrap().reset();
+        self.calls.lock().unwrap().reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_output_halts_at_threshold_and_changes_reset() {
+        let tracker = SuccessfulRepeatTracker::new(3, 3);
+        assert_eq!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Continue
+        );
+        assert!(matches!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Halt(message) if message.contains("3 iterations")
+        ));
+        assert_eq!(
+            tracker.record_output("different", false),
+            SuccessfulRepeat::Continue
+        );
+    }
+
+    #[test]
+    fn successful_call_batches_halt_but_failures_reset() {
+        let tracker = SuccessfulRepeatTracker::new(4, 2);
+        assert_eq!(
+            tracker.record_call_batch("tool:args", true, false),
+            SuccessfulRepeat::Continue
+        );
+        assert!(matches!(
+            tracker.record_call_batch("tool:args", true, false),
+            SuccessfulRepeat::Halt(message) if message.contains("2 times")
+        ));
+        assert_eq!(
+            tracker.record_call_batch("tool:args", false, false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_call_batch("tool:args", true, false),
+            SuccessfulRepeat::Continue
+        );
+    }
+
+    #[test]
+    fn exempt_batches_reset_both_streaks() {
+        let tracker = SuccessfulRepeatTracker::new(2, 2);
+        assert_eq!(
+            tracker.record_output("poll", false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_output("poll", true),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_output("poll", false),
+            SuccessfulRepeat::Continue
+        );
+
+        assert_eq!(
+            tracker.record_call_batch("poll", true, false),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_call_batch("poll", true, true),
+            SuccessfulRepeat::Continue
+        );
+        assert_eq!(
+            tracker.record_call_batch("poll", true, false),
+            SuccessfulRepeat::Continue
+        );
+    }
+
+    #[test]
+    fn zero_thresholds_are_fail_safe() {
+        let tracker = SuccessfulRepeatTracker::new(0, 0);
+        assert!(matches!(
+            tracker.record_output("same", false),
+            SuccessfulRepeat::Halt(_)
+        ));
+        assert!(matches!(
+            tracker.record_call_batch("same", true, false),
+            SuccessfulRepeat::Halt(_)
+        ));
+    }
+}

--- a/src/harness/no_progress/successful_repeat.rs
+++ b/src/harness/no_progress/successful_repeat.rs
@@ -8,28 +8,13 @@
 //! signatures and deciding which polling tools are exempt.
 
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
+
+use super::types::{Streak, SuccessfulRepeat, SuccessfulRepeatTracker};
 
 /// Consecutive identical assistant-output batches required to halt.
 pub const DEFAULT_REPEAT_OUTPUT_THRESHOLD: u32 = 4;
 /// Consecutive identical successful tool-call batches required to halt.
 pub const DEFAULT_REPEAT_CALL_THRESHOLD: u32 = 3;
-
-/// Verdict returned after recording a successful-repeat signal.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SuccessfulRepeat {
-    /// The signature changed, is exempt, failed, or remains below its threshold.
-    Continue,
-    /// The same successful action has repeated enough times to be considered
-    /// stuck. The message is suitable for steering or a halt summary.
-    Halt(String),
-}
-
-#[derive(Default)]
-struct Streak {
-    last_hash: Option<u64>,
-    consecutive: u32,
-}
 
 impl Streak {
     fn record(&mut self, signature: &str) -> u32 {
@@ -50,19 +35,6 @@ impl Streak {
     }
 }
 
-/// Tracks identical assistant-output and successful tool-call batches.
-///
-/// The two streaks are independent: output is observed before tools execute,
-/// while a call batch is recorded only after every result is known. Exempt
-/// polling batches reset their streak; a failed call batch also resets the
-/// successful-call streak so the failure ladder remains authoritative.
-pub struct SuccessfulRepeatTracker {
-    output_threshold: u32,
-    call_threshold: u32,
-    output: Mutex<Streak>,
-    calls: Mutex<Streak>,
-}
-
 impl Default for SuccessfulRepeatTracker {
     fn default() -> Self {
         Self::new(
@@ -80,8 +52,8 @@ impl SuccessfulRepeatTracker {
         Self {
             output_threshold: output_threshold.max(1),
             call_threshold: call_threshold.max(1),
-            output: Mutex::new(Streak::default()),
-            calls: Mutex::new(Streak::default()),
+            output: std::sync::Mutex::new(Streak::default()),
+            calls: std::sync::Mutex::new(Streak::default()),
         }
     }
 

--- a/src/harness/no_progress/test.rs
+++ b/src/harness/no_progress/test.rs
@@ -137,3 +137,107 @@ fn identical_halt_threshold_is_clamped_above_the_nudge() {
         NoProgress::Halt(_)
     ));
 }
+
+#[test]
+fn identical_output_halts_at_threshold_and_changes_reset() {
+    let tracker = SuccessfulRepeatTracker::new(3, 3);
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue
+    );
+    assert!(matches!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Halt(message) if message.contains("3 iterations")
+    ));
+    assert_eq!(
+        tracker.record_output("different", false),
+        SuccessfulRepeat::Continue
+    );
+}
+
+#[test]
+fn successful_call_batches_halt_but_failures_reset() {
+    let tracker = SuccessfulRepeatTracker::new(4, 2);
+    assert_eq!(
+        tracker.record_call_batch("tool:args", true, false),
+        SuccessfulRepeat::Continue
+    );
+    assert!(matches!(
+        tracker.record_call_batch("tool:args", true, false),
+        SuccessfulRepeat::Halt(message) if message.contains("2 times")
+    ));
+    assert_eq!(
+        tracker.record_call_batch("tool:args", false, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("tool:args", true, false),
+        SuccessfulRepeat::Continue
+    );
+}
+
+#[test]
+fn failed_call_batches_reset_output_repeats() {
+    let tracker = SuccessfulRepeatTracker::new(2, 2);
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("same-call", false, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue,
+        "a failed prior batch must not count toward a successful output loop"
+    );
+}
+
+#[test]
+fn exempt_batches_reset_both_streaks() {
+    let tracker = SuccessfulRepeatTracker::new(2, 2);
+    assert_eq!(
+        tracker.record_output("poll", false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("poll", true, true),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_output("poll", false),
+        SuccessfulRepeat::Continue,
+        "an exempt completed batch must clear its already-recorded output"
+    );
+
+    assert_eq!(
+        tracker.record_call_batch("poll", true, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("poll", true, true),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("poll", true, false),
+        SuccessfulRepeat::Continue
+    );
+}
+
+#[test]
+fn zero_thresholds_are_fail_safe() {
+    let tracker = SuccessfulRepeatTracker::new(0, 0);
+    assert!(matches!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Halt(_)
+    ));
+    assert!(matches!(
+        tracker.record_call_batch("same", true, false),
+        SuccessfulRepeat::Halt(_)
+    ));
+}

--- a/src/harness/no_progress/test.rs
+++ b/src/harness/no_progress/test.rs
@@ -140,17 +140,30 @@ fn identical_halt_threshold_is_clamped_above_the_nudge() {
 
 #[test]
 fn identical_output_halts_at_threshold_and_changes_reset() {
-    let tracker = SuccessfulRepeatTracker::new(3, 3);
+    let tracker = SuccessfulRepeatTracker::new(3, 10);
     assert_eq!(
         tracker.record_output("same", false),
         SuccessfulRepeat::Continue
     );
     assert_eq!(
+        tracker.record_call_batch("call-1", true, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
         tracker.record_output("same", false),
         SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_call_batch("call-2", true, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue,
+        "output cannot halt before its tool batch is classified"
     );
     assert!(matches!(
-        tracker.record_output("same", false),
+        tracker.record_call_batch("call-3", true, false),
         SuccessfulRepeat::Halt(message) if message.contains("3 iterations")
     ));
     assert_eq!(
@@ -188,7 +201,16 @@ fn failed_call_batches_reset_output_repeats() {
         SuccessfulRepeat::Continue
     );
     assert_eq!(
-        tracker.record_call_batch("same-call", false, false),
+        tracker.record_call_batch("first-call", true, false),
+        SuccessfulRepeat::Continue
+    );
+    assert_eq!(
+        tracker.record_output("same", false),
+        SuccessfulRepeat::Continue,
+        "a threshold crossing is pending until batch success is known"
+    );
+    assert_eq!(
+        tracker.record_call_batch("failed-call", false, false),
         SuccessfulRepeat::Continue
     );
     assert_eq!(
@@ -232,10 +254,10 @@ fn exempt_batches_reset_both_streaks() {
 #[test]
 fn zero_thresholds_are_fail_safe() {
     let tracker = SuccessfulRepeatTracker::new(0, 0);
-    assert!(matches!(
+    assert_eq!(
         tracker.record_output("same", false),
-        SuccessfulRepeat::Halt(_)
-    ));
+        SuccessfulRepeat::Continue
+    );
     assert!(matches!(
         tracker.record_call_batch("same", true, false),
         SuccessfulRepeat::Halt(_)

--- a/src/harness/no_progress/types.rs
+++ b/src/harness/no_progress/types.rs
@@ -63,3 +63,32 @@ pub struct NoProgressTracker {
     pub(super) identical_halt_threshold: usize,
     pub(super) state: Mutex<LadderState>,
 }
+
+/// Verdict returned after recording a successful-repeat signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SuccessfulRepeat {
+    /// The signature changed, is exempt, failed, or remains below its threshold.
+    Continue,
+    /// The same successful action has repeated enough times to be considered
+    /// stuck. The message is suitable for steering or a halt summary.
+    Halt(String),
+}
+
+#[derive(Default)]
+pub(super) struct Streak {
+    pub(super) last_hash: Option<u64>,
+    pub(super) consecutive: u32,
+}
+
+/// Tracks identical assistant-output and successful tool-call batches.
+///
+/// The two streaks are independent: output is observed before tools execute,
+/// while a call batch is recorded only after every result is known. Exempt
+/// polling batches reset their streak; a failed call batch also resets the
+/// successful-call streak so the failure ladder remains authoritative.
+pub struct SuccessfulRepeatTracker {
+    pub(super) output_threshold: u32,
+    pub(super) call_threshold: u32,
+    pub(super) output: Mutex<Streak>,
+    pub(super) calls: Mutex<Streak>,
+}

--- a/src/harness/no_progress/types.rs
+++ b/src/harness/no_progress/types.rs
@@ -82,10 +82,11 @@ pub(super) struct Streak {
 
 /// Tracks identical assistant-output and successful tool-call batches.
 ///
-/// The two streaks are independent: output is observed before tools execute,
-/// while a call batch is recorded only after every result is known. Exempt
-/// polling batches reset their streak; a failed call batch also resets the
-/// successful-call streak so the failure ladder remains authoritative.
+/// The two streaks are independent, but their verdict timing is coordinated:
+/// output is staged before tools execute and can halt only after the matching
+/// call batch is recorded as successful and non-exempt. Exempt polling batches
+/// and failed batches reset both streaks so the failure ladder remains
+/// authoritative.
 pub struct SuccessfulRepeatTracker {
     pub(super) output_threshold: u32,
     pub(super) call_threshold: u32,


### PR DESCRIPTION
## Summary

- add a reusable `SuccessfulRepeatTracker` beside the failure-oriented no-progress tracker
- independently track identical assistant-output batches and successful tool-call batches
- reset streaks for failed batches and caller-declared polling exemptions
- provide conservative defaults matching the proven OpenHuman breaker thresholds

The crate owns generic repeat accounting and messages; host middleware remains responsible for canonical signatures, polling-tool classification, and steering/halt presentation.

## Validation

- `cargo test successful_repeat --lib`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for repeated assistant outputs and successful tool-call batches.
  * Runs can now halt automatically when repeated activity indicates a stuck state.
  * Added configurable repetition thresholds with safe minimum values.
  * Exposed repetition tracking controls for integration with the harness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->