### PR TITLE
fix(providers): harden local runtime presets

### DIFF
--- a/src/harness/embeddings/mod.rs
+++ b/src/harness/embeddings/mod.rs
@@ -21,6 +21,9 @@
 //!
 //! [`OpenAiEmbeddingModel`] adds a hosted provider backed by the OpenAI
 //! embeddings endpoint (always compiled).
+//! [`OllamaEmbeddingModel::embed_discovering_dimensions`] handles
+//! provider-managed local models whose vector width is unknown without exposing
+//! an adapter whose dimensional identity can change after construction.
 //!
 //! The design mirrors LangChain's separation of concerns: chat models generate
 //! messages, embedding models generate vectors, vector stores search vectors,

--- a/src/harness/embeddings/ollama.rs
+++ b/src/harness/embeddings/ollama.rs
@@ -2,6 +2,10 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use super::EmbeddingModel;
 use crate::error::{Result, TinyAgentsError};
@@ -17,7 +21,7 @@ pub struct OllamaEmbeddingModel {
     client: reqwest::Client,
     base_url: String,
     model: String,
-    dimensions: usize,
+    dimensions: Arc<AtomicUsize>,
     options: Option<OllamaOptions>,
 }
 
@@ -27,11 +31,22 @@ impl OllamaEmbeddingModel {
             client: reqwest::Client::new(),
             base_url: normalize_base_url(base_url)?,
             model: normalize_model(model)?,
-            dimensions: if dimensions == 0 {
+            dimensions: Arc::new(AtomicUsize::new(if dimensions == 0 {
                 DEFAULT_OLLAMA_DIMENSIONS
             } else {
                 dimensions
-            },
+            })),
+            options: None,
+        })
+    }
+
+    /// Builds a model that learns its vector width from the first response.
+    pub fn try_new_dynamic(base_url: &str, model: &str) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::new(),
+            base_url: normalize_base_url(base_url)?,
+            model: normalize_model(model)?,
+            dimensions: Arc::new(AtomicUsize::new(0)),
             options: None,
         })
     }
@@ -135,10 +150,24 @@ impl OllamaEmbeddingModel {
     }
 
     fn validate_dimensions(&self, index: usize, vector: &[f32]) -> Result<()> {
-        if vector.len() != self.dimensions {
+        if vector.is_empty() {
+            return Err(TinyAgentsError::Embedding(format!(
+                "ollama embed returned an empty vector at index {index}"
+            )));
+        }
+        let expected = match self.dimensions.compare_exchange(
+            0,
+            vector.len(),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => vector.len(),
+            Err(expected) => expected,
+        };
+        if vector.len() != expected {
             return Err(TinyAgentsError::Embedding(format!(
                 "ollama embed dimension mismatch at index {index}: expected {}, got {}",
-                self.dimensions,
+                expected,
                 vector.len()
             )));
         }
@@ -284,7 +313,7 @@ impl EmbeddingModel for OllamaEmbeddingModel {
     }
 
     fn dimensions(&self) -> usize {
-        self.dimensions
+        self.dimensions.load(Ordering::Acquire)
     }
 
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
@@ -374,6 +403,15 @@ mod tests {
         assert!(OllamaEmbeddingModel::try_new("http://host:11434/api", "m", 1).is_err());
         assert!(OllamaEmbeddingModel::try_new("http://user:p@host:11434", "m", 1).is_err());
         assert!(OllamaEmbeddingModel::try_new("http://host:11434", "local-v1", 1).is_err());
+    }
+
+    #[test]
+    fn dynamic_dimensions_are_learned_and_enforced() {
+        let model = OllamaEmbeddingModel::try_new_dynamic("http://host:11434", "custom").unwrap();
+        assert_eq!(model.dimensions(), 0);
+        model.validate_dimensions(0, &[0.0; 7]).unwrap();
+        assert_eq!(model.dimensions(), 7);
+        assert!(model.validate_dimensions(1, &[0.0; 8]).is_err());
     }
 
     #[tokio::test]

--- a/src/harness/embeddings/ollama.rs
+++ b/src/harness/embeddings/ollama.rs
@@ -40,8 +40,7 @@ impl OllamaEmbeddingModel {
         })
     }
 
-    /// Builds a model that learns its vector width from the first response.
-    pub fn try_new_dynamic(base_url: &str, model: &str) -> Result<Self> {
+    fn try_new_unresolved(base_url: &str, model: &str) -> Result<Self> {
         Ok(Self {
             client: reqwest::Client::new(),
             base_url: normalize_base_url(base_url)?,
@@ -49,6 +48,26 @@ impl OllamaEmbeddingModel {
             dimensions: Arc::new(AtomicUsize::new(0)),
             options: None,
         })
+    }
+
+    /// Embeds text for a model whose vector width is not known in advance.
+    ///
+    /// The temporary adapter learns and validates the response width internally;
+    /// callers receive only the resolved width and vectors, so no model with an
+    /// unstable `dimensions()` or signature escapes this operation.
+    pub async fn embed_discovering_dimensions(
+        base_url: &str,
+        model: &str,
+        client: reqwest::Client,
+        texts: &[String],
+        num_ctx: u32,
+        num_batch: u32,
+    ) -> Result<(usize, Vec<Vec<f32>>)> {
+        let adapter = Self::try_new_unresolved(base_url, model)?
+            .with_client(client)
+            .with_context_options(num_ctx, num_batch);
+        let vectors = adapter.embed(texts).await?;
+        Ok((adapter.dimensions(), vectors))
     }
 
     pub fn new(base_url: &str, model: &str, dimensions: usize) -> Self {
@@ -406,8 +425,9 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_dimensions_are_learned_and_enforced() {
-        let model = OllamaEmbeddingModel::try_new_dynamic("http://host:11434", "custom").unwrap();
+    fn unresolved_dimensions_are_learned_and_enforced_internally() {
+        let model =
+            OllamaEmbeddingModel::try_new_unresolved("http://host:11434", "custom").unwrap();
         assert_eq!(model.dimensions(), 0);
         model.validate_dimensions(0, &[0.0; 7]).unwrap();
         assert_eq!(model.dimensions(), 7);

--- a/src/harness/embeddings/ollama.rs
+++ b/src/harness/embeddings/ollama.rs
@@ -63,6 +63,12 @@ impl OllamaEmbeddingModel {
         num_ctx: u32,
         num_batch: u32,
     ) -> Result<(usize, Vec<Vec<f32>>)> {
+        if !texts.iter().any(|text| !text.trim().is_empty()) {
+            return Err(TinyAgentsError::Validation(
+                "dynamic embedding dimension discovery requires at least one nonblank input"
+                    .to_string(),
+            ));
+        }
         let adapter = Self::try_new_unresolved(base_url, model)?
             .with_client(client)
             .with_context_options(num_ctx, num_batch);
@@ -432,6 +438,21 @@ mod tests {
         model.validate_dimensions(0, &[0.0; 7]).unwrap();
         assert_eq!(model.dimensions(), 7);
         assert!(model.validate_dimensions(1, &[0.0; 8]).is_err());
+    }
+
+    #[tokio::test]
+    async fn dynamic_discovery_rejects_blank_only_batches() {
+        let error = OllamaEmbeddingModel::embed_discovering_dimensions(
+            "http://host:11434",
+            "custom",
+            reqwest::Client::new(),
+            &[" ".to_string()],
+            1,
+            1,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("nonblank"));
     }
 
     #[tokio::test]

--- a/src/harness/embeddings/ollama.rs
+++ b/src/harness/embeddings/ollama.rs
@@ -40,7 +40,7 @@ impl OllamaEmbeddingModel {
         })
     }
 
-    fn try_new_unresolved(base_url: &str, model: &str) -> Result<Self> {
+    pub(super) fn try_new_unresolved(base_url: &str, model: &str) -> Result<Self> {
         Ok(Self {
             client: reqwest::Client::new(),
             base_url: normalize_base_url(base_url)?,
@@ -174,7 +174,7 @@ impl OllamaEmbeddingModel {
         Ok(output)
     }
 
-    fn validate_dimensions(&self, index: usize, vector: &[f32]) -> Result<()> {
+    pub(super) fn validate_dimensions(&self, index: usize, vector: &[f32]) -> Result<()> {
         if vector.is_empty() {
             return Err(TinyAgentsError::Embedding(format!(
                 "ollama embed returned an empty vector at index {index}"
@@ -428,31 +428,6 @@ mod tests {
         assert!(OllamaEmbeddingModel::try_new("http://host:11434/api", "m", 1).is_err());
         assert!(OllamaEmbeddingModel::try_new("http://user:p@host:11434", "m", 1).is_err());
         assert!(OllamaEmbeddingModel::try_new("http://host:11434", "local-v1", 1).is_err());
-    }
-
-    #[test]
-    fn unresolved_dimensions_are_learned_and_enforced_internally() {
-        let model =
-            OllamaEmbeddingModel::try_new_unresolved("http://host:11434", "custom").unwrap();
-        assert_eq!(model.dimensions(), 0);
-        model.validate_dimensions(0, &[0.0; 7]).unwrap();
-        assert_eq!(model.dimensions(), 7);
-        assert!(model.validate_dimensions(1, &[0.0; 8]).is_err());
-    }
-
-    #[tokio::test]
-    async fn dynamic_discovery_rejects_blank_only_batches() {
-        let error = OllamaEmbeddingModel::embed_discovering_dimensions(
-            "http://host:11434",
-            "custom",
-            reqwest::Client::new(),
-            &[" ".to_string()],
-            1,
-            1,
-        )
-        .await
-        .unwrap_err();
-        assert!(error.to_string().contains("nonblank"));
     }
 
     #[tokio::test]

--- a/src/harness/embeddings/test.rs
+++ b/src/harness/embeddings/test.rs
@@ -69,6 +69,30 @@ async fn mock_model_batches_in_order() {
     }
 }
 
+#[test]
+fn unresolved_ollama_dimensions_are_learned_and_enforced_internally() {
+    let model = OllamaEmbeddingModel::try_new_unresolved("http://host:11434", "custom").unwrap();
+    assert_eq!(model.dimensions(), 0);
+    model.validate_dimensions(0, &[0.0; 7]).unwrap();
+    assert_eq!(model.dimensions(), 7);
+    assert!(model.validate_dimensions(1, &[0.0; 8]).is_err());
+}
+
+#[tokio::test]
+async fn dynamic_ollama_discovery_rejects_blank_only_batches() {
+    let error = OllamaEmbeddingModel::embed_discovering_dimensions(
+        "http://host:11434",
+        "custom",
+        reqwest::Client::new(),
+        &[" ".to_string()],
+        1,
+        1,
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("nonblank"));
+}
+
 #[tokio::test]
 async fn mock_model_empty_input_returns_empty() {
     let model = MockEmbeddingModel::new(8);

--- a/src/harness/providers/openai/README.md
+++ b/src/harness/providers/openai/README.md
@@ -37,12 +37,20 @@ of the rest of the harness.
 - `OpenAiModel::from_spec(spec, api_key)` / `from_spec_env(spec)` — build from a
   `providers::ProviderSpec` (base URL, default model, provider id already
   resolved).
-- **Compatibility presets** — thin wrappers over `new` + `with_base_url` +
-  `with_model` for endpoints that speak the same Chat Completions wire format:
+- **Compatibility presets** for hosted endpoints that speak the same Chat
+  Completions wire format:
   `compatible(base_url, model)` / `compatible_provider(..)` (arbitrary
   endpoint), `deepseek`, `anthropic` (compat endpoint, not the native
-  Anthropic API), `groq`, `xai`, `openrouter`, `together`, `mistral`, `ollama`.
+  Anthropic API), `groq`, `xai`, `openrouter`, `together`, and `mistral`.
   Override the preset's default model with `.with_model(..)`.
+- **Local-runtime presets** — `ollama()`, fallible
+  `ollama_at(base_url, model)`, and fallible
+  `lm_studio(base_url, api_key, model)`. These normalize a server or
+  `/v1/models` URL to its `/v1` API base and use conservative local defaults:
+  no native or parallel tool calls, no streamed tool chunks, and no image
+  input. Ollama sends no authorization header; LM Studio sends a bearer token
+  only when its API key is non-empty. `ProviderSpec::Ollama` uses the same
+  defaults.
 
 Accessors: `.model()`, `.provider()`, `.base_url()`.
 

--- a/src/harness/providers/openai/README.md
+++ b/src/harness/providers/openai/README.md
@@ -48,9 +48,10 @@ of the rest of the harness.
   `lm_studio(base_url, api_key, model)`. These normalize a server or
   `/v1/models` URL to its `/v1` API base and use conservative local defaults:
   no native or parallel tool calls, no streamed tool chunks, and no image
-  input. Ollama sends no authorization header; LM Studio sends a bearer token
-  only when its API key is non-empty. `ProviderSpec::Ollama` uses the same
-  defaults.
+  input. `ollama()` and `ollama_at()` send no authorization header; LM Studio
+  sends a bearer token only when its API key is non-empty.
+  `ProviderSpec::Ollama` uses the same defaults unless `requires_api_key` is
+  enabled, in which case it sends a bearer token.
 
 Accessors: `.model()`, `.provider()`, `.base_url()`.
 

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -671,6 +671,14 @@ fn local_runtime_presets_normalize_endpoint_and_model() {
     assert!(!profile.modalities.image_in);
 
     assert!(OpenAiModel::ollama_at("http://[::1", "qwen3").is_err());
+    assert!(OpenAiModel::ollama_at("ftp://host", "qwen3").is_err());
+
+    let caller_client = OpenAiModel::ollama().with_client(reqwest::Client::new());
+    assert_eq!(caller_client.effective_request_timeout(None, false), None);
+    assert_eq!(
+        caller_client.effective_request_timeout(Some(25), false),
+        Some(std::time::Duration::from_millis(25))
+    );
 }
 
 #[test]

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -639,29 +639,38 @@ fn compatible_presets_set_base_url_and_default_model() {
 
 #[test]
 fn local_runtime_presets_normalize_endpoint_and_model() {
-    let ollama = OpenAiModel::ollama_at("127.0.0.1:11434/", "qwen3:8b");
+    let ollama = OpenAiModel::ollama_at("127.0.0.1:11434/", "qwen3:8b").unwrap();
     assert_eq!(ollama.provider(), "ollama");
     assert_eq!(ollama.base_url(), "http://127.0.0.1:11434/v1");
     assert_eq!(ollama.model(), "qwen3:8b");
 
-    let lm_studio = OpenAiModel::lm_studio("http://127.0.0.1:1234/v1/models", "", "local-model");
+    let lm_studio =
+        OpenAiModel::lm_studio("http://127.0.0.1:1234/v1/models", "", "local-model").unwrap();
     assert_eq!(lm_studio.provider(), "lm_studio");
     assert_eq!(lm_studio.base_url(), "http://127.0.0.1:1234/v1");
     assert_eq!(lm_studio.model(), "local-model");
 
     assert_eq!(
-        OpenAiModel::ollama_at("http://models", "qwen3").base_url(),
+        OpenAiModel::ollama_at("http://models", "qwen3")
+            .unwrap()
+            .base_url(),
         "http://models/v1"
     );
     assert_eq!(
-        OpenAiModel::ollama_at("http://v1", "qwen3").base_url(),
+        OpenAiModel::ollama_at("http://v1", "qwen3")
+            .unwrap()
+            .base_url(),
         "http://v1/v1"
     );
 
     let overridden = OpenAiModel::ollama().with_model("qwen3:8b");
     let profile = <OpenAiModel as ChatModel<()>>::profile(&overridden).unwrap();
     assert!(!profile.tool_calling);
+    assert!(!profile.parallel_tool_calls);
+    assert!(!profile.streaming_tool_chunks);
     assert!(!profile.modalities.image_in);
+
+    assert!(OpenAiModel::ollama_at("http://[::1", "qwen3").is_err());
 }
 
 #[test]

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -693,6 +693,14 @@ fn provider_spec_builds_compatible_model() {
     assert!(!profile.parallel_tool_calls);
     assert!(!profile.streaming_tool_chunks);
     assert!(!profile.modalities.image_in);
+
+    let mut authenticated = ProviderSpec::for_kind(ProviderKind::Ollama);
+    authenticated.requires_api_key = true;
+    let authenticated = OpenAiModel::from_spec(authenticated, "proxy-secret").unwrap();
+    assert_eq!(
+        authenticated.auth_config(),
+        ("proxy-secret", &AuthStyle::Bearer)
+    );
 }
 
 #[test]

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -688,6 +688,11 @@ fn provider_spec_builds_compatible_model() {
             .as_deref(),
         Some("ollama")
     );
+    let profile = <OpenAiModel as ChatModel<()>>::profile(&model).unwrap();
+    assert!(!profile.tool_calling);
+    assert!(!profile.parallel_tool_calls);
+    assert!(!profile.streaming_tool_chunks);
+    assert!(!profile.modalities.image_in);
 }
 
 #[test]

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -638,6 +638,14 @@ impl OpenAiModel {
                 "provider spec base_url must not be empty".to_string(),
             ));
         }
+        if spec.kind == crate::harness::providers::ProviderKind::Ollama {
+            return Ok(Self::local_runtime(
+                &spec.provider,
+                normalize_local_v1_base_url(spec.base_url, "http://localhost:11434")?,
+                "",
+                spec.model,
+            ));
+        }
         Ok(Self::compatible_provider(
             spec.provider,
             api_key,

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -628,6 +628,7 @@ impl OpenAiModel {
     /// Builds an OpenAI-compatible model from a provider spec and explicit API
     /// key.
     pub fn from_spec(spec: ProviderSpec, api_key: impl Into<String>) -> Result<Self> {
+        let api_key = api_key.into();
         if spec.model.trim().is_empty() {
             return Err(TinyAgentsError::Validation(
                 "provider spec model must not be empty".to_string(),
@@ -639,12 +640,18 @@ impl OpenAiModel {
             ));
         }
         if spec.kind == crate::harness::providers::ProviderKind::Ollama {
+            let auth = if spec.requires_api_key {
+                AuthStyle::Bearer
+            } else {
+                AuthStyle::None
+            };
             return Ok(Self::local_runtime(
                 &spec.provider,
                 normalize_local_v1_base_url(spec.base_url, "http://localhost:11434")?,
-                "",
+                api_key,
                 spec.model,
-            ));
+            )
+            .with_auth_style(auth));
         }
         Ok(Self::compatible_provider(
             spec.provider,
@@ -872,6 +879,11 @@ impl OpenAiModel {
     fn lock_local_capabilities(mut self) -> Self {
         self.local_capabilities_locked = true;
         self
+    }
+
+    #[cfg(test)]
+    pub(super) fn auth_config(&self) -> (&str, &AuthStyle) {
+        (&self.api_key, &self.auth)
     }
 
     /// Returns the default model id this instance will request.

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -545,12 +545,19 @@ impl OpenAiModel {
     /// Overrides the default model id.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
-        let local_capabilities = self
-            .local_capabilities_locked
-            .then_some((self.profile.tool_calling, self.profile.modalities.image_in));
+        let local_capabilities = self.local_capabilities_locked.then_some((
+            self.profile.tool_calling,
+            self.profile.parallel_tool_calls,
+            self.profile.streaming_tool_chunks,
+            self.profile.modalities.image_in,
+        ));
         self.profile = derive_profile(&self.provider, &self.model);
-        if let Some((tool_calling, image_in)) = local_capabilities {
+        if let Some((tool_calling, parallel_tool_calls, streaming_tool_chunks, image_in)) =
+            local_capabilities
+        {
             self.profile.tool_calling = tool_calling;
+            self.profile.parallel_tool_calls = parallel_tool_calls;
+            self.profile.streaming_tool_chunks = streaming_tool_chunks;
             self.profile.modalities.image_in = image_in;
         }
         self
@@ -559,12 +566,19 @@ impl OpenAiModel {
     /// Overrides the provider family id used in profiles and normalized errors.
     pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
         self.provider = provider.into();
-        let local_capabilities = self
-            .local_capabilities_locked
-            .then_some((self.profile.tool_calling, self.profile.modalities.image_in));
+        let local_capabilities = self.local_capabilities_locked.then_some((
+            self.profile.tool_calling,
+            self.profile.parallel_tool_calls,
+            self.profile.streaming_tool_chunks,
+            self.profile.modalities.image_in,
+        ));
         self.profile = derive_profile(&self.provider, &self.model);
-        if let Some((tool_calling, image_in)) = local_capabilities {
+        if let Some((tool_calling, parallel_tool_calls, streaming_tool_chunks, image_in)) =
+            local_capabilities
+        {
             self.profile.tool_calling = tool_calling;
+            self.profile.parallel_tool_calls = parallel_tool_calls;
+            self.profile.streaming_tool_chunks = streaming_tool_chunks;
             self.profile.modalities.image_in = image_in;
         }
         self
@@ -797,16 +811,17 @@ impl OpenAiModel {
     /// `llama3.2`.
     pub fn ollama() -> Self {
         Self::ollama_at("http://localhost:11434", "llama3.2")
+            .expect("the built-in Ollama URL is valid")
     }
 
     /// An Ollama server exposed through its OpenAI-compatible HTTP API.
-    pub fn ollama_at(base_url: impl Into<String>, model: impl Into<String>) -> Self {
-        Self::local_runtime(
+    pub fn ollama_at(base_url: impl Into<String>, model: impl Into<String>) -> Result<Self> {
+        Ok(Self::local_runtime(
             "ollama",
-            normalize_local_v1_base_url(base_url.into(), "http://localhost:11434"),
+            normalize_local_v1_base_url(base_url.into(), "http://localhost:11434")?,
             "",
             model,
-        )
+        ))
     }
 
     /// An LM Studio server exposed through its OpenAI-compatible HTTP API.
@@ -817,20 +832,20 @@ impl OpenAiModel {
         base_url: impl Into<String>,
         api_key: impl Into<String>,
         model: impl Into<String>,
-    ) -> Self {
+    ) -> Result<Self> {
         let api_key = api_key.into();
         let auth = if api_key.trim().is_empty() {
             AuthStyle::None
         } else {
             AuthStyle::Bearer
         };
-        Self::local_runtime(
+        Ok(Self::local_runtime(
             "lm_studio",
-            normalize_local_v1_base_url(base_url.into(), "http://localhost:1234"),
+            normalize_local_v1_base_url(base_url.into(), "http://localhost:1234")?,
             api_key,
             model,
         )
-        .with_auth_style(auth)
+        .with_auth_style(auth))
     }
 
     fn local_runtime(
@@ -1278,7 +1293,7 @@ impl OpenAiModel {
     }
 }
 
-fn normalize_local_v1_base_url(raw: String, default_root: &str) -> String {
+fn normalize_local_v1_base_url(raw: String, default_root: &str) -> Result<String> {
     let trimmed = raw.trim().trim_end_matches('/');
     let root = if trimmed.is_empty() {
         default_root.to_owned()
@@ -1287,8 +1302,9 @@ fn normalize_local_v1_base_url(raw: String, default_root: &str) -> String {
     } else {
         format!("http://{trimmed}")
     };
-    let mut url =
-        reqwest::Url::parse(&root).expect("local runtime URL is normalized with a scheme");
+    let mut url = reqwest::Url::parse(&root).map_err(|error| {
+        TinyAgentsError::Validation(format!("invalid local runtime URL `{root}`: {error}"))
+    })?;
     let mut segments: Vec<&str> = url
         .path()
         .split('/')
@@ -1305,7 +1321,7 @@ fn normalize_local_v1_base_url(raw: String, default_root: &str) -> String {
     url.set_path(&format!("/{}", segments.join("/")));
     url.set_query(None);
     url.set_fragment(None);
-    url.to_string().trim_end_matches('/').to_owned()
+    Ok(url.to_string().trim_end_matches('/').to_owned())
 }
 
 /// Request-shape degradations to apply when building an OpenAI wire body.

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -393,6 +393,13 @@ impl OpenAiModel {
         self
     }
 
+    /// Reuses a caller-configured HTTP client, including its connection pool,
+    /// proxy settings, and request deadlines.
+    pub fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
+    }
+
     /// Overrides how the API credential is sent (default [`AuthStyle::Bearer`]).
     ///
     /// Use this for OpenAI-compatible endpoints that authenticate with

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -39,6 +39,8 @@ pub enum AuthStyle {
 pub struct OpenAiModel {
     /// Shared HTTP client.
     client: reqwest::Client,
+    /// Whether the client was supplied by the caller and owns default deadlines.
+    caller_owned_client: bool,
     /// API credential; how it is sent is governed by [`Self::auth`].
     api_key: String,
     /// How `api_key` is attached to each request (default [`AuthStyle::Bearer`]).
@@ -317,6 +319,7 @@ impl OpenAiModel {
                 .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
                 .build()
                 .expect("default reqwest client builds"),
+            caller_owned_client: false,
             api_key: api_key.into(),
             auth: AuthStyle::Bearer,
             extra_headers: Vec::new(),
@@ -397,6 +400,7 @@ impl OpenAiModel {
     /// proxy settings, and request deadlines.
     pub fn with_client(mut self, client: reqwest::Client) -> Self {
         self.client = client;
+        self.caller_owned_client = true;
         self
     }
 
@@ -1151,7 +1155,7 @@ impl OpenAiModel {
         url: &str,
     ) -> Result<reqwest::Response> {
         let mut builder = self.authorized(self.client.post(url)).json(body);
-        if let Some(timeout) = request_timeout(timeout_ms, false) {
+        if let Some(timeout) = self.effective_request_timeout(timeout_ms, false) {
             builder = builder.timeout(timeout);
         }
         self.send_checked(builder, "responses request", url).await
@@ -1202,10 +1206,22 @@ impl OpenAiModel {
     ) -> Result<reqwest::Response> {
         let url = format!("{}/chat/completions", self.base_url);
         let mut builder = self.authorized(self.client.post(&url)).json(body);
-        if let Some(timeout) = request_timeout(timeout_ms, streaming) {
+        if let Some(timeout) = self.effective_request_timeout(timeout_ms, streaming) {
             builder = builder.timeout(timeout);
         }
         self.send_checked(builder, what, &url).await
+    }
+
+    pub(super) fn effective_request_timeout(
+        &self,
+        timeout_ms: Option<u64>,
+        streaming: bool,
+    ) -> Option<Duration> {
+        if self.caller_owned_client && timeout_ms.is_none() {
+            None
+        } else {
+            request_timeout(timeout_ms, streaming)
+        }
     }
 
     /// Builds the chat-completions wire body for `request` under the given
@@ -1332,6 +1348,12 @@ fn normalize_local_v1_base_url(raw: String, default_root: &str) -> Result<String
     let mut url = reqwest::Url::parse(&root).map_err(|error| {
         TinyAgentsError::Validation(format!("invalid local runtime URL `{root}`: {error}"))
     })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(TinyAgentsError::Validation(format!(
+            "local runtime URL must use http or https, got `{}`",
+            url.scheme()
+        )));
+    }
     let mut segments: Vec<&str> = url
         .path()
         .split('/')


### PR DESCRIPTION
## Summary

- preserve all conservative local-runtime capability flags across model/provider overrides
- make configurable Ollama and LM Studio constructors return validation errors for invalid URLs
- apply the same Ollama defaults through `ProviderSpec` and document the local presets

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --lib -- -D warnings`
- OpenHuman host `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml -q` against the vendored head

Follow-up to #79 for review feedback received after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic embedding-dimension discovery for local Ollama models.
  - Added support for validating and consistently using learned embedding dimensions.

- **Improvements**
  - Improved local Ollama and LM Studio endpoint configuration and validation.
  - Added clearer handling of authentication and local-runtime capabilities.
  - Improved request-timeout behavior when using custom network clients.

- **Documentation**
  - Clarified hosted OpenAI-compatible and local-runtime configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->