### PR TITLE
fix(harness): guarantee a resolvable user turn for non-native-tool models

### DIFF
--- a/docs/modules/harness/tool.md
+++ b/docs/modules/harness/tool.md
@@ -188,6 +188,30 @@ preference:
 - If a provider only accepts JSON tool declarations, it may fall back to the
   JSON schema while preserving `ToolSchema::format` in harness metadata.
 
+## Prompt-Guided Message Shape
+
+A model whose profile reports `tool_calling = false` is driven through its own
+Jinja chat template by the serving runtime (LM Studio, llama.cpp, Ollama), so
+the outgoing message list has to satisfy that template, not just the wire
+schema. Two helpers in `harness::tool` normalize it:
+
+- `coalesce_prompt_tool_results` renders assistant `tool_calls` back into
+  `<tool_call>` text and folds consecutive `tool`-role results into one
+  `[Tool results]` user turn — the `tool` role and structured `tool_calls`
+  field are not consumable by these models.
+- `ensure_resolvable_user_turn` guarantees the list contains a user turn the
+  template can resolve as "the user query", inserting one after any leading
+  system turns when none is present. Several widely used templates hard-require
+  one: Qwen 3's raises `No user query found in messages.` and the runtime
+  returns a 400 before the model is called. A prompt-guided tool loop reaches
+  that state legitimately once the real user turn ages out of the window
+  (summarization, a resumed transcript, a task carried entirely by the system
+  prompt), leaving only assistant continuations and folded tool results — which
+  do not count as a query, since the model requested them itself.
+
+Both are applied by the OpenAI-compatible adapter before wire translation.
+Native-tool models keep their message list untouched.
+
 ## Execution Lifecycle
 
 1. Check cancellation, wall-clock deadline, and tool-call limits.

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -2091,6 +2091,73 @@ fn prompt_guided_request_replays_calls_and_results_as_text() {
 }
 
 #[test]
+fn prompt_guided_request_carries_a_user_turn_for_the_chat_template() {
+    // openhuman#5291: a tool loop whose real user turn has aged out sends only a
+    // system prompt plus assistant/tool continuations. LM Studio renders that
+    // through the model's own template, and Qwen 3's raises `No user query found
+    // in messages.` — a 400 before the model is called. The wire body must carry
+    // a user turn regardless.
+    let model = OpenAiModel::new("k")
+        .with_model("qwen3.5-9b")
+        .with_native_tool_calling(false);
+    let mut assistant = Message::assistant("");
+    let Message::Assistant(message) = &mut assistant else {
+        unreachable!()
+    };
+    message.tool_calls = vec![crate::harness::tool::ToolCall::new(
+        "call-1",
+        "lookup",
+        json!({"q":"weather"}),
+    )];
+    let request = ModelRequest::new(vec![
+        Message::system("You are a helpful assistant."),
+        assistant,
+        Message::tool("call-1", "sunny"),
+    ])
+    .with_tools(vec![ToolSchema::new(
+        "lookup",
+        "look something up",
+        json!({"type":"object"}),
+    )]);
+
+    let value = serde_json::to_value(model.translate_request(&request).unwrap()).unwrap();
+    let messages = value["messages"].as_array().unwrap();
+    let queries: Vec<&str> = messages
+        .iter()
+        .filter(|m| m["role"] == "user")
+        .filter_map(|m| m["content"].as_str())
+        .filter(|content| !content.starts_with("[Tool results]"))
+        .collect();
+    assert_eq!(
+        queries.len(),
+        1,
+        "exactly one resolvable user query is present: {messages:?}"
+    );
+    // It sits after the system prompt, so the transcript still reads
+    // system → user → assistant.
+    assert_eq!(messages[0]["role"], "system");
+    assert_eq!(messages[1]["role"], "user");
+    assert_eq!(messages[2]["role"], "assistant");
+}
+
+#[test]
+fn native_tool_model_keeps_its_messages_untouched() {
+    // The normalization is scoped to the no-native-tools profile: a native-tool
+    // model is served through the provider's tool protocol, not a Jinja template
+    // with a user-query guard, so nothing is inserted.
+    let model = OpenAiModel::new("k").with_model("gpt-4o-mini");
+    let request = ModelRequest::new(vec![
+        Message::system("You are a helpful assistant."),
+        Message::assistant("continuing"),
+    ]);
+
+    let value = serde_json::to_value(model.translate_request(&request).unwrap()).unwrap();
+    let messages = value["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert!(messages.iter().all(|m| m["role"] != "user"));
+}
+
+#[test]
 fn with_vision_toggles_image_in_modality() {
     let off = OpenAiModel::new("k")
         .with_model("qwen2.5")

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -905,7 +905,7 @@ impl OpenAiModel {
         let prompt_guided_tools = !self.profile.tool_calling && !request.tools.is_empty();
         let prompt_messages;
         let instructed_messages;
-        let base_messages: &[Message] = if prompt_guided_tools {
+        let coalesced_messages: &[Message] = if prompt_guided_tools {
             prompt_messages = crate::harness::tool::coalesce_prompt_tool_results(&request.messages);
             instructed_messages = crate::harness::tool::with_prompt_tool_instructions(
                 &prompt_messages,
@@ -914,6 +914,22 @@ impl OpenAiModel {
             &instructed_messages
         } else {
             &request.messages
+        };
+
+        // A model with no native tool calling is rendered through its own chat
+        // template by the serving runtime, and templates like Qwen 3's abort the
+        // request outright when they cannot locate a user query. Guarantee one
+        // (openhuman#5291). Scoped to the no-native-tools profile — that is the
+        // set of models served through a Jinja template with this guard — and
+        // applied after the coalescing above so folded tool results are already
+        // in their final user-turn shape when we look for a real query.
+        let user_normalized_messages;
+        let base_messages: &[Message] = if self.profile.tool_calling {
+            coalesced_messages
+        } else {
+            user_normalized_messages =
+                crate::harness::tool::ensure_resolvable_user_turn(coalesced_messages);
+            &user_normalized_messages
         };
 
         // Optionally fold system messages into the first user turn (for endpoints

--- a/src/harness/tool/prompt.rs
+++ b/src/harness/tool/prompt.rs
@@ -35,6 +35,18 @@ const OPEN_PREFIX: &str = "<tool_call";
 const DS_OPEN: &str = "<｜tool▁call▁begin｜>";
 const DS_CLOSE: &str = "<｜tool▁call▁end｜>";
 
+/// Leading marker of the synthetic user turn that [`coalesce_prompt_tool_results`]
+/// folds tool results into. Shared with [`ensure_resolvable_user_turn`], which
+/// must be able to tell a folded result apart from a real user query — keeping
+/// one const means the two can never drift.
+const TOOL_RESULTS_MARKER: &str = "[Tool results]";
+
+/// User turn synthesized by [`ensure_resolvable_user_turn`] when a request
+/// carries none. Deliberately content-free: the actual task is in the system
+/// prompt (or in the transcript that follows), and this exists to satisfy chat
+/// templates that require a locatable user query, not to add instructions.
+const CONTINUATION_USER_TURN: &str = "Continue with the task described above.";
+
 /// Build the tool-use protocol block appended to the system prompt when native
 /// tool calling is unavailable. Describes the `<tool_call>` convention and lists
 /// each tool's name, description, and JSON-Schema parameters.
@@ -99,7 +111,7 @@ pub fn coalesce_prompt_tool_results(messages: &[Message]) -> Vec<Message> {
     fn flush(out: &mut Vec<Message>, pending: &mut Vec<String>) {
         if !pending.is_empty() {
             out.push(Message::user(format!(
-                "[Tool results]\n{}",
+                "{TOOL_RESULTS_MARKER}\n{}",
                 std::mem::take(pending).join("\n")
             )));
         }
@@ -136,6 +148,70 @@ pub fn coalesce_prompt_tool_results(messages: &[Message]) -> Vec<Message> {
         }
     }
     flush(&mut out, &mut pending);
+    out
+}
+
+/// Whether this message is a user turn a chat template can resolve as "the user
+/// query".
+///
+/// A folded tool-result turn does not count. It carries the
+/// [`TOOL_RESULTS_MARKER`] prefix, and templates that look for a user query are
+/// looking for a request to answer, not for the transcript of a tool the model
+/// itself invoked — Qwen 3's template makes the same distinction, skipping user
+/// turns that are wholly a tool response. Neither does an empty or
+/// whitespace-only turn. Non-text content (JSON, an image) does count: it is a
+/// real user input the model is being asked about.
+fn is_resolvable_user_query(message: &Message) -> bool {
+    let Message::User(user) = message else {
+        return false;
+    };
+    if message.text().trim_start().starts_with(TOOL_RESULTS_MARKER) {
+        return false;
+    }
+    user.content.iter().any(|block| match block {
+        ContentBlock::Text(text) => !text.trim().is_empty(),
+        ContentBlock::Json(_) | ContentBlock::Image(_) => true,
+        // Reasoning replay and opaque provider payloads are not user input.
+        ContentBlock::Thinking { .. }
+        | ContentBlock::RedactedThinking { .. }
+        | ContentBlock::ProviderExtension(_) => false,
+    })
+}
+
+/// Guarantee the outgoing list contains a user turn a chat template can resolve,
+/// inserting one only when none is present.
+///
+/// Models without native tool calling are driven through their **own** chat
+/// template by the serving runtime (LM Studio, llama.cpp, Ollama), and several
+/// widely used templates hard-require a locatable user query. Qwen 3's raises
+/// outright:
+///
+/// ```text
+/// {%- if ns.multi_step_tool %}{{- raise_exception('No user query found in messages.') }}
+/// ```
+///
+/// A prompt-guided tool loop can reach that state legitimately: once the real
+/// user turn has aged out of the window — summarization, a resumed transcript,
+/// a task delivered entirely through the system prompt — every remaining
+/// non-system turn is an assistant continuation or a folded tool result, and the
+/// template aborts the request with a 400 before the model is ever called
+/// (tinyhumansai/openhuman#5291). Native-tool models are unaffected: they are
+/// served through the provider's own tool protocol, not a Jinja template with
+/// this guard.
+///
+/// The inserted turn goes directly after any leading system messages, so the
+/// transcript still reads system → user → assistant. A request that already has
+/// a real user turn is returned unchanged.
+pub fn ensure_resolvable_user_turn(messages: &[Message]) -> Vec<Message> {
+    if messages.iter().any(is_resolvable_user_query) {
+        return messages.to_vec();
+    }
+    let mut out = messages.to_vec();
+    let insert_at = out
+        .iter()
+        .position(|message| !matches!(message, Message::System(_)))
+        .unwrap_or(out.len());
+    out.insert(insert_at, Message::user(CONTINUATION_USER_TURN));
     out
 }
 

--- a/src/harness/tool/prompt_test.rs
+++ b/src/harness/tool/prompt_test.rs
@@ -1,7 +1,7 @@
 //! Tests for the prompt-guided tool-call protocol.
 
 use super::*;
-use crate::harness::message::{ContentBlock, Message};
+use crate::harness::message::{ContentBlock, ImageRef, Message};
 
 fn schema(name: &str) -> ToolSchema {
     ToolSchema {
@@ -82,6 +82,88 @@ fn prompt_results_coalesce_consecutive_tool_messages() {
 fn prompt_result_coalescing_without_tools_is_identity() {
     let messages = vec![Message::system("system"), Message::user("question")];
     assert_eq!(coalesce_prompt_tool_results(&messages), messages);
+}
+
+#[test]
+fn user_turn_normalization_leaves_a_real_query_alone() {
+    let messages = vec![
+        Message::system("system"),
+        Message::user("question"),
+        Message::assistant("answer"),
+    ];
+    assert_eq!(ensure_resolvable_user_turn(&messages), messages);
+}
+
+#[test]
+fn user_turn_normalization_inserts_after_leading_system_turns() {
+    // openhuman#5291: the real user turn aged out of the window, leaving a
+    // system prompt and an assistant continuation. Qwen 3's template raises
+    // `No user query found in messages.` on exactly this shape.
+    let messages = vec![
+        Message::system("system"),
+        Message::system("tool protocol"),
+        Message::assistant("continuing"),
+    ];
+
+    let out = ensure_resolvable_user_turn(&messages);
+
+    assert_eq!(out.len(), 4);
+    assert!(matches!(out[0], Message::System(_)));
+    assert!(matches!(out[1], Message::System(_)));
+    assert!(matches!(out[2], Message::User(_)), "user turn is inserted");
+    assert!(matches!(out[3], Message::Assistant(_)));
+}
+
+#[test]
+fn user_turn_normalization_does_not_count_folded_tool_results() {
+    // The only user-role turns are coalesced tool results, which is not a query
+    // the template can answer — the model asked for those itself.
+    let coalesced = coalesce_prompt_tool_results(&[
+        Message::system("system"),
+        Message::assistant("calling"),
+        Message::tool("call-1", "result"),
+    ]);
+    assert!(
+        coalesced.iter().any(|m| matches!(m, Message::User(_))),
+        "coalescing produces a user-role turn"
+    );
+
+    let out = ensure_resolvable_user_turn(&coalesced);
+
+    assert_eq!(out.len(), coalesced.len() + 1);
+    assert!(matches!(out[1], Message::User(_)));
+    assert!(!out[1].text().starts_with("[Tool results]"));
+}
+
+#[test]
+fn user_turn_normalization_ignores_a_blank_user_turn() {
+    let messages = vec![Message::system("system"), Message::user("   ")];
+    let out = ensure_resolvable_user_turn(&messages);
+    assert_eq!(out.len(), 3);
+    assert!(!out[1].text().trim().is_empty());
+}
+
+#[test]
+fn user_turn_normalization_accepts_a_non_text_user_turn() {
+    // An image-only turn carries no text but is still a real user input.
+    let mut messages = vec![Message::system("system"), Message::user("")];
+    let Message::User(user) = &mut messages[1] else {
+        unreachable!()
+    };
+    user.content = vec![ContentBlock::Image(ImageRef {
+        url: "https://example.invalid/a.png".to_string(),
+        mime_type: None,
+    })];
+
+    assert_eq!(ensure_resolvable_user_turn(&messages), messages);
+}
+
+#[test]
+fn user_turn_normalization_inserts_first_when_there_is_no_system_turn() {
+    let messages = vec![Message::assistant("continuing")];
+    let out = ensure_resolvable_user_turn(&messages);
+    assert_eq!(out.len(), 2);
+    assert!(matches!(out[0], Message::User(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

A model whose profile reports no native tool calling is driven through its **own** Jinja chat template by the serving runtime (LM Studio, llama.cpp, Ollama), so the outgoing message list has to satisfy that template — not just the wire schema. Several widely used templates hard-require a locatable user query. Qwen 3's raises outright:

```jinja
{%- if ns.multi_step_tool %}
    {{- raise_exception('No user query found in messages.') }}
```

A prompt-guided tool loop reaches that state legitimately: once the real user turn has aged out of the window — summarization, a resumed transcript, a task carried entirely by the system prompt — every remaining non-system turn is an assistant continuation or a folded tool result, and the runtime aborts with a `400` **before the model is ever called**.

Reported downstream as tinyhumansai/openhuman#5291 (LM Studio + `qwen/qwen3.5-9b`, `supports_native_tools=false`, 80 tools, both retries dead).

## API Or Behavior Changes

- **New public helper** `harness::tool::ensure_resolvable_user_turn(&[Message]) -> Vec<Message>` (re-exported via the existing `pub use prompt::*`). Guarantees the list contains a user turn a chat template can resolve, inserting one after any leading system turns **only when none is present**; a list that already has a real user turn is returned unchanged.
- **Applied by the OpenAI-compatible adapter** (`translate_request_with`) for no-native-tools profiles, after the existing tool-result coalescing.
- **Native-tool models are untouched** — they are served through the provider's own tool protocol, not a template with this guard. Pinned by a test in both directions.

Two judgment calls worth reviewer attention:

1. **A folded `[Tool results]` turn does not count as a resolvable query.** The model requested those itself, and Qwen's template makes the same distinction (it skips user turns that are wholly a tool response). The marker string is now a shared const so `coalesce_prompt_tool_results` and the resolvability check cannot drift.
2. **Scoped to `!profile.tool_calling`, not to `prompt_guided_tools`.** The guard is a property of the template, not of whether tools were sent — so a no-native-tools model with an empty tool list and no user turn is covered by the same normalization.

A non-text user turn (JSON, an image) **does** count as resolvable — an image-only turn is real user input and must not be displaced.

## Tests

Six unit tests in `src/harness/tool/prompt_test.rs` (real query left alone · insertion after leading system turns · folded tool results do not count · blank turn ignored · image-only turn accepted · insertion at index 0 when there is no system turn) and two adapter tests in `src/harness/providers/openai/test.rs` (prompt-guided wire body carries exactly one resolvable user query in system → user → assistant order; native-tool model's messages untouched).

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — not run
- [ ] `cargo build --all-targets` — not run separately (covered by the test build)
- [ ] `cargo build --all-targets --all-features` — not run
- [x] `cargo test` (`--lib`, 1232 passed / 0 failed)
- [ ] `cargo test --all-features` — not run

## Documentation

`docs/modules/harness/tool.md` gains a **Prompt-Guided Message Shape** section documenting both normalization helpers, why the template (not the wire schema) is the constraint for these models, and why a folded tool result is not a query.
