### PR TITLE
ci: enforce 90 percent line coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,9 @@ jobs:
 
       - name: Test all features
         run: cargo test --all-features
+
+      - name: Coverage gate
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Verify line coverage
+        run: cargo llvm-cov --all-features --workspace --fail-under-lines 90


### PR DESCRIPTION
## Summary

Adds a CI coverage gate using `cargo-llvm-cov`. The workflow now fails when all-feature line coverage drops below 90%.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo llvm-cov --all-features --workspace --fail-under-lines 90 --summary-only` (93.24% lines)