### PR TITLE
fix(openai): recover text-mode tool calls from native models that emit tags

### DIFF
--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -531,13 +531,12 @@ fn parse_error_body_classifies_retryability_by_http_status() {
 
     // A 400 with "Stream must be set to true" — the common proxy-enforced
     // streaming check that triggers the invoke -> stream fallback.
-    let stream_required = m.parse_error_body(
-        400,
-        r#"{"detail":"Stream must be set to true"}"#,
-    );
+    let stream_required = m.parse_error_body(400, r#"{"detail":"Stream must be set to true"}"#);
     assert_eq!(stream_required.status, Some(400));
     assert!(
-        stream_required.message.contains("Stream must be set to true"),
+        stream_required
+            .message
+            .contains("Stream must be set to true"),
         "error message must contain the trigger phrase: got {}",
         stream_required.message
     );

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -2196,3 +2196,78 @@ fn degrade_for_400_unions_with_existing_baseline_degrade() {
         })
     );
 }
+
+#[test]
+fn stream_cleanup_scrubs_leaked_markup_from_live_deltas() {
+    use crate::harness::message::{AssistantMessage, ContentBlock, MessageDelta};
+    use crate::harness::model::ModelResponse;
+    use crate::harness::tool::ToolCallStreamScrubber;
+
+    // A native model (tools offered) that leaked its call as `<tool_call>` text,
+    // streamed across deltas that split the open marker and the close — the exact
+    // SSE scenario the terminal-only recovery left leaking to live consumers.
+    let deltas = [
+        "Sure, ",
+        "looking that up.",
+        "<tool_", // partial open marker — must be held, never surfaced
+        "call>{\"name\":\"lookup\",",
+        "\"arguments\":{\"q\":1}}</tool_call>",
+        " done",
+    ];
+    let mut scrubber = ToolCallStreamScrubber::new();
+    let mut emitted = String::new();
+    for d in deltas {
+        for item in super::transport::clean_stream_item(
+            ModelStreamItem::MessageDelta(MessageDelta::text(d)),
+            &mut scrubber,
+            true, // native
+        ) {
+            if let ModelStreamItem::MessageDelta(delta) = item {
+                assert!(
+                    !delta.text.contains("<tool_call"),
+                    "raw markup leaked in a live delta: {:?}",
+                    delta.text
+                );
+                emitted.push_str(&delta.text);
+            }
+        }
+    }
+
+    // Terminal native-fallback response (no structured calls) carrying the same
+    // leaked markup in its text: recovery lifts it into `tool_calls`.
+    let response = ModelResponse {
+        message: AssistantMessage {
+            id: None,
+            content: vec![ContentBlock::Text(
+                "Sure, looking that up.<tool_call>{\"name\":\"lookup\",\"arguments\":{\"q\":1}}</tool_call> done"
+                    .to_string(),
+            )],
+            tool_calls: Vec::new(),
+            usage: None,
+        },
+        usage: None,
+        finish_reason: None,
+        raw: None,
+        resolved_model: None,
+        continue_turn: None,
+    };
+    let terminal = super::transport::clean_stream_item(
+        ModelStreamItem::Completed(response),
+        &mut scrubber,
+        true,
+    );
+    let completed = terminal
+        .iter()
+        .find_map(|i| match i {
+            ModelStreamItem::Completed(r) => Some(r),
+            _ => None,
+        })
+        .expect("a Completed item is forwarded");
+
+    // Live deltas rendered clean prose only; the recovered call is off the text
+    // and present as a structured tool call on the terminal response.
+    assert_eq!(emitted, "Sure, looking that up. done");
+    assert!(!completed.text().contains("<tool_call"));
+    assert_eq!(completed.tool_calls().len(), 1);
+    assert_eq!(completed.tool_calls()[0].name, "lookup");
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -1403,9 +1403,16 @@ impl<State: Send + Sync> ChatModel<State> for OpenAiModel {
 
         let value: Value = serde_json::from_str(&text)?;
         let response = parse_chat_response(value, self.effective_reasoning_tags())?;
-        // Prompt-guided tools: recover the model's `<tool_call>` blocks into
-        // `message.tool_calls` when native tool calling was suppressed.
-        if !self.profile.tool_calling && !request.tools.is_empty() {
+        // Recover the model's `<tool_call>` blocks into `message.tool_calls` for
+        // prompt-guided models, and as a fallback for native models that emitted
+        // the call as text despite being flagged native (empty structured
+        // `tool_calls`). Native responses that already carry structured calls are
+        // returned unchanged.
+        if crate::harness::tool::should_recover(
+            self.profile.tool_calling,
+            !request.tools.is_empty(),
+            response.message.tool_calls.len(),
+        ) {
             return Ok(crate::harness::tool::apply_prompt_tool_calls(response));
         }
         Ok(response)
@@ -1471,7 +1478,11 @@ impl<State: Send + Sync> ChatModel<State> for OpenAiModel {
             })?;
             let value: Value = serde_json::from_str(&text)?;
             let mut parsed = parse_chat_response(value, self.effective_reasoning_tags())?;
-            if !self.profile.tool_calling && !request.tools.is_empty() {
+            if crate::harness::tool::should_recover(
+                self.profile.tool_calling,
+                !request.tools.is_empty(),
+                parsed.message.tool_calls.len(),
+            ) {
                 parsed = crate::harness::tool::apply_prompt_tool_calls(parsed);
             }
             let delta = crate::harness::message::MessageDelta {
@@ -1508,18 +1519,33 @@ impl<State: Send + Sync> ChatModel<State> for OpenAiModel {
         };
 
         let stream = futures::stream::unfold(state, sse_next);
-        // Prompt-guided tools: recover `<tool_call>` blocks from the terminal
-        // `Completed` response into `message.tool_calls` (the streamed text deltas
-        // still carry the raw markup — cleaning them mid-stream is a follow-up).
-        if !self.profile.tool_calling && !request.tools.is_empty() {
-            return Ok(Box::pin(stream.map(|item| match item {
-                ModelStreamItem::Completed(response) => ModelStreamItem::Completed(
-                    crate::harness::tool::apply_prompt_tool_calls(response),
-                ),
-                other => other,
-            })));
+        // Recover `<tool_call>` blocks from the terminal `Completed` response into
+        // `message.tool_calls`: always for prompt-guided models, and as a fallback
+        // for native models whose terminal response carried no structured
+        // `tool_calls` (the streamed text deltas still carry the raw markup —
+        // cleaning them mid-stream is a follow-up). Native responses with
+        // structured calls pass through unchanged; with no tools offered the
+        // stream is forwarded untouched.
+        if request.tools.is_empty() {
+            return Ok(Box::pin(stream));
         }
-        Ok(Box::pin(stream))
+        let native = self.profile.tool_calling;
+        Ok(Box::pin(stream.map(move |item| match item {
+            ModelStreamItem::Completed(response) => {
+                if crate::harness::tool::should_recover(
+                    native,
+                    true,
+                    response.message.tool_calls.len(),
+                ) {
+                    ModelStreamItem::Completed(crate::harness::tool::apply_prompt_tool_calls(
+                        response,
+                    ))
+                } else {
+                    ModelStreamItem::Completed(response)
+                }
+            }
+            other => other,
+        })))
     }
 }
 

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -1519,33 +1519,81 @@ impl<State: Send + Sync> ChatModel<State> for OpenAiModel {
         };
 
         let stream = futures::stream::unfold(state, sse_next);
-        // Recover `<tool_call>` blocks from the terminal `Completed` response into
-        // `message.tool_calls`: always for prompt-guided models, and as a fallback
-        // for native models whose terminal response carried no structured
-        // `tool_calls` (the streamed text deltas still carry the raw markup —
-        // cleaning them mid-stream is a follow-up). Native responses with
-        // structured calls pass through unchanged; with no tools offered the
-        // stream is forwarded untouched.
+        // Recover `<tool_call>` blocks into `message.tool_calls`: always for
+        // prompt-guided models, and as a fallback for native models whose terminal
+        // response carried no structured `tool_calls` (some OpenAI-compatible
+        // routes leak the call as `<tool_call>` text instead). Two surfaces are
+        // cleaned so nothing leaks:
+        //   * the terminal `Completed` response (the aggregated answer), and
+        //   * each streamed `MessageDelta`, via `ToolCallStreamScrubber`, so a
+        //     consumer rendering live text never sees raw markup mid-stream.
+        // With no tools offered the stream is forwarded untouched. When native
+        // structured calls came back the terminal response passes through
+        // unchanged (`should_recover` is false); delta text is re-chunked but its
+        // concatenation is byte-identical, since a structured-call response has no
+        // `<tool_call>` markup for the scrubber to remove.
         if request.tools.is_empty() {
             return Ok(Box::pin(stream));
         }
         let native = self.profile.tool_calling;
-        Ok(Box::pin(stream.map(move |item| match item {
-            ModelStreamItem::Completed(response) => {
-                if crate::harness::tool::should_recover(
-                    native,
-                    true,
-                    response.message.tool_calls.len(),
-                ) {
-                    ModelStreamItem::Completed(crate::harness::tool::apply_prompt_tool_calls(
-                        response,
-                    ))
-                } else {
-                    ModelStreamItem::Completed(response)
-                }
-            }
-            other => other,
+        let mut scrubber = crate::harness::tool::ToolCallStreamScrubber::new();
+        Ok(Box::pin(stream.flat_map(move |item| {
+            futures::stream::iter(clean_stream_item(item, &mut scrubber, native))
         })))
+    }
+}
+
+/// Applies text-mode tool-call cleanup to one streamed item, in the
+/// recovery-eligible path (tools were offered).
+///
+/// * A [`MessageDelta`](ModelStreamItem::MessageDelta) has its visible text run
+///   through `scrubber` so raw `<tool_call>` markup never reaches a consumer
+///   rendering live deltas; a delta the scrubber emptied entirely (and that
+///   carries no reasoning or tool-call chunk) is dropped.
+/// * The terminal [`Completed`](ModelStreamItem::Completed) response first emits
+///   any text the scrubber was holding as a final delta (so delta-rebuilt text
+///   matches the cleaned response), then recovers `<tool_call>` blocks per
+///   [`should_recover`](crate::harness::tool::should_recover) — a native response
+///   with structured calls passes through unchanged.
+///
+/// Returns the item(s) to forward; stateful across a stream via `scrubber`.
+pub(super) fn clean_stream_item(
+    item: ModelStreamItem,
+    scrubber: &mut crate::harness::tool::ToolCallStreamScrubber,
+    native: bool,
+) -> Vec<ModelStreamItem> {
+    match item {
+        ModelStreamItem::MessageDelta(mut delta) => {
+            if !delta.text.is_empty() {
+                delta.text = scrubber.feed(&delta.text);
+            }
+            if delta.text.is_empty() && delta.reasoning.is_empty() && delta.tool_call.is_none() {
+                Vec::new()
+            } else {
+                vec![ModelStreamItem::MessageDelta(delta)]
+            }
+        }
+        ModelStreamItem::Completed(response) => {
+            let mut out = Vec::new();
+            let tail = scrubber.flush();
+            if !tail.is_empty() {
+                out.push(ModelStreamItem::MessageDelta(
+                    crate::harness::message::MessageDelta::text(tail),
+                ));
+            }
+            let recovered = if crate::harness::tool::should_recover(
+                native,
+                true,
+                response.message.tool_calls.len(),
+            ) {
+                crate::harness::tool::apply_prompt_tool_calls(response)
+            } else {
+                response
+            };
+            out.push(ModelStreamItem::Completed(recovered));
+            out
+        }
+        other => vec![other],
     }
 }
 

--- a/src/harness/tool/prompt.rs
+++ b/src/harness/tool/prompt.rs
@@ -236,6 +236,151 @@ fn next_open(text: &str) -> Option<OpenMatch> {
     best
 }
 
+/// Byte index in `buf` from which the trailing bytes must be held back because
+/// they could still grow into a tool-call open delimiter once more text arrives.
+/// Returns `buf.len()` when the whole buffer is provably safe to surface now.
+///
+/// Two shapes are held: an in-progress `<tool_call …` open tag whose closing `>`
+/// has not arrived yet (so [`next_open`] cannot see it), and a trailing byte run
+/// that is a proper prefix of an open delimiter (`<tool_cal`, a partial DeepSeek
+/// `<｜tool▁`, or a lone `<`). A complete open delimiter is never reported here —
+/// [`next_open`] handles that case.
+fn hold_from(buf: &str) -> usize {
+    // In-progress `<tool_call …` tag: the last openable prefix occurrence whose
+    // `>` has not yet arrived. `<tool_calls>` (name not delimited) is not openable.
+    let mut from = 0;
+    let mut incomplete: Option<usize> = None;
+    while let Some(rel) = buf[from..].find(OPEN_PREFIX) {
+        let start = from + rel;
+        let after = &buf[start + OPEN_PREFIX.len()..];
+        let openable = match after.chars().next() {
+            None => true,
+            Some('>') | Some('|') => true,
+            Some(c) => c.is_whitespace(),
+        };
+        if openable && !after.contains('>') {
+            incomplete = Some(start);
+        }
+        from = start + OPEN_PREFIX.len();
+    }
+    if let Some(start) = incomplete {
+        return start;
+    }
+
+    // Trailing proper prefix of an open delimiter (a full delimiter would have
+    // been reported by `next_open` or the in-progress branch above).
+    let len = buf.len();
+    for marker in [OPEN_PREFIX, DS_OPEN] {
+        // A held tail can be as long as the whole buffer when the buffer is
+        // shorter than the marker, so the range is inclusive of `max`.
+        let max = marker.len().min(len);
+        for k in (1..=max).rev() {
+            if marker.is_char_boundary(k)
+                && buf.is_char_boundary(len - k)
+                && buf[len - k..] == marker[..k]
+            {
+                return len - k;
+            }
+        }
+    }
+    len
+}
+
+/// Streaming counterpart to [`parse_prompt_tool_calls_from_text`]: strips
+/// `<tool_call>…</tool_call>` markup from a text stream *as fragments arrive*.
+///
+/// The terminal-response recovery ([`apply_prompt_tool_calls`]) only cleans the
+/// aggregated answer, so a consumer that renders live [`MessageDelta`] text would
+/// still see raw markup stream through. This scrubber closes that gap: it emits
+/// only the text that is provably not part of a tool-call block, holding back any
+/// tail that could still become one (a partial `<tool_call`, an open tag whose
+/// `>` or matching close has not arrived, or a partial DeepSeek delimiter) until
+/// more input resolves it.
+///
+/// It is stateful across fragments — feed each fragment through [`feed`](Self::feed)
+/// and call [`flush`](Self::flush) once when the stream ends to drain the final
+/// safe remainder. Only the visible-text channel is scrubbed; reasoning and
+/// structured tool-call channels are unaffected.
+#[derive(Debug, Default)]
+pub struct ToolCallStreamScrubber {
+    buf: String,
+}
+
+impl ToolCallStreamScrubber {
+    /// Creates an empty scrubber.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feeds the next text fragment and returns the portion that is safe to emit
+    /// now. Complete `<tool_call>` blocks are dropped; text that could still be
+    /// the start of one is buffered for a later fragment.
+    pub fn feed(&mut self, fragment: &str) -> String {
+        self.buf.push_str(fragment);
+        let mut out = String::new();
+        loop {
+            match next_open(&self.buf) {
+                Some(open) => {
+                    let after_open = &self.buf[open.body_start..];
+                    if let Some(end) = after_open.find(open.close) {
+                        // Complete block: the prefix before it is safe; drop the
+                        // block and keep scanning the remainder.
+                        out.push_str(&self.buf[..open.start]);
+                        let next = open.body_start + end + open.close.len();
+                        self.buf.drain(..next);
+                        continue;
+                    }
+                    // Open delimiter located but not yet closed: emit the prefix,
+                    // hold the unterminated block for later fragments.
+                    out.push_str(&self.buf[..open.start]);
+                    self.buf.drain(..open.start);
+                    break;
+                }
+                None => {
+                    // No complete open delimiter: emit everything except the tail
+                    // that could still grow into one.
+                    let hold = hold_from(&self.buf);
+                    out.push_str(&self.buf[..hold]);
+                    self.buf.drain(..hold);
+                    break;
+                }
+            }
+        }
+        out
+    }
+
+    /// Drains the final safe remainder once no more fragments will arrive. A
+    /// complete tool-call block still buffered is dropped; a dangling partial
+    /// delimiter is surfaced verbatim (with the stream ended it was never a real
+    /// call). Unlike [`parse_prompt_tool_calls_from_text`], the remainder is not
+    /// trimmed — streamed whitespace is preserved.
+    pub fn flush(&mut self) -> String {
+        let mut out = String::new();
+        loop {
+            match next_open(&self.buf) {
+                Some(open) => {
+                    let after_open = &self.buf[open.body_start..];
+                    if let Some(end) = after_open.find(open.close) {
+                        out.push_str(&self.buf[..open.start]);
+                        let next = open.body_start + end + open.close.len();
+                        self.buf.drain(..next);
+                        continue;
+                    }
+                    // Unterminated at end of stream: real text, emit verbatim.
+                    out.push_str(&self.buf);
+                    break;
+                }
+                None => {
+                    out.push_str(&self.buf);
+                    break;
+                }
+            }
+        }
+        self.buf.clear();
+        out
+    }
+}
+
 /// Whether text-mode `<tool_call>` recovery should run over a completed response.
 ///
 /// * Prompt-guided models (`native == false`) always recover — the whole point of

--- a/src/harness/tool/prompt.rs
+++ b/src/harness/tool/prompt.rs
@@ -22,6 +22,19 @@ use crate::harness::tool::{ToolCall, ToolSchema};
 const OPEN_TAG: &str = "<tool_call>";
 const CLOSE_TAG: &str = "</tool_call>";
 
+/// Prefix of the opening delimiter, matched tolerantly so the attribute form
+/// (`<tool_call id="call_0">`, as emitted by Hermes / DeepSeek chat templates)
+/// and the pipe variant (`<tool_call|>`) are recognized — not just the bare
+/// `<tool_call>` literal. The scanner matches this prefix, verifies the tag name
+/// is properly delimited, and then consumes up to the tag's closing `>`.
+const OPEN_PREFIX: &str = "<tool_call";
+
+/// DeepSeek-R1 native tool-call delimiters, emitted verbatim as text by some
+/// OpenAI-compatible routes. Matched as an alternative open/close pair so the
+/// body between them is parsed (or dropped) instead of leaking to the caller.
+const DS_OPEN: &str = "<｜tool▁call▁begin｜>";
+const DS_CLOSE: &str = "<｜tool▁call▁end｜>";
+
 /// Build the tool-use protocol block appended to the system prompt when native
 /// tool calling is unavailable. Describes the `<tool_call>` convention and lists
 /// each tool's name, description, and JSON-Schema parameters.
@@ -130,30 +143,113 @@ pub fn coalesce_prompt_tool_results(messages: &[Message]) -> Vec<Message> {
 /// object (`{"name":…,"arguments":…}`) into a [`ToolCall`]. Returns the text with
 /// the blocks removed (trimmed) plus the parsed calls, in order.
 ///
+/// The opening delimiter is matched tolerantly: the bare `<tool_call>` literal,
+/// the attribute form `<tool_call id="…">` and pipe variant `<tool_call|>`
+/// emitted by Hermes / DeepSeek chat templates, and the DeepSeek
+/// `<｜tool▁call▁begin｜>` delimiter all open a block.
+///
 /// Robust to noise: a block whose inner text is not a JSON object with a string
-/// `name` is dropped; a dangling `<tool_call>` with no close is left verbatim in
-/// the returned text.
+/// `name` is dropped (its raw markup never leaks back into the text); a dangling
+/// open tag with no close is left verbatim in the returned text; a prose mention
+/// of `<tool_call` with no closing `>` (or the plural `<tool_calls>`) is not
+/// treated as an opening tag.
 pub fn parse_prompt_tool_calls_from_text(text: &str) -> (String, Vec<ToolCall>) {
     let mut calls = Vec::new();
     let mut cleaned = String::new();
     let mut rest = text;
 
-    while let Some(start) = rest.find(OPEN_TAG) {
-        cleaned.push_str(&rest[..start]);
-        let after_open = &rest[start + OPEN_TAG.len()..];
-        let Some(end) = after_open.find(CLOSE_TAG) else {
+    while let Some(open) = next_open(rest) {
+        cleaned.push_str(&rest[..open.start]);
+        let after_open = &rest[open.body_start..];
+        let Some(end) = after_open.find(open.close) else {
             // Unterminated block: keep it (and everything after) as plain text.
-            cleaned.push_str(&rest[start..]);
+            cleaned.push_str(&rest[open.start..]);
             return (cleaned.trim().to_string(), calls);
         };
         let inner = after_open[..end].trim();
         if let Some(call) = parse_one(inner, calls.len() + 1) {
             calls.push(call);
         }
-        rest = &after_open[end + CLOSE_TAG.len()..];
+        rest = &after_open[end + open.close.len()..];
     }
     cleaned.push_str(rest);
     (cleaned.trim().to_string(), calls)
+}
+
+/// A located opening tool-call delimiter.
+struct OpenMatch {
+    /// Byte offset of the opening `<`.
+    start: usize,
+    /// Byte offset where the inner body begins (just past the opening tag's `>`
+    /// for the `<tool_call …>` family, or past the DeepSeek open delimiter).
+    body_start: usize,
+    /// Closing delimiter that terminates this block.
+    close: &'static str,
+}
+
+/// Find the earliest opening tool-call delimiter in `text`, tolerant of the
+/// attribute form (`<tool_call id="…">`), the pipe variant (`<tool_call|>`), and
+/// the DeepSeek `<｜tool▁call▁begin｜>` delimiter. Returns `None` when no complete
+/// opening tag is present. A bare `<tool_call` mention with no closing `>` (prose)
+/// is not treated as an opening tag.
+fn next_open(text: &str) -> Option<OpenMatch> {
+    let mut best: Option<OpenMatch> = None;
+
+    // DeepSeek native delimiter (literal open/close pair).
+    if let Some(start) = text.find(DS_OPEN) {
+        best = Some(OpenMatch {
+            start,
+            body_start: start + DS_OPEN.len(),
+            close: DS_CLOSE,
+        });
+    }
+
+    // `<tool_call …>` family: the first prefix occurrence whose tag name is
+    // properly delimited (`>`, whitespace, or `|` — so `<tool_calls>` /
+    // `<tool_callable>` do not match) and is closed by a `>`.
+    let mut from = 0;
+    while let Some(rel) = text[from..].find(OPEN_PREFIX) {
+        let start = from + rel;
+        let after_prefix = &text[start + OPEN_PREFIX.len()..];
+        let delimited = match after_prefix.chars().next() {
+            Some('>') | Some('|') => true,
+            Some(c) => c.is_whitespace(),
+            None => false,
+        };
+        if delimited && let Some(gt) = after_prefix.find('>') {
+            let candidate = OpenMatch {
+                start,
+                body_start: start + OPEN_PREFIX.len() + gt + 1,
+                close: CLOSE_TAG,
+            };
+            best = match best {
+                Some(b) if b.start <= candidate.start => Some(b),
+                _ => Some(candidate),
+            };
+            break;
+        }
+        // Not a usable open tag here (prose mention, or no closing `>`): keep
+        // scanning past this occurrence. Advances by a non-zero amount.
+        from = start + OPEN_PREFIX.len();
+    }
+
+    best
+}
+
+/// Whether text-mode `<tool_call>` recovery should run over a completed response.
+///
+/// * Prompt-guided models (`native == false`) always recover — the whole point of
+///   the mode is that tool calls arrive as text.
+/// * Native models recover only as a **fallback**: when they were offered tools
+///   but returned an empty structured `tool_calls` array, some OpenAI-compatible
+///   routes (Hermes / DeepSeek chat templates via OpenRouter) emit the call as
+///   `<tool_call>…</tool_call>` text instead of the structured field — recovering
+///   it keeps the raw markup from leaking to the caller as assistant content.
+/// * When native tool calls came back structured (`structured_calls > 0`),
+///   recovery is skipped so the native path stays byte-for-byte unchanged.
+/// * When no tools were offered, there is nothing to recover.
+pub fn should_recover(native: bool, has_tools: bool, structured_calls: usize) -> bool {
+    has_tools && (!native || structured_calls == 0)
 }
 
 /// Extract prompt-guided `<tool_call>` blocks from a completed [`ModelResponse`]'s

--- a/src/harness/tool/prompt_test.rs
+++ b/src/harness/tool/prompt_test.rs
@@ -280,7 +280,7 @@ fn should_recover_gating_matrix() {
 fn should_recover_skips_native_response_with_structured_calls() {
     // When a real structured call is present the guard skips recovery, so the
     // native path is left byte-for-byte unchanged.
-    let calls = vec![ToolCall {
+    let calls = [ToolCall {
         id: "call_1".to_string(),
         name: "real".to_string(),
         arguments: serde_json::json!({}),

--- a/src/harness/tool/prompt_test.rs
+++ b/src/harness/tool/prompt_test.rs
@@ -288,3 +288,109 @@ fn should_recover_skips_native_response_with_structured_calls() {
     }];
     assert!(!should_recover(true, true, calls.len()));
 }
+
+/// Feeds every fragment through the scrubber and appends the flush, returning the
+/// full text a delta consumer would render.
+fn scrub_all(fragments: &[&str]) -> String {
+    let mut s = ToolCallStreamScrubber::new();
+    let mut out = String::new();
+    for f in fragments {
+        out.push_str(&s.feed(f));
+    }
+    out.push_str(&s.flush());
+    out
+}
+
+#[test]
+fn scrubber_passes_plain_text_through_unchanged() {
+    // No markup: the concatenated emissions equal the input exactly.
+    assert_eq!(scrub_all(&["hello ", "world", " done"]), "hello world done");
+}
+
+#[test]
+fn scrubber_drops_a_complete_block_in_one_fragment() {
+    let out = scrub_all(&[r#"before <tool_call>{"name":"x","arguments":{}}</tool_call> after"#]);
+    assert_eq!(out, "before  after");
+}
+
+#[test]
+fn scrubber_suppresses_markup_split_across_fragments() {
+    // The open tag, body, and close arrive in separate fragments — no raw markup
+    // may appear in any emission, and the surrounding prose survives.
+    let out = scrub_all(&[
+        "answer: ",
+        "<tool_",
+        "call>{\"name\":\"x\",",
+        "\"arguments\":{}}</tool",
+        "_call> end",
+    ]);
+    assert_eq!(out, "answer:  end");
+    assert!(!out.contains("<tool_call"));
+}
+
+#[test]
+fn scrubber_never_emits_partial_open_marker_mid_stream() {
+    // A fragment ending in a partial open marker must not surface it; it is held
+    // until the next fragment resolves the block.
+    let mut s = ToolCallStreamScrubber::new();
+    let first = s.feed("value <tool");
+    assert_eq!(first, "value ", "partial `<tool` must be held, not emitted");
+    let second = s.feed("_call>{\"name\":\"x\",\"arguments\":{}}</tool_call>!");
+    assert_eq!(second, "!");
+    assert_eq!(s.flush(), "");
+}
+
+#[test]
+fn scrubber_handles_attribute_open_form_split() {
+    // The Hermes/DeepSeek attribute form `<tool_call id="...">` split mid-tag.
+    let out = scrub_all(&[
+        "ok ",
+        "<tool_call id=\"call_0\"",
+        ">{\"name\":\"x\",\"arguments\":{}}</tool_call>",
+    ]);
+    assert_eq!(out, "ok ");
+}
+
+#[test]
+fn scrubber_handles_deepseek_delimiters_split() {
+    let out = scrub_all(&[
+        "r ",
+        "<｜tool▁call▁be",
+        "gin｜>{\"name\":\"x\",\"arguments\":{}}<｜tool▁call▁end｜>",
+        " s",
+    ]);
+    assert_eq!(out, "r  s");
+    assert!(!out.contains("tool▁call"));
+}
+
+#[test]
+fn scrubber_does_not_hold_plural_tool_calls_prose() {
+    // `<tool_calls>` (name not delimiter-terminated) is prose, not an open tag.
+    assert_eq!(
+        scrub_all(&["see <tool_calls> below"]),
+        "see <tool_calls> below"
+    );
+}
+
+#[test]
+fn scrubber_flush_surfaces_a_dangling_open_verbatim_untrimmed() {
+    // A `<tool_call` with no close is real text once the stream ends; leading and
+    // trailing whitespace is preserved (flush does not trim).
+    let mut s = ToolCallStreamScrubber::new();
+    let mid = s.feed("  a <tool_call ");
+    assert_eq!(mid, "  a ", "the in-progress open tag is held");
+    assert_eq!(s.flush(), "<tool_call ");
+}
+
+#[test]
+fn scrubber_matches_batch_parser_on_the_visible_text() {
+    // Property: scrubbing a fragmented stream yields the same visible text as the
+    // batch parser produces (modulo the batch parser's trim) for the same input.
+    let full = r#"lead <tool_call>{"name":"a","arguments":{}}</tool_call> mid <tool_call>{"name":"b","arguments":{"k":1}}</tool_call> tail"#;
+    let (batch, calls) = parse_prompt_tool_calls_from_text(full);
+    assert_eq!(calls.len(), 2);
+    // Fragment the input into single-byte-ish chunks at char boundaries.
+    let frags: Vec<String> = full.chars().map(|c| c.to_string()).collect();
+    let refs: Vec<&str> = frags.iter().map(String::as_str).collect();
+    assert_eq!(scrub_all(&refs).trim(), batch);
+}

--- a/src/harness/tool/prompt_test.rs
+++ b/src/harness/tool/prompt_test.rs
@@ -184,3 +184,107 @@ fn prompt_parser_returns_plain_text_verbatim() {
     assert!(calls.is_empty());
     assert_eq!(cleaned, "just a normal answer");
 }
+
+// --- Attribute / variant-tolerant matching (Hermes / DeepSeek templates) ---
+
+#[test]
+fn prompt_parser_matches_attribute_form_open_tag() {
+    // Regression for the exact-literal miss: `<tool_call id="…">` must match so a
+    // native model that leaks the call as text doesn't dump raw markup.
+    let text = r#"<tool_call id="call_0">{"name":"foo","arguments":{"a":1}}</tool_call>"#;
+    let (cleaned, calls) = parse_prompt_tool_calls_from_text(text);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "foo");
+    assert_eq!(calls[0].arguments, serde_json::json!({"a": 1}));
+    assert!(cleaned.is_empty());
+    assert!(!cleaned.contains("<tool_call"));
+}
+
+#[test]
+fn prompt_parser_matches_pipe_variant_open_tag() {
+    let text = r#"<tool_call|>{"name":"foo","arguments":{}}</tool_call>"#;
+    let (_, calls) = parse_prompt_tool_calls_from_text(text);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "foo");
+}
+
+#[test]
+fn prompt_parser_matches_deepseek_delimiters() {
+    let text = "<｜tool▁call▁begin｜>{\"name\":\"foo\",\"arguments\":{}}<｜tool▁call▁end｜>";
+    let (cleaned, calls) = parse_prompt_tool_calls_from_text(text);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "foo");
+    assert!(cleaned.is_empty());
+}
+
+#[test]
+fn prompt_parser_drops_attribute_form_no_name_body_without_leak() {
+    // The reported bug: `<tool_call id="call_0">{}</tool_call>` has no `name`.
+    // It must be dropped — never echoed back as assistant content.
+    let text = "prefix <tool_call id=\"call_0\">\n{}\n</tool_call> suffix";
+    let (cleaned, calls) = parse_prompt_tool_calls_from_text(text);
+    assert!(calls.is_empty());
+    assert!(!cleaned.contains("<tool_call"));
+    assert!(!cleaned.contains("{}"));
+    assert_eq!(cleaned, "prefix  suffix");
+}
+
+#[test]
+fn prompt_parser_does_not_match_plural_tag() {
+    // `<tool_calls>` must not be mistaken for an opening `<tool_call>`.
+    let text = "see the <tool_calls> list";
+    let (cleaned, calls) = parse_prompt_tool_calls_from_text(text);
+    assert!(calls.is_empty());
+    assert_eq!(cleaned, "see the <tool_calls> list");
+}
+
+#[test]
+fn prompt_parser_does_not_misparse_prose_open_tag_without_close() {
+    let text = "You can emit a <tool_call id=\"1\"> block to call a tool.";
+    let (cleaned, calls) = parse_prompt_tool_calls_from_text(text);
+    assert!(calls.is_empty());
+    assert_eq!(cleaned, text);
+}
+
+// --- apply_prompt_tool_calls recovery + native-mode fallback gating ---
+
+#[test]
+fn apply_prompt_tool_calls_recovers_attribute_markup() {
+    // A native model emitted the call as text with EMPTY structured tool_calls:
+    // recovery yields a structured call and the raw markup does NOT survive.
+    let resp = crate::harness::model::ModelResponse::assistant(
+        r#"<tool_call id="call_0">{"name":"foo","arguments":{}}</tool_call>"#,
+    );
+    let out = apply_prompt_tool_calls(resp);
+    assert_eq!(out.message.tool_calls.len(), 1);
+    assert_eq!(out.message.tool_calls[0].name, "foo");
+    assert!(!out.text().contains("<tool_call"));
+    assert!(out.text().is_empty());
+}
+
+#[test]
+fn should_recover_gating_matrix() {
+    // Prompt-guided (native == false): always recover when tools were offered.
+    assert!(should_recover(false, true, 0));
+    assert!(should_recover(false, true, 2));
+    // Native fallback: only when tools offered AND no structured calls.
+    assert!(should_recover(true, true, 0));
+    // Native with structured calls present: never recover (path stays as-is).
+    assert!(!should_recover(true, true, 1));
+    // No tools offered: nothing to recover, either mode.
+    assert!(!should_recover(true, false, 0));
+    assert!(!should_recover(false, false, 0));
+}
+
+#[test]
+fn should_recover_skips_native_response_with_structured_calls() {
+    // When a real structured call is present the guard skips recovery, so the
+    // native path is left byte-for-byte unchanged.
+    let calls = vec![ToolCall {
+        id: "call_1".to_string(),
+        name: "real".to_string(),
+        arguments: serde_json::json!({}),
+        invalid: None,
+    }];
+    assert!(!should_recover(true, true, calls.len()));
+}


### PR DESCRIPTION
## Summary

Recover DeepSeek/Hermes text-mode tool calls that leak into assistant content when a native-flagged model emits its call as `<tool_call …>` text instead of the structured `tool_calls` field.

## Problem

opencompany's company agents run on OpenHuman → tinyagents. On staging the model is DeepSeek (via OpenRouter). DeepSeek/Hermes chat templates emit tool calls as text — `<tool_call id="call_0">{...}</tool_call>` — but the model is flagged as **native** structured tool-calling. Two failures compound:

1. **Attribute form defeats the matcher.** The inline text parser matched only the exact `<tool_call>` literal, so `<tool_call id="…">` (and the `<tool_call|>` / DeepSeek `<｜tool▁call▁begin｜>` variants) never matched.
2. **Recovery gated off in native mode.** The three OpenAI recovery sites ran text recovery only when `!profile.tool_calling`. A native model that returned an empty structured `tool_calls` array but text markup got no recovery — so the raw `<tool_call>…</tool_call>` markup leaked into the assistant reply as literal text instead of executing.

## Solution

Ported as a delta on top of what `main` already covers:

- **`main` already covered (kept, not duplicated):** malformed *argument JSON* recovery for the structured `function.arguments` field (`relaxed_json.rs`, #68) — a different concern (argument blob repair, not text-tag markup). The exact-literal `<tool_call>` prompt-guided path and its no-name drop also already existed.
- **This PR adds the still-missing pieces:**
  - `src/harness/tool/prompt.rs` — a prefix-tolerant opening-delimiter scanner (`next_open`) handling `<tool_call id="…">`, `<tool_call|>`, and the DeepSeek `<｜tool▁call▁begin｜>`/`end` pair. The tag name must be properly delimited (`>`, `|`, or whitespace) so `<tool_calls>` / `<tool_callable>` don't match; a no-`name` body is dropped without leaking its raw markup; a prose `<tool_call` with no closing `>` is left verbatim.
  - `should_recover(native, has_tools, structured_calls)` gate, wired into all three OpenAI recovery sites (unary, non-stream, SSE terminal): prompt-guided models always recover; native models recover only as a **fallback** when tools were offered but the structured array came back empty.

## Invariants preserved

- Native structured tool-calling (real `tool_calls` present, `structured_calls > 0`) is **byte-for-byte unchanged** — `should_recover` returns `false`, so `apply_prompt_tool_calls` is never invoked.
- No tools offered → stream/response forwarded untouched.
- Plain prose mentioning `<tool_call>` without a full tag+body is not misparsed; `<tool_calls>` (plural) never matches.
- Unterminated open tag is kept as text (existing behaviour retained).

## Test coverage

Added to `src/harness/tool/prompt_test.rs` (9 new tests, all green):

- attribute-form `<tool_call id="x">{"name":"foo",…}</tool_call>` parses to `foo`, markup does not survive into content
- pipe variant `<tool_call|>` and DeepSeek `<｜tool▁call▁begin｜>` delimiters parse
- malformed no-`name` body (`{}`) dropped without leaking `<tool_call`/`{}`
- plural `<tool_calls>` not matched; prose open-tag without close not misparsed
- `apply_prompt_tool_calls` recovers attribute markup from an empty-structured-calls response
- `should_recover` gating matrix + native-with-structured-calls skip

`cargo test` green for `harness::tool::prompt` (22 passed) and `harness::providers::openai` (125 passed). `cargo fmt --check` clean on touched files; `cargo clippy --lib` clean.

## Related

Fixes the DeepSeek text-mode tool-call leak observed in opencompany company agents on staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call recovery for both prompt-guided and native model outputs using smarter decision logic for when to convert text markup into structured tool calls.
  * Expanded recognition of tool-call text formats (attribute-tolerant tags, pipe variants, and DeepSeek-style delimiters) while avoiding false positives and preserving malformed markup as plain text.
  * Applied consistent recovery behavior across unary and streaming responses, including SSE/non-SSE handling.

* **Tests**
  * Added regression tests covering new accepted formats, negative/malformed cases, and the recovery gating matrix for both unary and streaming flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->