### PR TITLE
feat(todos): expose board lifecycle for host integrations

### DIFF
--- a/src/graph/todos/store.rs
+++ b/src/graph/todos/store.rs
@@ -58,13 +58,33 @@ fn validate_thread_id(thread_id: &str) -> Result<String> {
 
 /// Loads the raw cards for `thread_id` (empty when the thread has no board).
 async fn load_cards(store: &Arc<dyn Store>, thread_id: &str) -> Result<Vec<TaskBoardCard>> {
-    match store.get(TODOS_NAMESPACE, &key(thread_id)).await? {
-        Some(value) => {
-            let board: TaskBoard = serde_json::from_value(value)?;
-            Ok(board.cards)
-        }
-        None => Ok(Vec::new()),
+    Ok(get(store, thread_id)
+        .await?
+        .map(|board| board.cards)
+        .unwrap_or_default())
+}
+
+/// Load a board without normalising it, preserving the distinction between an
+/// absent board and a present empty board.
+pub async fn get(store: &Arc<dyn Store>, thread_id: &str) -> Result<Option<TaskBoard>> {
+    let thread_id = validate_thread_id(thread_id)?;
+    match store.get(TODOS_NAMESPACE, &key(&thread_id)).await? {
+        Some(value) => Ok(Some(serde_json::from_value(value)?)),
+        None => Ok(None),
     }
+}
+
+/// Delete a board value outright, returning whether one was present.
+///
+/// This differs from [`clear`], which persists a present, empty board.
+pub async fn delete(store: &Arc<dyn Store>, thread_id: &str) -> Result<bool> {
+    let thread_id = validate_thread_id(thread_id)?;
+    let board_key = key(&thread_id);
+    let existed = store.get(TODOS_NAMESPACE, &board_key).await?.is_some();
+    if existed {
+        store.delete(TODOS_NAMESPACE, &board_key).await?;
+    }
+    Ok(existed)
 }
 
 /// Normalises and persists `cards` for `thread_id`, returning the normalised set.

--- a/src/graph/todos/store.rs
+++ b/src/graph/todos/store.rs
@@ -87,6 +87,25 @@ pub async fn delete(store: &Arc<dyn Store>, thread_id: &str) -> Result<bool> {
     Ok(existed)
 }
 
+/// Import a board only when its thread has no stored value.
+///
+/// The existence check and write share the normal per-thread lock. Existing
+/// values are left untouched even when they use a newer or undecodable schema,
+/// which makes this suitable for one-time legacy migrations.
+pub async fn import_if_absent(store: &Arc<dyn Store>, board: TaskBoard) -> Result<bool> {
+    let thread_id = validate_thread_id(&board.thread_id)?;
+    let lock = thread_lock(&thread_id);
+    let _guard = lock.lock().await;
+    let board_key = key(&thread_id);
+    if store.get(TODOS_NAMESPACE, &board_key).await?.is_some() {
+        return Ok(false);
+    }
+    store
+        .put(TODOS_NAMESPACE, &board_key, serde_json::to_value(board)?)
+        .await?;
+    Ok(true)
+}
+
 /// Normalises and persists `cards` for `thread_id`, returning the normalised set.
 async fn save_cards(
     store: &Arc<dyn Store>,

--- a/src/graph/todos/test.rs
+++ b/src/graph/todos/test.rs
@@ -158,6 +158,20 @@ mod store_tests {
     }
 
     #[tokio::test]
+    async fn get_and_delete_preserve_absent_vs_empty() {
+        let s = store();
+        assert!(store::get(&s, " t ").await.unwrap().is_none());
+
+        store::clear(&s, "t").await.unwrap();
+        let board = store::get(&s, "t").await.unwrap().expect("present board");
+        assert!(board.cards.is_empty());
+
+        assert!(store::delete(&s, "t").await.unwrap());
+        assert!(store::get(&s, "t").await.unwrap().is_none());
+        assert!(!store::delete(&s, "t").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn add_rejects_empty_content_and_blank_thread() {
         let s = store();
         assert!(

--- a/src/graph/todos/test.rs
+++ b/src/graph/todos/test.rs
@@ -176,12 +176,11 @@ mod store_tests {
         let s = store();
         let board = super::super::types::TaskBoard::empty(" t ");
         assert!(store::import_if_absent(&s, board).await.unwrap());
-        assert!(!store::import_if_absent(
-            &s,
-            super::super::types::TaskBoard::empty("t")
-        )
-        .await
-        .unwrap());
+        assert!(
+            !store::import_if_absent(&s, super::super::types::TaskBoard::empty("t"))
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/graph/todos/test.rs
+++ b/src/graph/todos/test.rs
@@ -172,6 +172,19 @@ mod store_tests {
     }
 
     #[tokio::test]
+    async fn import_if_absent_never_overwrites_an_existing_value() {
+        let s = store();
+        let board = super::super::types::TaskBoard::empty(" t ");
+        assert!(store::import_if_absent(&s, board).await.unwrap());
+        assert!(!store::import_if_absent(
+            &s,
+            super::super::types::TaskBoard::empty("t")
+        )
+        .await
+        .unwrap());
+    }
+
+    #[tokio::test]
     async fn add_rejects_empty_content_and_blank_thread() {
         let s = store();
         assert!(


### PR DESCRIPTION
## Summary

Expose the raw task-board lifecycle needed by host applications and add a non-destructive legacy import primitive.

## API Or Behavior Changes

- Add `graph::todos::store::get` to preserve absent-vs-empty board semantics.
- Add `graph::todos::store::delete` for removing a board value outright.
- Add `graph::todos::store::import_if_absent` for atomic, non-destructive legacy migration.

## Tests

- [x] `cargo fmt --check`
- [x] N/A: full clippy is covered by CI; focused change was validated with the todo store suite.
- [x] N/A: all-features clippy is covered by CI; no feature-gated code changed.
- [x] N/A: full build is covered by CI; focused test build completed locally.
- [x] N/A: all-features build is covered by CI; no feature-gated code changed.
- [x] `cargo test graph::todos::test::store_tests --lib` (11 passed)
- [x] N/A: all-features test is covered by CI; no feature-gated code changed.

## Documentation

Public functions include rustdoc; no separate guide changes are needed.