### PR TITLE
feat(harness): add policy-aware token trimming

### DIFF
--- a/src/harness/summarization/mod.rs
+++ b/src/harness/summarization/mod.rs
@@ -166,6 +166,76 @@ pub fn trim_messages(messages: &[Message], strategy: &TrimStrategy) -> Vec<Messa
     }
 }
 
+/// Trim messages to a token budget while preserving their original order.
+///
+/// `estimate` lets callers account for provider-specific payloads without
+/// teaching the harness about their wire representation. The built-in
+/// [`Message::estimated_char_weight`] already assigns a flat weight to native
+/// image blocks; hosts may additionally recognize inline image markers or use a
+/// real tokenizer. Oldest non-system messages are evicted first. System
+/// messages are either retained unconditionally or evicted oldest-first only
+/// after all other messages, according to [`TokenTrimPolicy::preserve_system`].
+///
+/// When `drop_leading_orphan_tools` is enabled, leading tool-result messages are
+/// removed after budget eviction so the retained transcript starts on a valid
+/// provider turn boundary. The returned messages always retain their original
+/// relative order.
+pub fn trim_messages_to_token_budget_with(
+    messages: &[Message],
+    policy: TokenTrimPolicy,
+    estimate: impl Fn(&Message) -> u64,
+) -> Vec<Message> {
+    let estimates: Vec<u64> = messages.iter().map(estimate).collect();
+    let mut total: u64 = estimates.iter().copied().sum();
+    if total <= policy.limit {
+        return messages.to_vec();
+    }
+
+    let mut retained = vec![true; messages.len()];
+    for (index, message) in messages.iter().enumerate() {
+        if total <= policy.limit {
+            break;
+        }
+        if !matches!(message, Message::System(_)) {
+            retained[index] = false;
+            total = total.saturating_sub(estimates[index]);
+        }
+    }
+
+    if !policy.preserve_system && total > policy.limit {
+        for (index, message) in messages.iter().enumerate() {
+            if total <= policy.limit {
+                break;
+            }
+            if matches!(message, Message::System(_)) && retained[index] {
+                retained[index] = false;
+                total = total.saturating_sub(estimates[index]);
+            }
+        }
+    }
+
+    let mut result: Vec<Message> = messages
+        .iter()
+        .zip(retained)
+        .filter(|(_, keep)| *keep)
+        .map(|(message, _)| message.clone())
+        .collect();
+
+    if policy.drop_leading_orphan_tools {
+        while let Some(index) = result
+            .iter()
+            .position(|message| !matches!(message, Message::System(_)))
+        {
+            if matches!(result[index], Message::Tool(_)) {
+                result.remove(index);
+            } else {
+                break;
+            }
+        }
+    }
+    result
+}
+
 // ---------------------------------------------------------------------------
 // ConcatSummarizer
 // ---------------------------------------------------------------------------

--- a/src/harness/summarization/mod.rs
+++ b/src/harness/summarization/mod.rs
@@ -187,7 +187,7 @@ pub fn trim_messages_to_token_budget_with(
 ) -> Vec<Message> {
     let estimates: Vec<u64> = messages.iter().map(estimate).collect();
     let mut total: u64 = estimates.iter().copied().sum();
-    if total <= policy.limit {
+    if total <= policy.limit && !policy.drop_leading_orphan_tools {
         return messages.to_vec();
     }
 

--- a/src/harness/summarization/test.rs
+++ b/src/harness/summarization/test.rs
@@ -153,6 +153,22 @@ mod smoke {
     }
 
     #[test]
+    fn token_budget_trim_drops_orphan_tool_results_when_under_budget() {
+        let messages = vec![
+            Message::system("policy"),
+            Message::tool("call-1", "orphan"),
+            Message::user("new"),
+        ];
+        let policy = TokenTrimPolicy::strict(100).drop_leading_orphan_tools();
+        let trimmed = trim_messages_to_token_budget_with(&messages, policy, |_| 1);
+
+        assert_eq!(
+            trimmed,
+            vec![Message::system("policy"), Message::user("new")]
+        );
+    }
+
+    #[test]
     fn trim_max_tokens_drops_oldest_non_system_first() {
         // Each user message ~ "aaaaaaaa" (8 chars) → 2 tokens. System "ssss" (4) → 1 token.
         let msgs = vec![

--- a/src/harness/summarization/test.rs
+++ b/src/harness/summarization/test.rs
@@ -10,8 +10,8 @@
 mod smoke {
     use crate::harness::message::Message;
     use crate::harness::summarization::{
-        ConcatSummarizer, SummarizationPolicy, Summarizer, TrimStrategy, estimate_tokens,
-        trim_messages,
+        ConcatSummarizer, SummarizationPolicy, Summarizer, TokenTrimPolicy, TrimStrategy,
+        estimate_tokens, trim_messages, trim_messages_to_token_budget_with,
     };
 
     /// Verify that `estimate_tokens` produces a non-zero value for a non-empty
@@ -109,6 +109,47 @@ mod smoke {
         let trimmed = trim_messages(&msgs, &TrimStrategy::KeepLast(5));
         assert_eq!(trimmed.len(), 1);
         assert_eq!(trimmed[0].text(), "only");
+    }
+
+    #[test]
+    fn token_budget_trim_preserves_order_and_system_messages() {
+        let messages = vec![
+            Message::user("old"),
+            Message::system("late-system"),
+            Message::assistant("new"),
+        ];
+        let policy = TokenTrimPolicy::strict(2).preserve_system();
+        let trimmed = trim_messages_to_token_budget_with(&messages, policy, |_| 2);
+
+        assert_eq!(trimmed, vec![Message::system("late-system")]);
+    }
+
+    #[test]
+    fn token_budget_trim_uses_caller_estimator() {
+        let messages = vec![Message::user("large-image"), Message::user("small")];
+        let policy = TokenTrimPolicy::strict(2);
+        let trimmed = trim_messages_to_token_budget_with(&messages, policy, |message| {
+            if message.text() == "large-image" {
+                10
+            } else {
+                2
+            }
+        });
+
+        assert_eq!(trimmed, vec![Message::user("small")]);
+    }
+
+    #[test]
+    fn token_budget_trim_drops_leading_orphan_tool_results() {
+        let messages = vec![
+            Message::assistant("old"),
+            Message::tool("call-1", "result"),
+            Message::user("new"),
+        ];
+        let policy = TokenTrimPolicy::strict(2).drop_leading_orphan_tools();
+        let trimmed = trim_messages_to_token_budget_with(&messages, policy, |_| 1);
+
+        assert_eq!(trimmed, vec![Message::user("new")]);
     }
 
     #[test]

--- a/src/harness/summarization/types.rs
+++ b/src/harness/summarization/types.rs
@@ -58,6 +58,45 @@ pub enum TrimStrategy {
     MaxTokens(u64),
 }
 
+/// Options for order-preserving token-budget trimming with a caller-supplied
+/// message estimator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TokenTrimPolicy {
+    /// Maximum estimated tokens retained after trimming.
+    pub limit: u64,
+    /// Never evict system messages, even when they alone exceed `limit`.
+    pub preserve_system: bool,
+    /// After eviction, discard leading tool results that no longer have their
+    /// preceding assistant tool call. System messages may precede the first
+    /// retained conversational message.
+    pub drop_leading_orphan_tools: bool,
+}
+
+impl TokenTrimPolicy {
+    /// Creates a strict token-budget policy. System messages may be dropped as
+    /// a last resort and no structural cleanup is applied.
+    pub const fn strict(limit: u64) -> Self {
+        Self {
+            limit,
+            preserve_system: false,
+            drop_leading_orphan_tools: false,
+        }
+    }
+
+    /// Keeps system instructions even when they exceed the configured budget.
+    pub const fn preserve_system(mut self) -> Self {
+        self.preserve_system = true;
+        self
+    }
+
+    /// Drops tool results left at the leading conversational boundary after
+    /// their assistant tool-call message was evicted.
+    pub const fn drop_leading_orphan_tools(mut self) -> Self {
+        self.drop_leading_orphan_tools = true;
+        self
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Compression provenance
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add an order-preserving token-budget trim primitive with a caller-supplied estimator
- optionally preserve system instructions even when they exceed the nominal budget
- optionally drop leading orphan tool results after older assistant calls are evicted
- retain the existing `TrimStrategy::MaxTokens` behavior for compatibility

TinyAgents already assigns native images a flat context weight. The estimator hook lets hosts extend that accounting to provider-specific inline image encodings without baking those encodings into the crate.

## Validation

- `cargo test token_budget_trim --lib`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`