### PR TITLE
fix(todos): serialize raw board deletion

### DIFF
--- a/docs/modules/graph/todos.md
+++ b/docs/modules/graph/todos.md
@@ -25,9 +25,15 @@ surface; this spec captures the design contract.
 ## Persistence
 
 One serialized `TaskBoard` per thread in the `graph.todos` namespace of a
-`harness::store::Store`, keyed by `hex(thread_id)`. Each mutation runs
+`harness::store::Store`, keyed by `hex(thread_id)`. Normal CRUD mutations run
 `load → mutate → normalise → put` under a per-thread async mutex (atomic within
 one process, same caveat as `graph::goals`).
+
+Host integrations can use three raw lifecycle operations: `get` reads without
+normalising and preserves absent versus present-empty; `delete` removes the
+value outright under the thread lock; and `import_if_absent` atomically writes
+a complete board only when no value exists, leaving existing or undecodable
+values untouched for safe one-time migrations.
 
 ### Invariants
 

--- a/src/graph/todos/README.md
+++ b/src/graph/todos/README.md
@@ -31,13 +31,21 @@ string (dependency-free, no `chrono`).
 ## Persistence (`store.rs`)
 
 One serialized `TaskBoard` per thread under the `graph.todos` namespace of a
-`crate::harness::store::Store`, keyed by `hex(thread_id)`. Every mutation runs
-`load → mutate → normalise → put` under a per-thread async mutex (a weak-value
-`graph::thread_locks::ThreadLockMap`, so idle threads' mutexes are reclaimed
-instead of leaking) — atomic within one process (same single-process caveat as
-`graph::goals::store`). Ops:
+`crate::harness::store::Store`, keyed by `hex(thread_id)`. Normal CRUD mutations
+run `load → mutate → normalise → put` under a per-thread async mutex (a
+weak-value `graph::thread_locks::ThreadLockMap`, so idle threads' mutexes are
+reclaimed instead of leaking) — atomic within one process (same single-process
+caveat as `graph::goals::store`). Ops:
 `add` / `edit` / `update_status` / `decide_plan` / `revise_plan` / `remove` /
 `replace` / `clear` / `list` / `claim_card` / `set_session_thread`.
+
+Host integrations also have raw lifecycle operations:
+
+- `get` preserves absent versus present-empty and does not normalise.
+- `delete` removes the board value outright under the same per-thread lock.
+- `import_if_absent` writes a complete board only when no value exists, without
+  decoding or overwriting an existing value. The check and write share the
+  per-thread lock, making it suitable for one-time legacy imports.
 
 Invariants preserved from OpenHuman:
 

--- a/src/graph/todos/store.rs
+++ b/src/graph/todos/store.rs
@@ -79,6 +79,8 @@ pub async fn get(store: &Arc<dyn Store>, thread_id: &str) -> Result<Option<TaskB
 /// This differs from [`clear`], which persists a present, empty board.
 pub async fn delete(store: &Arc<dyn Store>, thread_id: &str) -> Result<bool> {
     let thread_id = validate_thread_id(thread_id)?;
+    let lock = thread_lock(&thread_id);
+    let _guard = lock.lock().await;
     let board_key = key(&thread_id);
     let existed = store.get(TODOS_NAMESPACE, &board_key).await?.is_some();
     if existed {

--- a/src/graph/todos/test.rs
+++ b/src/graph/todos/test.rs
@@ -123,6 +123,11 @@ fn normalise_trims_generates_ids_and_recomputes_order() {
 
 mod store_tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use tokio::sync::Notify;
 
     use super::super::store;
     use super::super::types::{CardPatch, TaskBoardCard, TaskCardStatus};
@@ -169,6 +174,97 @@ mod store_tests {
         assert!(store::delete(&s, "t").await.unwrap());
         assert!(store::get(&s, "t").await.unwrap().is_none());
         assert!(!store::delete(&s, "t").await.unwrap());
+    }
+
+    struct BlockingGetStore {
+        inner: InMemoryStore,
+        armed: AtomicBool,
+        first_get_started: Notify,
+        release_first_get: Notify,
+        first_get_released: AtomicBool,
+        concurrent_get: AtomicBool,
+    }
+
+    impl BlockingGetStore {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryStore::default(),
+                armed: AtomicBool::new(false),
+                first_get_started: Notify::new(),
+                release_first_get: Notify::new(),
+                first_get_released: AtomicBool::new(false),
+                concurrent_get: AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Store for BlockingGetStore {
+        async fn get(&self, namespace: &str, key: &str) -> crate::error::Result<Option<Value>> {
+            let value = self.inner.get(namespace, key).await?;
+            if self.armed.swap(false, Ordering::SeqCst) {
+                self.first_get_started.notify_one();
+                self.release_first_get.notified().await;
+                self.first_get_released.store(true, Ordering::SeqCst);
+            } else if !self.first_get_released.load(Ordering::SeqCst) {
+                self.concurrent_get.store(true, Ordering::SeqCst);
+            }
+            Ok(value)
+        }
+
+        async fn put(&self, namespace: &str, key: &str, value: Value) -> crate::error::Result<()> {
+            self.inner.put(namespace, key, value).await
+        }
+
+        async fn delete(&self, namespace: &str, key: &str) -> crate::error::Result<()> {
+            self.inner.delete(namespace, key).await
+        }
+
+        async fn list(&self, namespace: &str) -> crate::error::Result<Vec<String>> {
+            self.inner.list(namespace).await
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_waits_for_an_in_flight_mutation() {
+        let concrete = Arc::new(BlockingGetStore::new());
+        let s: Arc<dyn Store> = concrete.clone();
+        let snap = store::add(&s, "t", "original", CardPatch::default())
+            .await
+            .unwrap();
+        let card_id = snap.cards[0].id.clone();
+
+        concrete.concurrent_get.store(false, Ordering::SeqCst);
+        concrete.armed.store(true, Ordering::SeqCst);
+        let edit_store = s.clone();
+        let edit = tokio::spawn(async move {
+            store::edit(
+                &edit_store,
+                "t",
+                &card_id,
+                CardPatch {
+                    content: Some("edited".into()),
+                    ..CardPatch::default()
+                },
+            )
+            .await
+        });
+        concrete.first_get_started.notified().await;
+
+        let delete_store = s.clone();
+        let delete = tokio::spawn(async move { store::delete(&delete_store, "t").await });
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !concrete.concurrent_get.load(Ordering::SeqCst),
+            "delete must not enter the store while a mutation holds the thread lock"
+        );
+
+        concrete.release_first_get.notify_one();
+        edit.await.unwrap().unwrap();
+        assert!(delete.await.unwrap().unwrap());
+        assert!(store::get(&s, "t").await.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- serialize raw board deletion with the same per-thread lock as CRUD mutations
- add a deterministic regression test proving delete cannot race and resurrect an in-flight edit
- document the raw `get`, `delete`, and `import_if_absent` lifecycle APIs and their persistence semantics

Follow-up to #80.

## API Or Behavior Changes

`graph::todos::store::delete` now waits for in-flight mutations on the same thread before checking and deleting the board. No signature changes.

## Tests

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo build --all-targets --all-features`
- [ ] `cargo test`
- [ ] `cargo test --all-features`
- [x] `cargo test graph::todos::test::store_tests --lib` (12 passed)

## Documentation

Updated `src/graph/todos/README.md` and `docs/modules/graph/todos.md` with the raw lifecycle APIs and locking/normalization semantics.