### PR TITLE
feat(message): carry a tool result's trusted-verbatim request into the transcript

### DIFF
--- a/src/harness/agent_loop/tools.rs
+++ b/src/harness/agent_loop/tools.rs
@@ -361,10 +361,10 @@ impl<State: Send + Sync, Ctx: Send + Sync> AgentHarness<State, Ctx> {
         });
         status.set_last_event(record.id);
 
-        messages.push(Message::tool(
-            result.call_id.clone(),
-            result.content.clone(),
-        ));
+        // `tool_from_result`, not `tool`: a result that asked to reach the model
+        // byte-for-byte must carry that request into the transcript, or the host
+        // has no way to tell it apart from output it may freely reshape.
+        messages.push(Message::tool_from_result(&result));
         Ok(())
     }
 

--- a/src/harness/message/mod.rs
+++ b/src/harness/message/mod.rs
@@ -125,10 +125,30 @@ impl Message {
     }
 
     /// Creates a tool result message for the given tool call id.
+    ///
+    /// Leaves [`ToolMessage::trusted_verbatim`] unset. Use
+    /// [`Message::tool_from_result`] to fold a real
+    /// [`crate::harness::tool::ToolResult`], which carries the flag across.
     pub fn tool(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
         Message::Tool(ToolMessage {
             tool_call_id: tool_call_id.into(),
             content: vec![ContentBlock::Text(content.into())],
+            trusted_verbatim: false,
+        })
+    }
+
+    /// Folds a [`crate::harness::tool::ToolResult`] into the transcript message
+    /// that answers its call.
+    ///
+    /// Preferred over [`Message::tool`] on the agent-loop path: a `ToolResult`
+    /// carries structured metadata the message shape would otherwise drop, and
+    /// [`ToolMessage::trusted_verbatim`] is the part a host must not lose — it
+    /// is what tells the host this content may not be reshaped.
+    pub fn tool_from_result(result: &crate::harness::tool::ToolResult) -> Self {
+        Message::Tool(ToolMessage {
+            tool_call_id: result.call_id.clone(),
+            content: vec![ContentBlock::Text(result.content.clone())],
+            trusted_verbatim: result.is_trusted_verbatim(),
         })
     }
 

--- a/src/harness/message/test.rs
+++ b/src/harness/message/test.rs
@@ -239,7 +239,7 @@ fn tool_from_result_carries_trusted_verbatim_and_tool_does_not() {
     // Folding a marked result carries the request across, which is the whole
     // point: without it the host cannot tell this content apart from output it
     // may freely summarise or re-frame.
-    result.mark_trusted_verbatim();
+    assert!(result.mark_trusted_verbatim());
     let Message::Tool(marked) = Message::tool_from_result(&result) else {
         panic!("expected a tool message");
     };
@@ -256,4 +256,24 @@ fn a_transcript_stored_before_the_flag_existed_still_deserializes() {
     let msg: ToolMessage = serde_json::from_value(legacy).unwrap();
     assert_eq!(msg.tool_call_id, "call-1");
     assert!(!msg.trusted_verbatim);
+}
+
+#[test]
+fn an_unset_flag_is_omitted_from_the_wire() {
+    // The opt-in must cost nothing for the messages that never use it: a tool
+    // message without the flag serializes exactly as it did before the field
+    // existed, matching how the rest of the crate omits unset fields.
+    let plain = Message::tool("call-1", "ok");
+    let wire = serde_json::to_value(&plain).unwrap();
+    assert_eq!(
+        wire,
+        json!({ "tool": { "tool_call_id": "call-1", "content": [{ "text": "ok" }] } })
+    );
+
+    let Message::Tool(mut msg) = plain else {
+        panic!("expected a tool message");
+    };
+    msg.trusted_verbatim = true;
+    let wire = serde_json::to_value(Message::Tool(msg)).unwrap();
+    assert_eq!(wire["tool"]["trusted_verbatim"], json!(true));
 }

--- a/src/harness/message/test.rs
+++ b/src/harness/message/test.rs
@@ -208,3 +208,52 @@ fn legacy_content_without_thinking_still_parses() {
     assert_eq!(blocks[0].as_text(), Some("hello"));
     assert!(!blocks[1].is_reasoning());
 }
+
+#[test]
+fn tool_from_result_carries_trusted_verbatim_and_tool_does_not() {
+    use crate::harness::tool::ToolResult;
+
+    let mut result = ToolResult {
+        call_id: "call-7".into(),
+        name: "read_schema".into(),
+        content: "verbatim body".into(),
+        raw: None,
+        error: None,
+        elapsed_ms: 0,
+    };
+
+    // The plain constructor never claims the flag — nothing changes for the
+    // callers that do not opt in.
+    let Message::Tool(plain) = Message::tool("call-7", "verbatim body") else {
+        panic!("expected a tool message");
+    };
+    assert!(!plain.trusted_verbatim);
+
+    // Folding an unmarked result matches the plain constructor.
+    let Message::Tool(unmarked) = Message::tool_from_result(&result) else {
+        panic!("expected a tool message");
+    };
+    assert!(!unmarked.trusted_verbatim);
+    assert_eq!(unmarked, plain);
+
+    // Folding a marked result carries the request across, which is the whole
+    // point: without it the host cannot tell this content apart from output it
+    // may freely summarise or re-frame.
+    result.mark_trusted_verbatim();
+    let Message::Tool(marked) = Message::tool_from_result(&result) else {
+        panic!("expected a tool message");
+    };
+    assert!(marked.trusted_verbatim);
+    assert_eq!(marked.tool_call_id, "call-7");
+    assert_eq!(marked.content, plain.content);
+}
+
+#[test]
+fn a_transcript_stored_before_the_flag_existed_still_deserializes() {
+    // Additive field: `#[serde(default)]` keeps older persisted transcripts
+    // loadable, and they read as not-trusted rather than failing.
+    let legacy = json!({ "tool_call_id": "call-1", "content": [{ "text": "ok" }] });
+    let msg: ToolMessage = serde_json::from_value(legacy).unwrap();
+    assert_eq!(msg.tool_call_id, "call-1");
+    assert!(!msg.trusted_verbatim);
+}

--- a/src/harness/message/types.rs
+++ b/src/harness/message/types.rs
@@ -99,6 +99,24 @@ pub struct ToolMessage {
     pub tool_call_id: String,
     /// Ordered content blocks.
     pub content: Vec<ContentBlock>,
+    /// The producing tool asked for this content to reach the model
+    /// byte-for-byte, so a host that rewrites tool output must leave it alone.
+    ///
+    /// Set from [`ToolResult::is_trusted_verbatim`] by
+    /// [`Message::tool_from_result`]; `false` for every other constructor, so
+    /// nothing changes unless a tool opts in.
+    ///
+    /// A host is free to summarise, truncate, batch, or re-frame tool output —
+    /// and normally should. But some results are only useful intact: an input
+    /// schema the model must copy argument names out of, a signature, a diff.
+    /// Rewriting those silently produces content that reads fine and is wrong.
+    /// The flag lets a tool say "this one is not safe to reshape" without the
+    /// host having to guess from the text.
+    ///
+    /// `#[serde(default)]` so transcripts persisted before this field existed
+    /// still deserialise.
+    #[serde(default)]
+    pub trusted_verbatim: bool,
 }
 
 /// A structured conversation message.

--- a/src/harness/message/types.rs
+++ b/src/harness/message/types.rs
@@ -114,8 +114,10 @@ pub struct ToolMessage {
     /// host having to guess from the text.
     ///
     /// `#[serde(default)]` so transcripts persisted before this field existed
-    /// still deserialise.
-    #[serde(default)]
+    /// still deserialise, and `skip_serializing_if` so a message that never
+    /// opted in stays byte-identical on the wire — matching how the rest of the
+    /// crate omits unset fields.
+    #[serde(default, skip_serializing_if = "is_false")]
     pub trusted_verbatim: bool,
 }
 
@@ -171,4 +173,9 @@ impl MessageDelta {
             ..Self::default()
         }
     }
+}
+
+/// Serde helper: skip serializing `false` booleans.
+fn is_false(value: &bool) -> bool {
+    !*value
 }

--- a/src/harness/tool/test.rs
+++ b/src/harness/tool/test.rs
@@ -400,7 +400,7 @@ fn trusted_verbatim_is_opt_in_and_round_trips_through_raw() {
         "a plain result must not claim the flag"
     );
 
-    result.mark_trusted_verbatim();
+    assert!(result.mark_trusted_verbatim(), "an absent `raw` makes room");
     assert!(result.is_trusted_verbatim());
 
     // Stored under a known key in `raw`, so a host can round-trip it through its
@@ -415,7 +415,7 @@ fn trusted_verbatim_is_opt_in_and_round_trips_through_raw() {
 
     // Marking twice is idempotent and preserves unrelated metadata.
     result.raw.as_mut().unwrap()["other"] = json!("kept");
-    result.mark_trusted_verbatim();
+    assert!(result.mark_trusted_verbatim());
     assert!(result.is_trusted_verbatim());
     assert_eq!(result.raw.as_ref().unwrap()["other"], json!("kept"));
 }
@@ -445,4 +445,43 @@ fn unrelated_raw_metadata_never_sets_the_flag() {
         ..with_other
     };
     assert!(!not_an_object.is_trusted_verbatim());
+}
+
+#[test]
+fn marking_is_refused_rather_than_silently_lost_when_raw_is_not_an_object() {
+    // Regression: the flag lives under a key in `raw`, so a scalar `raw` has
+    // nowhere to put it. Clobbering a value the tool deliberately set would be
+    // worse, so the request is refused — and the caller is told, because a
+    // silent failure leaves `is_trusted_verbatim()` answering `false` forever
+    // while the author believes the opt-in took effect.
+    for raw in [json!("opaque"), json!([1, 2, 3]), json!(7)] {
+        let mut result = ToolResult {
+            call_id: "c".into(),
+            name: "t".into(),
+            content: "x".into(),
+            raw: Some(raw.clone()),
+            error: None,
+            elapsed_ms: 0,
+        };
+        assert!(
+            !result.mark_trusted_verbatim(),
+            "a non-object `raw` ({raw}) must refuse the request"
+        );
+        assert!(!result.is_trusted_verbatim());
+        // The tool's own value is left exactly as it was.
+        assert_eq!(result.raw, Some(raw));
+    }
+
+    // Once the tool makes room, the same call succeeds.
+    let mut moved = ToolResult {
+        call_id: "c".into(),
+        name: "t".into(),
+        content: "x".into(),
+        raw: Some(json!({ "value": "opaque" })),
+        error: None,
+        elapsed_ms: 0,
+    };
+    assert!(moved.mark_trusted_verbatim());
+    assert!(moved.is_trusted_verbatim());
+    assert_eq!(moved.raw.as_ref().unwrap()["value"], json!("opaque"));
 }

--- a/src/harness/tool/test.rs
+++ b/src/harness/tool/test.rs
@@ -384,3 +384,65 @@ fn schema_validation_rejects_wrong_types_and_extra_fields() {
     let err = schema.validate_call(&extra).expect_err("extra field");
     assert!(err.to_string().contains("extra"));
 }
+
+#[test]
+fn trusted_verbatim_is_opt_in_and_round_trips_through_raw() {
+    let mut result = ToolResult {
+        call_id: "call-1".into(),
+        name: "read_schema".into(),
+        content: "{\n  \"a\": 1\n}".into(),
+        raw: None,
+        error: None,
+        elapsed_ms: 0,
+    };
+    assert!(
+        !result.is_trusted_verbatim(),
+        "a plain result must not claim the flag"
+    );
+
+    result.mark_trusted_verbatim();
+    assert!(result.is_trusted_verbatim());
+
+    // Stored under a known key in `raw`, so a host can round-trip it through its
+    // own serialization without a schema change.
+    assert_eq!(
+        result
+            .raw
+            .as_ref()
+            .and_then(|r| r.get(TRUSTED_VERBATIM_KEY)),
+        Some(&json!(true))
+    );
+
+    // Marking twice is idempotent and preserves unrelated metadata.
+    result.raw.as_mut().unwrap()["other"] = json!("kept");
+    result.mark_trusted_verbatim();
+    assert!(result.is_trusted_verbatim());
+    assert_eq!(result.raw.as_ref().unwrap()["other"], json!("kept"));
+}
+
+#[test]
+fn unrelated_raw_metadata_never_sets_the_flag() {
+    // The opt-in must not be trippable by a tool that happens to return raw
+    // metadata — including a value at the key that is not `true`.
+    let with_other = ToolResult {
+        call_id: "c".into(),
+        name: "t".into(),
+        content: "x".into(),
+        raw: Some(json!({ "rows": 3 })),
+        error: None,
+        elapsed_ms: 0,
+    };
+    assert!(!with_other.is_trusted_verbatim());
+
+    let wrong_type = ToolResult {
+        raw: Some(json!({ TRUSTED_VERBATIM_KEY: "yes" })),
+        ..with_other.clone()
+    };
+    assert!(!wrong_type.is_trusted_verbatim());
+
+    let not_an_object = ToolResult {
+        raw: Some(json!("opaque")),
+        ..with_other
+    };
+    assert!(!not_an_object.is_trusted_verbatim());
+}

--- a/src/harness/tool/types.rs
+++ b/src/harness/tool/types.rs
@@ -109,6 +109,48 @@ pub struct ToolResult {
     pub elapsed_ms: u64,
 }
 
+/// `raw` key under which [`ToolResult::mark_trusted_verbatim`] records the
+/// request that this result reach the model byte-for-byte.
+///
+/// Kept in `raw` rather than as a dedicated field so the opt-in costs nothing
+/// for the results that never use it, and so a host can round-trip the flag
+/// through its own serialisation without a schema change.
+pub const TRUSTED_VERBATIM_KEY: &str = "trusted_verbatim";
+
+impl ToolResult {
+    /// Asks hosts to deliver this result's content to the model unchanged.
+    ///
+    /// A host is free to summarise, truncate, batch, or re-frame tool output —
+    /// and usually should. This marks the results where that is not safe: an
+    /// input schema whose argument names the model must copy exactly, a
+    /// signature, a diff. Reshaping those yields content that still reads well
+    /// and is wrong.
+    ///
+    /// Advisory: the crate carries the flag to [`super::super::message::ToolMessage`]
+    /// via [`crate::harness::message::Message::tool_from_result`]; honouring it
+    /// is the host's job.
+    pub fn mark_trusted_verbatim(&mut self) {
+        let raw = self
+            .raw
+            .get_or_insert_with(|| Value::Object(Default::default()));
+        if let Some(map) = raw.as_object_mut() {
+            map.insert(TRUSTED_VERBATIM_KEY.to_string(), Value::Bool(true));
+        }
+    }
+
+    /// Whether [`Self::mark_trusted_verbatim`] was set on this result.
+    ///
+    /// `false` when `raw` is absent, is not an object, or holds anything other
+    /// than `true` — an opt-in that cannot be tripped by unrelated metadata.
+    pub fn is_trusted_verbatim(&self) -> bool {
+        self.raw
+            .as_ref()
+            .and_then(|raw| raw.get(TRUSTED_VERBATIM_KEY))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+}
+
 /// Live run context visible to a tool invoked by an agent loop.
 ///
 /// The legacy [`Tool::call`] entry point remains available for direct calls and

--- a/src/harness/tool/types.rs
+++ b/src/harness/tool/types.rs
@@ -129,12 +129,29 @@ impl ToolResult {
     /// Advisory: the crate carries the flag to [`super::super::message::ToolMessage`]
     /// via [`crate::harness::message::Message::tool_from_result`]; honouring it
     /// is the host's job.
-    pub fn mark_trusted_verbatim(&mut self) {
+    /// # Returns
+    ///
+    /// `true` when the request was recorded. `false` when [`Self::raw`] already
+    /// holds a **non-object** value (a string, array, or number): the flag lives
+    /// under a key in `raw`, and a scalar has nowhere to put a key. The crate
+    /// will not clobber a value the tool deliberately set, so the request is
+    /// refused rather than silently lost — make room by moving that value under
+    /// a key of its own, then call this again.
+    ///
+    /// `#[must_use]` precisely because the failure is otherwise invisible:
+    /// [`Self::is_trusted_verbatim`] would keep answering `false` with no
+    /// diagnostic, and the caller would believe the opt-in took effect.
+    #[must_use = "returns false when `raw` holds a non-object value and the request was refused"]
+    pub fn mark_trusted_verbatim(&mut self) -> bool {
         let raw = self
             .raw
             .get_or_insert_with(|| Value::Object(Default::default()));
-        if let Some(map) = raw.as_object_mut() {
-            map.insert(TRUSTED_VERBATIM_KEY.to_string(), Value::Bool(true));
+        match raw.as_object_mut() {
+            Some(map) => {
+                map.insert(TRUSTED_VERBATIM_KEY.to_string(), Value::Bool(true));
+                true
+            }
+            None => false,
         }
     }
 


### PR DESCRIPTION
## Summary

A `ToolResult` can hold structured metadata in `raw`, but folding it into the transcript goes through `Message::tool(call_id, content)`, which keeps only those two fields. Everything else is dropped at that boundary, so a host has no way to learn anything the tool wanted to say about its own output.

That matters for one property in particular: **whether the content may be reshaped.** Hosts summarise, truncate, batch, and re-frame tool output, and usually should — but some results are only useful intact. An input schema whose argument names the model must copy exactly, a signature, a diff: rewriting those produces content that still reads well and is wrong. Today a host can only guess from the text, and guessing wrong is silent.

This adds an explicit, opt-in request that survives the fold:

- `ToolResult::mark_trusted_verbatim()` / `is_trusted_verbatim()`, backed by `raw` under a new `TRUSTED_VERBATIM_KEY`, so the opt-in costs nothing for results that never use it and round-trips through a host's own serialization.
- `ToolMessage.trusted_verbatim: bool`, `#[serde(default)]`.
- `Message::tool_from_result(&ToolResult)`, which carries the flag across. The agent-loop fold site (`harness/agent_loop/tools.rs`) now uses it.

The flag is **advisory**: the crate transports it, honouring it is the host's job.

### Why `raw`-backed rather than a field on `ToolResult`

`ToolResult` is constructed all over user code; adding a required field would be a breaking change for every literal, and an `Option`/`Default` field would still widen a struct that most results never need. `raw` already exists for exactly this kind of side-band metadata, and a host that serializes results through its own types round-trips the flag with no schema change.

### Concrete motivation

Downstream (OpenHuman) delivers a tool's full input schema to the model as a recoverable tool error, then verifies on the next turn that the model can still see it. The host's own `after_tool` stages summarise and whitespace-collapse tool output; without a way to say "not this one", the delivered schema arrives reshaped and the verification can never match. That is a host problem to solve, but it needs one bit of information the crate currently discards.

## API Or Behavior Changes

**Additive only.**

- New: `TRUSTED_VERBATIM_KEY`, `ToolResult::mark_trusted_verbatim`, `ToolResult::is_trusted_verbatim`, `ToolMessage.trusted_verbatim`, `Message::tool_from_result`.
- `Message::tool` is unchanged and still yields `trusted_verbatim: false`, so nothing moves for callers that do not opt in.
- `ToolMessage` gains a field. Struct-literal construction of `ToolMessage` outside the crate would need the new field; `Message::tool` / `tool_from_result` are unaffected.
- Wire/serde: `#[serde(default)]` means transcripts persisted before this field still deserialize, reading as not-trusted.
- Behavior change in the agent loop: the folded message now reflects the result's flag instead of always `false`. No effect unless a tool opts in.

## Tests

All run locally on this branch:

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test` — 1205 lib tests + suites, 0 failed
- [x] `cargo test --all-features` — 1277 lib tests + suites, 0 failed
- [x] `cargo run --example basic_graph`

New coverage:

- `trusted_verbatim_is_opt_in_and_round_trips_through_raw` — off by default; idempotent marking preserves unrelated `raw` metadata.
- `unrelated_raw_metadata_never_sets_the_flag` — a non-boolean value at the key, and a non-object `raw`, both read as `false`, so the opt-in cannot be tripped by accident.
- `tool_from_result_carries_trusted_verbatim_and_tool_does_not` — an unmarked result folds identically to `Message::tool`; a marked one carries the flag.
- `a_transcript_stored_before_the_flag_existed_still_deserializes` — the `serde(default)` path.

## Documentation

Rustdoc on every new item, including why the flag is advisory and why it lives in `raw`. No wiki page seemed warranted for a single additive field — happy to add one if you would prefer it documented there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool outputs can be opt-in marked for byte-for-byte preservation back to the model.
  - Transcript entries now retain whether a tool output was marked as trusted verbatim.
  - Legacy transcripts remain compatible, defaulting to untrusted tool outputs.

- **Bug Fixes**
  - Completed tool calls now record tool result content and metadata with full fidelity.

- **Tests**
  - Added unit tests covering trust-flag behavior, wire/JSON compatibility, serialization rules, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->