### PR TITLE
feat(orchestration): manage detached task runtimes

### DIFF
--- a/docs/modules/graph/subagents-recursion.md
+++ b/docs/modules/graph/subagents-recursion.md
@@ -112,6 +112,21 @@ Every steering event must include root run id, parent run id, child run id when
 available, task id when graph-backed, namespace, actor, command kind, policy id,
 correlation id, and checkpoint id when available.
 
+## Detached Task Runtime Registry
+
+`DetachedTaskRegistry<Metadata, Status>` complements the durable `TaskStore`
+with process-local executor handles. Applications register a task's owner,
+metadata, status watch receiver, cancellation token, and abort handle, while
+the task's live `SteeringHandle` remains addressable through the shared
+`SteeringRegistry`.
+
+The registry enforces owner checks for wait and steering, keeps timed-out waits
+registered, prunes terminal waits, cancels cooperatively before hard-aborting,
+and sweeps terminal entries when its soft cap is reached. It never evicts live
+work to satisfy the cap and does not duplicate durable lifecycle records.
+After a restart, applications reconcile live `TaskStore` records that have no
+matching runtime entry according to their executor policy.
+
 ## Listing Orchestration Tasks {#orchestrate-list}
 
 The model-facing `orchestrate_list` tool enumerates managed tasks visible to the

--- a/docs/sdk-gaps.md
+++ b/docs/sdk-gaps.md
@@ -340,6 +340,10 @@ TinyAgents has sub-agent and steering primitives, but OpenHuman still owns
 session reuse, wait handles, detached run tracking, user-facing cancellation,
 early-exit handling, and parent-child progress aggregation.
 
+The generic `DetachedTaskRegistry` now owns process-local owner checks,
+wait/timeout, cooperative-cancel-before-abort, steering lookup, and bounded
+terminal cleanup. Reusable durable child sessions and product projections remain.
+
 Implement:
 
 - First-class detached sub-agent sessions.
@@ -467,4 +471,3 @@ Acceptance criteria:
 7. Remove OpenHuman-specific compatibility shims once the SDK behavior is
    equivalent.
 8. Implement conformance and regression tests last.
-

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -75,12 +75,13 @@ pub use observability::{
     StoreGraphEventJournal,
 };
 pub use orchestration::{
-    DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot, DetachedTaskWaitOutcome,
-    InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome, OrchestrationTaskFilter,
-    OrchestrationTaskKind, OrchestrationTaskRecord, OrchestrationTaskResult, OrchestrationTaskSpec,
-    OrchestrationTaskStatus, OrchestrationTool, OrchestrationToolKind, SteeringRegistry, TaskStore,
-    orchestration_tool_schema, orchestration_tool_schemas, orchestration_tools,
-    orchestration_tools_with_steering, register_orchestration_tools,
+    CancelledDetachedTask, DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot,
+    DetachedTaskWaitOutcome, InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome,
+    OrchestrationTaskFilter, OrchestrationTaskKind, OrchestrationTaskRecord,
+    OrchestrationTaskResult, OrchestrationTaskSpec, OrchestrationTaskStatus, OrchestrationTool,
+    OrchestrationToolKind, SteeringRegistry, TaskStore, orchestration_tool_schema,
+    orchestration_tool_schemas, orchestration_tools, orchestration_tools_with_steering,
+    register_orchestration_tools,
 };
 pub use recursion::{
     ChildRun, ChildRunSink, RecursionFrame, RecursionPolicy, RecursionStack, RunTree,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -75,6 +75,7 @@ pub use observability::{
     StoreGraphEventJournal,
 };
 pub use orchestration::{
+    DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot, DetachedTaskWaitOutcome,
     InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome, OrchestrationTaskFilter,
     OrchestrationTaskKind, OrchestrationTaskRecord, OrchestrationTaskResult, OrchestrationTaskSpec,
     OrchestrationTaskStatus, OrchestrationTool, OrchestrationToolKind, SteeringRegistry, TaskStore,

--- a/src/graph/orchestration/mod.rs
+++ b/src/graph/orchestration/mod.rs
@@ -10,10 +10,12 @@
 //! [`register_orchestration_tools`] to insert them into a
 //! [`crate::harness::tool::ToolRegistry`] alongside any other tools.
 
+mod runtime;
 mod store;
 mod tool;
 mod types;
 
+pub use runtime::DetachedTaskRegistry;
 pub use store::{InMemoryTaskStore, JsonlTaskStore, TaskStore};
 pub use tool::{
     OrchestrationTool, SteeringRegistry, orchestration_tool_schema, orchestration_tool_schemas,

--- a/src/graph/orchestration/runtime.rs
+++ b/src/graph/orchestration/runtime.rs
@@ -133,6 +133,42 @@ where
         snapshots
     }
 
+    /// Snapshots one task after enforcing ownership.
+    pub fn snapshot(
+        &self,
+        task_id: &TaskId,
+        owner_id: &str,
+    ) -> std::result::Result<DetachedTaskSnapshot<Metadata, Status>, DetachedTaskRegistryError>
+    {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let entry = guard
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::Unknown)?;
+        if entry.owner_id != owner_id {
+            return Err(DetachedTaskRegistryError::NotOwned);
+        }
+        Ok(Self::snapshot_entry(task_id, entry))
+    }
+
+    /// Trusted-control variant of [`Self::snapshot`] without an owner check.
+    pub fn snapshot_trusted(
+        &self,
+        task_id: &TaskId,
+    ) -> std::result::Result<DetachedTaskSnapshot<Metadata, Status>, DetachedTaskRegistryError>
+    {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let entry = guard
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::Unknown)?;
+        Ok(Self::snapshot_entry(task_id, entry))
+    }
+
     /// Returns a live steering handle after enforcing ownership and terminal
     /// status. The handle is looked up in the supplied [`SteeringRegistry`], so
     /// executors may register it independently when their run starts.
@@ -205,7 +241,10 @@ where
                 self.remove(task_id);
                 Ok(DetachedTaskWaitOutcome::Terminal(terminal))
             }
-            Ok(Err(error)) => Err(error),
+            Ok(Err(error)) => {
+                self.remove(task_id);
+                Err(error)
+            }
             Err(_) => Ok(DetachedTaskWaitOutcome::TimedOut(status.borrow().clone())),
         }
     }
@@ -351,6 +390,18 @@ where
             guard.remove(task_id);
         }
         self.steering.deregister(task_id);
+    }
+
+    fn snapshot_entry(
+        task_id: &TaskId,
+        entry: &DetachedTaskEntry<Metadata, Status>,
+    ) -> DetachedTaskSnapshot<Metadata, Status> {
+        DetachedTaskSnapshot {
+            task_id: task_id.clone(),
+            owner_id: entry.owner_id.clone(),
+            metadata: entry.metadata.clone(),
+            status: entry.status.borrow().clone(),
+        }
     }
 
     fn lock(

--- a/src/graph/orchestration/runtime.rs
+++ b/src/graph/orchestration/runtime.rs
@@ -6,7 +6,7 @@
 //! hard-abort handles, ownership checks, and live steering lookup.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use tokio::sync::watch;
@@ -28,6 +28,9 @@ struct DetachedTaskEntry<Metadata, Status> {
     cancellation: CancellationToken,
     abort: AbortHandle,
 }
+
+type RegistryGuard<'a, Metadata, Status> =
+    MutexGuard<'a, HashMap<TaskId, DetachedTaskEntry<Metadata, Status>>>;
 
 /// Ownership-aware registry for live detached task executors.
 ///
@@ -82,10 +85,10 @@ where
         cancellation: CancellationToken,
         abort: AbortHandle,
     ) -> Result<()> {
-        if self.len() >= self.soft_cap {
-            self.sweep_terminal();
+        if self.len().map_err(Self::tinyagents_error)? >= self.soft_cap {
+            self.sweep_terminal().map_err(Self::tinyagents_error)?;
         }
-        let mut guard = self.lock()?;
+        let mut guard = self.lock().map_err(Self::tinyagents_error)?;
         if guard.contains_key(&task_id) {
             return Err(TinyAgentsError::DuplicateComponent(format!(
                 "detached task runtime `{task_id}`"
@@ -105,20 +108,22 @@ where
     }
 
     /// Number of process-local task runtimes currently registered.
-    pub fn len(&self) -> usize {
-        self.inner.lock().map(|guard| guard.len()).unwrap_or(0)
+    pub fn len(&self) -> std::result::Result<usize, DetachedTaskRegistryError> {
+        Ok(self.lock()?.len())
     }
 
     /// Whether no process-local task runtimes are registered.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn is_empty(&self) -> std::result::Result<bool, DetachedTaskRegistryError> {
+        Ok(self.len()? == 0)
     }
 
     /// Snapshots every registered task, optionally filtering by owner.
-    pub fn snapshots(&self, owner_id: Option<&str>) -> Vec<DetachedTaskSnapshot<Metadata, Status>> {
-        let Ok(guard) = self.inner.lock() else {
-            return Vec::new();
-        };
+    pub fn snapshots(
+        &self,
+        owner_id: Option<&str>,
+    ) -> std::result::Result<Vec<DetachedTaskSnapshot<Metadata, Status>>, DetachedTaskRegistryError>
+    {
+        let guard = self.lock()?;
         let mut snapshots: Vec<_> = guard
             .iter()
             .filter(|(_, entry)| owner_id.is_none_or(|owner| entry.owner_id == owner))
@@ -130,7 +135,7 @@ where
             })
             .collect();
         snapshots.sort_by(|left, right| left.task_id.as_str().cmp(right.task_id.as_str()));
-        snapshots
+        Ok(snapshots)
     }
 
     /// Snapshots one task after enforcing ownership.
@@ -140,10 +145,7 @@ where
         owner_id: &str,
     ) -> std::result::Result<DetachedTaskSnapshot<Metadata, Status>, DetachedTaskRegistryError>
     {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let guard = self.lock()?;
         let entry = guard
             .get(task_id)
             .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -159,10 +161,7 @@ where
         task_id: &TaskId,
     ) -> std::result::Result<DetachedTaskSnapshot<Metadata, Status>, DetachedTaskRegistryError>
     {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let guard = self.lock()?;
         let entry = guard
             .get(task_id)
             .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -204,10 +203,7 @@ where
         timeout: Duration,
     ) -> std::result::Result<DetachedTaskWaitOutcome<Status>, DetachedTaskRegistryError> {
         let mut status = {
-            let guard = self
-                .inner
-                .lock()
-                .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+            let guard = self.lock()?;
             let entry = guard
                 .get(task_id)
                 .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -219,7 +215,7 @@ where
 
         let current = status.borrow_and_update().clone();
         if (self.is_terminal)(&current) {
-            self.remove(task_id);
+            self.remove(task_id)?;
             return Ok(DetachedTaskWaitOutcome::Terminal(current));
         }
 
@@ -238,11 +234,11 @@ where
 
         match tokio::time::timeout(timeout, waited).await {
             Ok(Ok(terminal)) => {
-                self.remove(task_id);
+                self.remove(task_id)?;
                 Ok(DetachedTaskWaitOutcome::Terminal(terminal))
             }
             Ok(Err(error)) => {
-                self.remove(task_id);
+                self.remove(task_id)?;
                 Err(error)
             }
             Err(_) => Ok(DetachedTaskWaitOutcome::TimedOut(status.borrow().clone())),
@@ -273,35 +269,32 @@ where
     pub fn cancel_where(
         &self,
         predicate: impl Fn(&Metadata) -> bool,
-    ) -> Vec<CancelledDetachedTask<Metadata, Status>> {
+    ) -> std::result::Result<Vec<CancelledDetachedTask<Metadata, Status>>, DetachedTaskRegistryError>
+    {
         let task_ids: Vec<TaskId> = self
-            .inner
-            .lock()
-            .map(|guard| {
-                guard
-                    .iter()
-                    .filter(|(_, entry)| predicate(&entry.metadata))
-                    .map(|(task_id, _)| task_id.clone())
-                    .collect()
-            })
-            .unwrap_or_default();
-        task_ids
+            .lock()?
+            .iter()
+            .filter(|(_, entry)| predicate(&entry.metadata))
+            .map(|(task_id, _)| task_id.clone())
+            .collect();
+        Ok(task_ids
             .into_iter()
             .filter_map(|task_id| self.cancel_trusted(&task_id).ok())
-            .collect()
+            .collect())
     }
 
     /// Cancels and removes every registered detached task.
-    pub fn cancel_all(&self) -> Vec<CancelledDetachedTask<Metadata, Status>> {
+    pub fn cancel_all(
+        &self,
+    ) -> std::result::Result<Vec<CancelledDetachedTask<Metadata, Status>>, DetachedTaskRegistryError>
+    {
         self.cancel_where(|_| true)
     }
 
     /// Prunes every entry whose latest watched status is terminal.
-    pub fn sweep_terminal(&self) -> usize {
+    pub fn sweep_terminal(&self) -> std::result::Result<usize, DetachedTaskRegistryError> {
         let removed = {
-            let Ok(mut guard) = self.inner.lock() else {
-                return 0;
-            };
+            let mut guard = self.lock()?;
             let task_ids: Vec<_> = guard
                 .iter()
                 .filter(|(_, entry)| (self.is_terminal)(&entry.status.borrow()))
@@ -315,7 +308,7 @@ where
         for task_id in &removed {
             self.steering.deregister(task_id);
         }
-        removed.len()
+        Ok(removed.len())
     }
 
     fn ensure_live_owned(
@@ -323,10 +316,7 @@ where
         task_id: &TaskId,
         owner_id: &str,
     ) -> std::result::Result<(), DetachedTaskRegistryError> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let guard = self.lock()?;
         let entry = guard
             .get(task_id)
             .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -340,10 +330,7 @@ where
     }
 
     fn ensure_live(&self, task_id: &TaskId) -> std::result::Result<(), DetachedTaskRegistryError> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let guard = self.lock()?;
         let entry = guard
             .get(task_id)
             .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -360,10 +347,7 @@ where
     ) -> std::result::Result<CancelledDetachedTask<Metadata, Status>, DetachedTaskRegistryError>
     {
         let entry = {
-            let mut guard = self
-                .inner
-                .lock()
-                .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+            let mut guard = self.lock()?;
             let entry = guard
                 .get(task_id)
                 .ok_or(DetachedTaskRegistryError::Unknown)?;
@@ -385,11 +369,10 @@ where
         })
     }
 
-    fn remove(&self, task_id: &TaskId) {
-        if let Ok(mut guard) = self.inner.lock() {
-            guard.remove(task_id);
-        }
+    fn remove(&self, task_id: &TaskId) -> std::result::Result<(), DetachedTaskRegistryError> {
+        self.lock()?.remove(task_id);
         self.steering.deregister(task_id);
+        Ok(())
     }
 
     fn snapshot_entry(
@@ -406,10 +389,13 @@ where
 
     fn lock(
         &self,
-    ) -> Result<std::sync::MutexGuard<'_, HashMap<TaskId, DetachedTaskEntry<Metadata, Status>>>>
-    {
-        self.inner.lock().map_err(|_| {
-            TinyAgentsError::Graph("detached task runtime registry lock poisoned".into())
-        })
+    ) -> std::result::Result<RegistryGuard<'_, Metadata, Status>, DetachedTaskRegistryError> {
+        self.inner
+            .lock()
+            .map_err(|_| DetachedTaskRegistryError::LockPoisoned)
+    }
+
+    fn tinyagents_error(error: DetachedTaskRegistryError) -> TinyAgentsError {
+        TinyAgentsError::Graph(error.to_string())
     }
 }

--- a/src/graph/orchestration/runtime.rs
+++ b/src/graph/orchestration/runtime.rs
@@ -1,0 +1,364 @@
+//! Process-local runtime handles for detached orchestration tasks.
+//!
+//! [`TaskStore`](super::TaskStore) remains the durable source of lifecycle
+//! truth. This registry owns the executor-only pieces that cannot survive a
+//! process restart: status watch channels, cooperative cancellation tokens,
+//! hard-abort handles, ownership checks, and live steering lookup.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio::task::AbortHandle;
+
+use crate::harness::ids::TaskId;
+use crate::harness::steering::SteeringHandle;
+use crate::{CancellationToken, Result, TinyAgentsError};
+
+use super::{
+    CancelledDetachedTask, DetachedTaskRegistryError, DetachedTaskSnapshot,
+    DetachedTaskWaitOutcome, SteeringRegistry,
+};
+
+struct DetachedTaskEntry<Metadata, Status> {
+    owner_id: String,
+    metadata: Metadata,
+    status: watch::Receiver<Status>,
+    cancellation: CancellationToken,
+    abort: AbortHandle,
+}
+
+/// Ownership-aware registry for live detached task executors.
+///
+/// The registry is generic over application metadata and status payloads. A
+/// caller supplies the terminal-status predicate once, then registers the
+/// runtime handles created by its executor. Every removal deregisters the
+/// corresponding [`SteeringHandle`] from the shared [`SteeringRegistry`].
+///
+/// This type intentionally does not duplicate durable state. Applications
+/// should insert and transition the matching task in a [`TaskStore`](super::TaskStore)
+/// as statuses are published. On restart, any non-terminal store record without
+/// a runtime entry is an orphan for the application to reconcile.
+#[derive(Clone)]
+pub struct DetachedTaskRegistry<Metadata, Status> {
+    inner: Arc<Mutex<HashMap<TaskId, DetachedTaskEntry<Metadata, Status>>>>,
+    steering: SteeringRegistry,
+    is_terminal: Arc<dyn Fn(&Status) -> bool + Send + Sync>,
+    soft_cap: usize,
+}
+
+impl<Metadata, Status> DetachedTaskRegistry<Metadata, Status>
+where
+    Metadata: Clone + Send + Sync + 'static,
+    Status: Clone + Send + Sync + 'static,
+{
+    /// Creates a registry using `is_terminal` to decide when a task can be
+    /// pruned. `soft_cap` triggers a terminal-entry sweep during registration;
+    /// live entries are never evicted merely to satisfy the cap.
+    pub fn new(
+        steering: SteeringRegistry,
+        soft_cap: usize,
+        is_terminal: impl Fn(&Status) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner: Arc::default(),
+            steering,
+            is_terminal: Arc::new(is_terminal),
+            soft_cap: soft_cap.max(1),
+        }
+    }
+
+    /// Registers the executor handles for a detached task.
+    ///
+    /// Duplicate live ids are rejected. Before insertion, a registry at its
+    /// soft cap prunes entries whose latest watched status is terminal.
+    pub fn register(
+        &self,
+        task_id: TaskId,
+        owner_id: impl Into<String>,
+        metadata: Metadata,
+        status: watch::Receiver<Status>,
+        cancellation: CancellationToken,
+        abort: AbortHandle,
+    ) -> Result<()> {
+        if self.len() >= self.soft_cap {
+            self.sweep_terminal();
+        }
+        let mut guard = self.lock()?;
+        if guard.contains_key(&task_id) {
+            return Err(TinyAgentsError::DuplicateComponent(format!(
+                "detached task runtime `{task_id}`"
+            )));
+        }
+        guard.insert(
+            task_id,
+            DetachedTaskEntry {
+                owner_id: owner_id.into(),
+                metadata,
+                status,
+                cancellation,
+                abort,
+            },
+        );
+        Ok(())
+    }
+
+    /// Number of process-local task runtimes currently registered.
+    pub fn len(&self) -> usize {
+        self.inner.lock().map(|guard| guard.len()).unwrap_or(0)
+    }
+
+    /// Whether no process-local task runtimes are registered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Snapshots every registered task, optionally filtering by owner.
+    pub fn snapshots(&self, owner_id: Option<&str>) -> Vec<DetachedTaskSnapshot<Metadata, Status>> {
+        let Ok(guard) = self.inner.lock() else {
+            return Vec::new();
+        };
+        let mut snapshots: Vec<_> = guard
+            .iter()
+            .filter(|(_, entry)| owner_id.is_none_or(|owner| entry.owner_id == owner))
+            .map(|(task_id, entry)| DetachedTaskSnapshot {
+                task_id: task_id.clone(),
+                owner_id: entry.owner_id.clone(),
+                metadata: entry.metadata.clone(),
+                status: entry.status.borrow().clone(),
+            })
+            .collect();
+        snapshots.sort_by(|left, right| left.task_id.as_str().cmp(right.task_id.as_str()));
+        snapshots
+    }
+
+    /// Returns a live steering handle after enforcing ownership and terminal
+    /// status. The handle is looked up in the supplied [`SteeringRegistry`], so
+    /// executors may register it independently when their run starts.
+    pub fn steering_handle(
+        &self,
+        task_id: &TaskId,
+        owner_id: &str,
+    ) -> std::result::Result<SteeringHandle, DetachedTaskRegistryError> {
+        self.ensure_live_owned(task_id, owner_id)?;
+        self.steering
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::NoSteeringHandle)
+    }
+
+    /// Trusted-control variant of [`Self::steering_handle`] that does not
+    /// require an owner id. It still rejects unknown and terminal tasks.
+    pub fn steering_handle_trusted(
+        &self,
+        task_id: &TaskId,
+    ) -> std::result::Result<SteeringHandle, DetachedTaskRegistryError> {
+        self.ensure_live(task_id)?;
+        self.steering
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::NoSteeringHandle)
+    }
+
+    /// Waits for a terminal status or `timeout`. A terminal result prunes the
+    /// process-local runtime; a timeout leaves it available for another wait.
+    pub async fn wait(
+        &self,
+        task_id: &TaskId,
+        owner_id: &str,
+        timeout: Duration,
+    ) -> std::result::Result<DetachedTaskWaitOutcome<Status>, DetachedTaskRegistryError> {
+        let mut status = {
+            let guard = self
+                .inner
+                .lock()
+                .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+            let entry = guard
+                .get(task_id)
+                .ok_or(DetachedTaskRegistryError::Unknown)?;
+            if entry.owner_id != owner_id {
+                return Err(DetachedTaskRegistryError::NotOwned);
+            }
+            entry.status.clone()
+        };
+
+        let current = status.borrow_and_update().clone();
+        if (self.is_terminal)(&current) {
+            self.remove(task_id);
+            return Ok(DetachedTaskWaitOutcome::Terminal(current));
+        }
+
+        let waited = async {
+            loop {
+                status
+                    .changed()
+                    .await
+                    .map_err(|_| DetachedTaskRegistryError::StatusChannelClosed)?;
+                let current = status.borrow().clone();
+                if (self.is_terminal)(&current) {
+                    return Ok(current);
+                }
+            }
+        };
+
+        match tokio::time::timeout(timeout, waited).await {
+            Ok(Ok(terminal)) => {
+                self.remove(task_id);
+                Ok(DetachedTaskWaitOutcome::Terminal(terminal))
+            }
+            Ok(Err(error)) => Err(error),
+            Err(_) => Ok(DetachedTaskWaitOutcome::TimedOut(status.borrow().clone())),
+        }
+    }
+
+    /// Cancels and removes an owned task, returning its application metadata.
+    pub fn cancel(
+        &self,
+        task_id: &TaskId,
+        owner_id: &str,
+    ) -> std::result::Result<CancelledDetachedTask<Metadata, Status>, DetachedTaskRegistryError>
+    {
+        self.take_and_cancel(task_id, Some(owner_id))
+    }
+
+    /// Trusted-control variant of [`Self::cancel`] that does not require an
+    /// owner id.
+    pub fn cancel_trusted(
+        &self,
+        task_id: &TaskId,
+    ) -> std::result::Result<CancelledDetachedTask<Metadata, Status>, DetachedTaskRegistryError>
+    {
+        self.take_and_cancel(task_id, None)
+    }
+
+    /// Cancels every task whose metadata matches `predicate`.
+    pub fn cancel_where(
+        &self,
+        predicate: impl Fn(&Metadata) -> bool,
+    ) -> Vec<CancelledDetachedTask<Metadata, Status>> {
+        let task_ids: Vec<TaskId> = self
+            .inner
+            .lock()
+            .map(|guard| {
+                guard
+                    .iter()
+                    .filter(|(_, entry)| predicate(&entry.metadata))
+                    .map(|(task_id, _)| task_id.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        task_ids
+            .into_iter()
+            .filter_map(|task_id| self.cancel_trusted(&task_id).ok())
+            .collect()
+    }
+
+    /// Cancels and removes every registered detached task.
+    pub fn cancel_all(&self) -> Vec<CancelledDetachedTask<Metadata, Status>> {
+        self.cancel_where(|_| true)
+    }
+
+    /// Prunes every entry whose latest watched status is terminal.
+    pub fn sweep_terminal(&self) -> usize {
+        let removed = {
+            let Ok(mut guard) = self.inner.lock() else {
+                return 0;
+            };
+            let task_ids: Vec<_> = guard
+                .iter()
+                .filter(|(_, entry)| (self.is_terminal)(&entry.status.borrow()))
+                .map(|(task_id, _)| task_id.clone())
+                .collect();
+            for task_id in &task_ids {
+                guard.remove(task_id);
+            }
+            task_ids
+        };
+        for task_id in &removed {
+            self.steering.deregister(task_id);
+        }
+        removed.len()
+    }
+
+    fn ensure_live_owned(
+        &self,
+        task_id: &TaskId,
+        owner_id: &str,
+    ) -> std::result::Result<(), DetachedTaskRegistryError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let entry = guard
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::Unknown)?;
+        if entry.owner_id != owner_id {
+            return Err(DetachedTaskRegistryError::NotOwned);
+        }
+        if (self.is_terminal)(&entry.status.borrow()) {
+            return Err(DetachedTaskRegistryError::AlreadyDone);
+        }
+        Ok(())
+    }
+
+    fn ensure_live(&self, task_id: &TaskId) -> std::result::Result<(), DetachedTaskRegistryError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+        let entry = guard
+            .get(task_id)
+            .ok_or(DetachedTaskRegistryError::Unknown)?;
+        if (self.is_terminal)(&entry.status.borrow()) {
+            return Err(DetachedTaskRegistryError::AlreadyDone);
+        }
+        Ok(())
+    }
+
+    fn take_and_cancel(
+        &self,
+        task_id: &TaskId,
+        owner_id: Option<&str>,
+    ) -> std::result::Result<CancelledDetachedTask<Metadata, Status>, DetachedTaskRegistryError>
+    {
+        let entry = {
+            let mut guard = self
+                .inner
+                .lock()
+                .map_err(|_| DetachedTaskRegistryError::Unknown)?;
+            let entry = guard
+                .get(task_id)
+                .ok_or(DetachedTaskRegistryError::Unknown)?;
+            if owner_id.is_some_and(|owner| entry.owner_id != owner) {
+                return Err(DetachedTaskRegistryError::NotOwned);
+            }
+            guard
+                .remove(task_id)
+                .ok_or(DetachedTaskRegistryError::Unknown)?
+        };
+        self.steering.deregister(task_id);
+        entry.cancellation.cancel();
+        entry.abort.abort();
+        Ok(CancelledDetachedTask {
+            task_id: task_id.clone(),
+            owner_id: entry.owner_id,
+            metadata: entry.metadata,
+            status: entry.status.borrow().clone(),
+        })
+    }
+
+    fn remove(&self, task_id: &TaskId) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.remove(task_id);
+        }
+        self.steering.deregister(task_id);
+    }
+
+    fn lock(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<TaskId, DetachedTaskEntry<Metadata, Status>>>>
+    {
+        self.inner.lock().map_err(|_| {
+            TinyAgentsError::Graph("detached task runtime registry lock poisoned".into())
+        })
+    }
+}

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -78,6 +78,15 @@ async fn detached_registry_enforces_owner_and_waits_for_terminal_status() {
         .unwrap();
 
     assert_eq!(
+        registry.snapshot(&task_id, "parent-b").unwrap_err(),
+        DetachedTaskRegistryError::NotOwned
+    );
+    assert_eq!(
+        registry.snapshot(&task_id, "parent-a").unwrap().metadata,
+        "researcher"
+    );
+
+    assert_eq!(
         registry
             .wait(&task_id, "parent-b", std::time::Duration::from_millis(1))
             .await,

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -100,7 +100,7 @@ async fn detached_registry_enforces_owner_and_waits_for_terminal_status() {
             .unwrap(),
         DetachedTaskWaitOutcome::Terminal(RuntimeStatus::Completed("done".into()))
     );
-    assert!(registry.is_empty());
+    assert!(registry.is_empty().unwrap());
     join.abort();
 }
 
@@ -127,7 +127,7 @@ async fn detached_registry_timeout_keeps_task_registered() {
             .unwrap(),
         DetachedTaskWaitOutcome::TimedOut(RuntimeStatus::Running)
     );
-    assert_eq!(registry.len(), 1);
+    assert_eq!(registry.len().unwrap(), 1);
     join.abort();
 }
 
@@ -151,7 +151,7 @@ async fn detached_registry_cancel_is_cooperative_then_aborts_and_returns_metadat
     assert_eq!(cancelled.metadata, "worker-meta");
     assert!(cancellation.is_cancelled());
     assert!(join.await.unwrap_err().is_cancelled());
-    assert!(registry.is_empty());
+    assert!(registry.is_empty().unwrap());
 }
 
 #[tokio::test]
@@ -192,11 +192,50 @@ async fn detached_registry_uses_shared_steering_and_sweeps_terminal_at_soft_cap(
         )
         .unwrap();
 
-    assert_eq!(registry.len(), 1);
+    assert_eq!(registry.len().unwrap(), 1);
     assert!(steering.get(&first).is_none());
-    assert_eq!(registry.snapshots(Some("parent"))[0].task_id, second);
+    assert_eq!(
+        registry.snapshots(Some("parent")).unwrap()[0].task_id,
+        second
+    );
     first_join.abort();
     second_join.abort();
+}
+
+#[derive(Debug)]
+struct PanickingMetadata;
+
+impl Clone for PanickingMetadata {
+    fn clone(&self) -> Self {
+        panic!("poison registry lock during metadata clone")
+    }
+}
+
+#[tokio::test]
+async fn detached_registry_reports_a_poisoned_lock() {
+    let registry =
+        DetachedTaskRegistry::new(SteeringRegistry::new(), 2, |status: &RuntimeStatus| {
+            matches!(status, RuntimeStatus::Completed(_))
+        });
+    let task_id = TaskId::new("detached-poison");
+    let (_tx, rx, cancellation, join) = detached_handles();
+    registry
+        .register(
+            task_id,
+            "parent",
+            PanickingMetadata,
+            rx,
+            cancellation,
+            join.abort_handle(),
+        )
+        .unwrap();
+
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = registry.snapshots(None);
+    }));
+    assert!(panic.is_err());
+    assert_eq!(registry.len(), Err(DetachedTaskRegistryError::LockPoisoned));
+    join.abort();
 }
 
 fn unique_log_path(tag: &str) -> std::path::PathBuf {

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use serde_json::json;
 
 use super::*;
+use crate::CancellationToken;
 use crate::harness::ids::TaskId;
+use crate::harness::steering::SteeringHandle;
 use crate::harness::tool::{Tool, ToolCall, ToolRegistry};
 
 fn graph_spec(id: &str) -> OrchestrationTaskSpec {
@@ -33,6 +35,159 @@ fn in_memory_store_tracks_task_lifecycle() {
     assert_eq!(completed.status, OrchestrationTaskStatus::Completed);
     assert!(completed.ended_at.is_some());
     assert!(completed.is_terminal());
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RuntimeStatus {
+    Running,
+    Completed(String),
+}
+
+fn runtime_registry() -> DetachedTaskRegistry<String, RuntimeStatus> {
+    DetachedTaskRegistry::new(SteeringRegistry::new(), 2, |status| {
+        matches!(status, RuntimeStatus::Completed(_))
+    })
+}
+
+fn detached_handles() -> (
+    tokio::sync::watch::Sender<RuntimeStatus>,
+    tokio::sync::watch::Receiver<RuntimeStatus>,
+    CancellationToken,
+    tokio::task::JoinHandle<()>,
+) {
+    let (tx, rx) = tokio::sync::watch::channel(RuntimeStatus::Running);
+    let cancellation = CancellationToken::new();
+    let join = tokio::spawn(std::future::pending());
+    (tx, rx, cancellation, join)
+}
+
+#[tokio::test]
+async fn detached_registry_enforces_owner_and_waits_for_terminal_status() {
+    let registry = runtime_registry();
+    let task_id = TaskId::new("detached-wait");
+    let (tx, rx, cancellation, join) = detached_handles();
+    registry
+        .register(
+            task_id.clone(),
+            "parent-a",
+            "researcher".to_string(),
+            rx,
+            cancellation,
+            join.abort_handle(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        registry
+            .wait(&task_id, "parent-b", std::time::Duration::from_millis(1))
+            .await,
+        Err(DetachedTaskRegistryError::NotOwned)
+    );
+    tx.send(RuntimeStatus::Completed("done".into())).unwrap();
+    assert_eq!(
+        registry
+            .wait(&task_id, "parent-a", std::time::Duration::from_secs(1))
+            .await
+            .unwrap(),
+        DetachedTaskWaitOutcome::Terminal(RuntimeStatus::Completed("done".into()))
+    );
+    assert!(registry.is_empty());
+    join.abort();
+}
+
+#[tokio::test]
+async fn detached_registry_timeout_keeps_task_registered() {
+    let registry = runtime_registry();
+    let task_id = TaskId::new("detached-timeout");
+    let (_tx, rx, cancellation, join) = detached_handles();
+    registry
+        .register(
+            task_id.clone(),
+            "parent",
+            "worker".to_string(),
+            rx,
+            cancellation,
+            join.abort_handle(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        registry
+            .wait(&task_id, "parent", std::time::Duration::from_millis(1))
+            .await
+            .unwrap(),
+        DetachedTaskWaitOutcome::TimedOut(RuntimeStatus::Running)
+    );
+    assert_eq!(registry.len(), 1);
+    join.abort();
+}
+
+#[tokio::test]
+async fn detached_registry_cancel_is_cooperative_then_aborts_and_returns_metadata() {
+    let registry = runtime_registry();
+    let task_id = TaskId::new("detached-cancel");
+    let (_tx, rx, cancellation, join) = detached_handles();
+    registry
+        .register(
+            task_id.clone(),
+            "parent",
+            "worker-meta".to_string(),
+            rx,
+            cancellation.clone(),
+            join.abort_handle(),
+        )
+        .unwrap();
+
+    let cancelled = registry.cancel(&task_id, "parent").unwrap();
+    assert_eq!(cancelled.metadata, "worker-meta");
+    assert!(cancellation.is_cancelled());
+    assert!(join.await.unwrap_err().is_cancelled());
+    assert!(registry.is_empty());
+}
+
+#[tokio::test]
+async fn detached_registry_uses_shared_steering_and_sweeps_terminal_at_soft_cap() {
+    let steering = SteeringRegistry::new();
+    let registry = DetachedTaskRegistry::new(steering.clone(), 1, |status: &RuntimeStatus| {
+        matches!(status, RuntimeStatus::Completed(_))
+    });
+    let first = TaskId::new("detached-first");
+    let (first_tx, first_rx, first_cancel, first_join) = detached_handles();
+    registry
+        .register(
+            first.clone(),
+            "parent",
+            "first".to_string(),
+            first_rx,
+            first_cancel,
+            first_join.abort_handle(),
+        )
+        .unwrap();
+    let handle = SteeringHandle::allow_all();
+    steering.register(first.clone(), handle);
+    assert!(registry.steering_handle(&first, "parent").is_ok());
+    first_tx
+        .send(RuntimeStatus::Completed("done".into()))
+        .unwrap();
+
+    let second = TaskId::new("detached-second");
+    let (_second_tx, second_rx, second_cancel, second_join) = detached_handles();
+    registry
+        .register(
+            second.clone(),
+            "parent",
+            "second".to_string(),
+            second_rx,
+            second_cancel,
+            second_join.abort_handle(),
+        )
+        .unwrap();
+
+    assert_eq!(registry.len(), 1);
+    assert!(steering.get(&first).is_none());
+    assert_eq!(registry.snapshots(Some("parent"))[0].task_id, second);
+    first_join.abort();
+    second_join.abort();
 }
 
 fn unique_log_path(tag: &str) -> std::path::PathBuf {

--- a/src/graph/orchestration/types.rs
+++ b/src/graph/orchestration/types.rs
@@ -488,6 +488,8 @@ pub enum DetachedTaskWaitOutcome<Status> {
 /// Why a detached task runtime control could not be completed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DetachedTaskRegistryError {
+    /// The process-local registry mutex was poisoned by a panicking operation.
+    LockPoisoned,
     /// No process-local runtime is registered for the task id.
     Unknown,
     /// The supplied owner id does not own the task.
@@ -503,6 +505,7 @@ pub enum DetachedTaskRegistryError {
 impl std::fmt::Display for DetachedTaskRegistryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let message = match self {
+            Self::LockPoisoned => "detached task runtime registry lock poisoned",
             Self::Unknown => "detached task is not registered",
             Self::NotOwned => "detached task is owned by another parent",
             Self::AlreadyDone => "detached task already reached a terminal status",

--- a/src/graph/orchestration/types.rs
+++ b/src/graph/orchestration/types.rs
@@ -445,3 +445,74 @@ pub struct OrchestrationControlOutcome {
     /// Human/model-readable summary.
     pub message: String,
 }
+
+/// A read-only snapshot of one process-local detached task runtime.
+///
+/// Durable lifecycle state belongs in a [`TaskStore`](super::TaskStore). This
+/// snapshot carries only the live executor metadata and status needed by a
+/// supervisor while the current process still owns the task.
+#[derive(Clone, Debug)]
+pub struct DetachedTaskSnapshot<Metadata, Status> {
+    /// Stable task id shared with the orchestration task store.
+    pub task_id: TaskId,
+    /// Application-defined owner id used for parent/tenant isolation.
+    pub owner_id: String,
+    /// Application metadata retained with the live executor handle.
+    pub metadata: Metadata,
+    /// Latest value published on the task's status watch channel.
+    pub status: Status,
+}
+
+/// Metadata returned when a detached task is cancelled and removed.
+#[derive(Clone, Debug)]
+pub struct CancelledDetachedTask<Metadata, Status> {
+    /// Stable task id shared with the orchestration task store.
+    pub task_id: TaskId,
+    /// Application-defined owner id.
+    pub owner_id: String,
+    /// Application metadata retained with the live executor handle.
+    pub metadata: Metadata,
+    /// Last status observed before cancellation.
+    pub status: Status,
+}
+
+/// Result of waiting on a process-local detached task.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DetachedTaskWaitOutcome<Status> {
+    /// The task published a terminal status. Its runtime entry was pruned.
+    Terminal(Status),
+    /// The deadline elapsed first. The runtime entry remains registered.
+    TimedOut(Status),
+}
+
+/// Why a detached task runtime control could not be completed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DetachedTaskRegistryError {
+    /// No process-local runtime is registered for the task id.
+    Unknown,
+    /// The supplied owner id does not own the task.
+    NotOwned,
+    /// The task has already published a terminal status.
+    AlreadyDone,
+    /// The task has no live steering handle registered.
+    NoSteeringHandle,
+    /// The status sender closed without publishing a terminal value.
+    StatusChannelClosed,
+}
+
+impl std::fmt::Display for DetachedTaskRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::Unknown => "detached task is not registered",
+            Self::NotOwned => "detached task is owned by another parent",
+            Self::AlreadyDone => "detached task already reached a terminal status",
+            Self::NoSteeringHandle => "detached task has no registered steering handle",
+            Self::StatusChannelClosed => {
+                "detached task status channel closed before a terminal update"
+            }
+        };
+        f.write_str(message)
+    }
+}
+
+impl std::error::Error for DetachedTaskRegistryError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ pub use graph::{
 
 // --- Graph: orchestration tools (ordinary harness Tool implementations) ---
 pub use graph::{
+    DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot, DetachedTaskWaitOutcome,
     InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome, OrchestrationTaskFilter,
     OrchestrationTaskKind, OrchestrationTaskRecord, OrchestrationTaskResult, OrchestrationTaskSpec,
     OrchestrationTaskStatus, OrchestrationTool, OrchestrationToolKind, SteeringRegistry, TaskStore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,12 +194,13 @@ pub use graph::{
 
 // --- Graph: orchestration tools (ordinary harness Tool implementations) ---
 pub use graph::{
-    DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot, DetachedTaskWaitOutcome,
-    InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome, OrchestrationTaskFilter,
-    OrchestrationTaskKind, OrchestrationTaskRecord, OrchestrationTaskResult, OrchestrationTaskSpec,
-    OrchestrationTaskStatus, OrchestrationTool, OrchestrationToolKind, SteeringRegistry, TaskStore,
-    orchestration_tool_schema, orchestration_tool_schemas, orchestration_tools,
-    orchestration_tools_with_steering, register_orchestration_tools,
+    CancelledDetachedTask, DetachedTaskRegistry, DetachedTaskRegistryError, DetachedTaskSnapshot,
+    DetachedTaskWaitOutcome, InMemoryTaskStore, JsonlTaskStore, OrchestrationControlOutcome,
+    OrchestrationTaskFilter, OrchestrationTaskKind, OrchestrationTaskRecord,
+    OrchestrationTaskResult, OrchestrationTaskSpec, OrchestrationTaskStatus, OrchestrationTool,
+    OrchestrationToolKind, SteeringRegistry, TaskStore, orchestration_tool_schema,
+    orchestration_tool_schemas, orchestration_tools, orchestration_tools_with_steering,
+    register_orchestration_tools,
 };
 
 // --- Graph: per-thread goal (durable objective + graph-native continuation) ---


### PR DESCRIPTION
## Summary

- add a generic `DetachedTaskRegistry<Metadata, Status>` beside the durable orchestration `TaskStore`
- centralize owner-checked wait/timeout, cooperative-cancel-before-abort, shared steering lookup, and soft-cap terminal cleanup
- document the process-local runtime boundary and add focused async lifecycle coverage

The registry intentionally does not duplicate durable state. Applications continue to transition the matching `TaskStore` record and reconcile store records with no live runtime after restart.

## Validation

- `cargo fmt --check`
- `cargo test graph::orchestration::test::detached_registry` (4 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime management for detached tasks, including status tracking, waiting, steering, cancellation, and ownership checks.
  * Added task snapshots and clear outcomes for completed or timed-out waits.
  * Added automatic cleanup of completed tasks with bounded runtime storage.

* **Documentation**
  * Documented detached task runtime management, cancellation behavior, ownership safeguards, and restart reconciliation.
  * Updated the SDK gaps documentation to reflect the available detached task controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->