### PR TITLE
fix(observability): bound repeated durable-append failure reports

### DIFF
--- a/src/graph/observability/README.md
+++ b/src/graph/observability/README.md
@@ -56,8 +56,11 @@ so existing runs are unchanged.
 async journal API through a background `AppendWorker`: `emit` hands the
 observation to a bounded channel drained on a dedicated thread, so it never
 blocks the executor on I/O. Persistence is **best-effort**: a full queue drops
-(and counts) the overflow, backend errors are reported to stderr rather than
-propagated, and neither aborts the run. The executor calls `GraphEventSink::flush`
+(and counts) the overflow, backend errors are counted and reported through
+`tracing` (rate-limited to one report per failure run plus a reminder every five
+minutes — see the harness `observability` README for the full error policy)
+rather than propagated, and neither aborts the run. The executor calls
+`GraphEventSink::flush`
 after the terminal run event (and callers can call it directly) to block until
 the durable log has caught up. Do not rely on the sink for delivery guarantees
 stronger than "usually persisted, never run-blocking."

--- a/src/harness/observability/README.md
+++ b/src/harness/observability/README.md
@@ -71,8 +71,10 @@ per-observation: the first failure of a run logs at `ERROR` on the
 first success afterwards logs one `WARN` recovery summary carrying how many
 observations were lost. The worker keeps attempting every item while degraded —
 the attempt is what detects recovery. Because reporting goes through `tracing`,
-an embedder with no subscriber installed sees nothing; read `append_failures`
-for a subscriber-independent signal.
+an embedder with no subscriber installed sees nothing — install a subscriber to
+observe durable-log loss. `AppendWorker::append_failures` counts it, but like
+the queue-full `dropped` count it is crate-internal, so it is not a signal a
+host application can read today.
 
 ## Latency metrics semantics
 

--- a/src/harness/observability/README.md
+++ b/src/harness/observability/README.md
@@ -56,11 +56,23 @@ Persisting sinks (`JournalSink`, `JsonlSink`) bridge the synchronous
 background `AppendWorker`: `on_event` hands the observation to a **bounded**
 channel drained on a dedicated thread, so it never blocks the run on I/O.
 Persistence is **best-effort**: if the queue is full the observation is dropped
-(and counted), backend errors are reported to stderr rather than propagated,
-and neither ever aborts the run. Call `JournalSink::flush` / `JsonlSink::flush`
-to block until the durable log has caught up (for example before reading it back
-or shutting down). Do not rely on a sink for delivery guarantees stronger than
-"usually persisted, never run-blocking."
+(and counted in `AppendWorker::dropped`), backend errors are counted (in
+`AppendWorker::append_failures`) and reported through `tracing` rather than
+propagated, and neither ever aborts the run. Call `JournalSink::flush` /
+`JsonlSink::flush` to block until the durable log has caught up (for example
+before reading it back or shutting down). Do not rely on a sink for delivery
+guarantees stronger than "usually persisted, never run-blocking."
+
+A persistent backend failure (read-only volume, full disk) fails every queued
+observation identically, so reporting is **rate-limited** rather than
+per-observation: the first failure of a run logs at `ERROR` on the
+`tinyagents::observability` target, further failures are counted silently with a
+`WARN` reminder at most once per `APPEND_REPORT_COOLDOWN` (5 minutes), and the
+first success afterwards logs one `WARN` recovery summary carrying how many
+observations were lost. The worker keeps attempting every item while degraded —
+the attempt is what detects recovery. Because reporting goes through `tracing`,
+an embedder with no subscriber installed sees nothing; read `append_failures`
+for a subscriber-independent signal.
 
 ## Latency metrics semantics
 

--- a/src/harness/observability/test.rs
+++ b/src/harness/observability/test.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use crate::error::TinyAgentsError;
 use crate::harness::events::{AgentEvent, EventListener, EventRecord, HarnessRunStatus, LimitKind};
 use crate::harness::ids::{CallId, ComponentId, EventId, ExecutionStatus, RunId, ThreadId};
 use crate::harness::observability::AppendWorker;
@@ -360,6 +361,112 @@ async fn append_worker_drops_and_counts_when_queue_is_full() {
         "a saturated bounded queue must drop and count overflow, got {}",
         worker.dropped()
     );
+}
+
+#[tokio::test]
+async fn append_worker_counts_failed_appends() {
+    // A sink that rejects every append: each failure is counted, and that count
+    // is kept separate from the queue-full drop count (nothing was dropped —
+    // every item reached the sink and was rejected by it).
+    let worker = AppendWorker::spawn("test-failing", 64, move |_n: u64| async move {
+        Err(TinyAgentsError::Storage("sink offline".into()))
+    });
+
+    for n in 0..12 {
+        worker.submit(n);
+    }
+    worker.flush();
+
+    // Both loss counters are surfaced on the debug view, so an operator dumping
+    // a sink can tell "never reached the backend" from "backend rejected it".
+    let debug = format!("{worker:?}");
+    assert!(
+        debug.contains("append_failures: 12") && debug.contains("dropped: 0"),
+        "debug view must distinguish append failures from queue-full drops, got {debug}"
+    );
+
+    assert_eq!(
+        worker.append_failures(),
+        12,
+        "every failed durable append must be counted"
+    );
+    assert_eq!(
+        worker.dropped(),
+        0,
+        "append failures must not be conflated with queue-full drops"
+    );
+}
+
+#[tokio::test]
+async fn append_worker_failure_then_recovery_keeps_attempting() {
+    use std::sync::Mutex;
+
+    // The sink fails the first 3 appends, then starts accepting. A worker that
+    // stopped attempting while degraded would never persist anything after the
+    // failure run; keeping attempts is what detects the recovery.
+    let attempts = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let seen: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    let counter = Arc::clone(&attempts);
+    let sink = Arc::clone(&seen);
+    // A zero cooldown makes the "still failing" reminder fire on every failure
+    // after the first, exercising the suppression path without a wall clock.
+    let worker = AppendWorker::spawn_with_cooldown(
+        "test-flaky",
+        64,
+        std::time::Duration::ZERO,
+        move |n: u64| {
+            let counter = Arc::clone(&counter);
+            let sink = Arc::clone(&sink);
+            async move {
+                if counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) < 3 {
+                    return Err(TinyAgentsError::Storage("sink offline".into()));
+                }
+                sink.lock().unwrap().push(n);
+                Ok(())
+            }
+        },
+    );
+
+    for n in 0..8 {
+        worker.submit(n);
+    }
+    worker.flush();
+
+    assert_eq!(
+        worker.append_failures(),
+        3,
+        "only the appends the sink rejected are counted as failures"
+    );
+    assert_eq!(
+        *seen.lock().unwrap(),
+        (3..8).collect::<Vec<_>>(),
+        "the worker must keep attempting while degraded, so items persist once the sink recovers"
+    );
+}
+
+#[test]
+fn should_report_bounds_repeats_to_one_per_cooldown() {
+    use crate::harness::observability::worker::should_report;
+    use std::time::{Duration, Instant};
+
+    let cooldown = Duration::from_secs(300);
+    let start = Instant::now();
+
+    // The first failure of a run has never reported, so it always reports.
+    assert!(should_report(None, start, cooldown));
+    // A failure inside the cooldown window is suppressed (counted, not logged).
+    assert!(!should_report(
+        Some(start),
+        start + Duration::from_secs(299),
+        cooldown
+    ));
+    // Once the cooldown has elapsed, the run is due for a reminder again.
+    assert!(should_report(Some(start), start + cooldown, cooldown));
+    assert!(should_report(
+        Some(start),
+        start + Duration::from_secs(600),
+        cooldown
+    ));
 }
 
 /// Collects forwarded records for assertions.

--- a/src/harness/observability/worker.rs
+++ b/src/harness/observability/worker.rs
@@ -44,8 +44,12 @@
 //!
 //! Persistence remains best-effort — an error never propagates back into the run
 //! — but it is observable. Note that reporting goes through `tracing`, so an
-//! embedder with no subscriber installed sees nothing; inspect
-//! [`AppendWorker::append_failures`] for a subscriber-independent signal.
+//! embedder with no subscriber installed sees nothing at all: installing one is
+//! how a host observes durable-log loss. [`AppendWorker::append_failures`]
+//! counts it, but — like the queue-full [`AppendWorker::dropped`] count it
+//! mirrors — it is crate-internal and is not reachable from a host application
+//! through [`JournalSink`](super::JournalSink) or
+//! [`JsonlSink`](super::JsonlSink).
 //!
 //! # Ordering & durability boundary
 //! A single drain thread preserves submit order. [`AppendWorker::flush`] blocks

--- a/src/harness/observability/worker.rs
+++ b/src/harness/observability/worker.rs
@@ -19,9 +19,33 @@
 //! the run). Callers that need a lossless log can inspect the dropped count.
 //!
 //! # Error policy
-//! Append errors are **not** silently discarded: the drain loop reports each
-//! failure to stderr with the sink name. Persistence remains best-effort — an
-//! error never propagates back into the run — but it is observable.
+//! Append errors are **not** silently discarded, but neither are they allowed to
+//! flood the host's log. Every failed append is counted in
+//! [`AppendWorker::append_failures`] (a lifetime total, distinct from the
+//! queue-full [`AppendWorker::dropped`] count), and the drain loop reports
+//! through `tracing` on the `tinyagents::observability` target with a `sink`
+//! field:
+//!
+//! - the **first** failure of a failure run is reported at `ERROR` — durable
+//!   observations are being lost;
+//! - subsequent failures are counted silently, with a reminder at `WARN` at most
+//!   once per [`APPEND_REPORT_COOLDOWN`]; each reminder carries the *latest*
+//!   error, so a changed cause (read-only volume → full disk) still surfaces
+//!   within one cooldown;
+//! - the first success after a failure run emits one `WARN` recovery summary
+//!   carrying how many observations were lost while the sink was down;
+//! - if the worker shuts down while still failing, it emits one final `WARN`
+//!   summary so a never-recovering run is not silently quiet.
+//!
+//! The worker keeps attempting every item while degraded: the attempt *is* the
+//! recovery detector, it runs off the run's critical path, and skipping it would
+//! turn a transient blip into guaranteed loss of everything still queued. Items
+//! that fail are lost, but counted.
+//!
+//! Persistence remains best-effort — an error never propagates back into the run
+//! — but it is observable. Note that reporting goes through `tracing`, so an
+//! embedder with no subscriber installed sees nothing; inspect
+//! [`AppendWorker::append_failures`] for a subscriber-independent signal.
 //!
 //! # Ordering & durability boundary
 //! A single drain thread preserves submit order. [`AppendWorker::flush`] blocks
@@ -35,6 +59,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Sender, SyncSender, TrySendError, sync_channel};
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use crate::error::Result;
 
@@ -43,6 +68,27 @@ use crate::error::Result;
 /// Sized so a transient backend stall buffers a healthy burst of events before
 /// the drop policy engages, without letting the queue grow without bound.
 pub(crate) const DEFAULT_DRAIN_CAPACITY: usize = 1024;
+
+/// Minimum interval between repeated reports of an *ongoing* append-failure run.
+///
+/// A persistent sink failure (a volume flipped read-only, a full disk) fails
+/// every queued observation identically; without a cooldown that is one log line
+/// per arriving event. The first failure is always reported; after that the
+/// drain loop stays quiet for this long between reminders.
+pub(crate) const APPEND_REPORT_COOLDOWN: Duration = Duration::from_secs(300);
+
+/// Whether an ongoing failure run is due for a reminder report.
+///
+/// `last` is when this run last reported (`None` before its first report).
+/// Pure and clock-free so the cooldown policy is unit-testable without a
+/// subscriber or a fake clock.
+pub(super) fn should_report(last: Option<Instant>, now: Instant, cooldown: Duration) -> bool {
+    match last {
+        None => true,
+        // Saturating: a non-monotonic `now` yields zero, not a panic.
+        Some(previous) => now.saturating_duration_since(previous) >= cooldown,
+    }
+}
 
 /// Messages carried over the drain channel.
 enum Msg<T> {
@@ -63,6 +109,8 @@ pub(crate) struct AppendWorker<T: Send + 'static> {
     tx: Option<SyncSender<Msg<T>>>,
     /// Count of payloads dropped because the queue was full (or disconnected).
     dropped: Arc<AtomicU64>,
+    /// Lifetime count of payloads whose durable append returned an error.
+    append_failures: Arc<AtomicU64>,
     /// Handle to the drain thread, joined on drop.
     handle: Option<JoinHandle<()>>,
     /// Human-readable sink name used in error reports.
@@ -80,7 +128,27 @@ impl<T: Send + 'static> AppendWorker<T> {
         F: Fn(T) -> Fut + Send + 'static,
         Fut: Future<Output = Result<()>>,
     {
+        Self::spawn_with_cooldown(name, capacity, APPEND_REPORT_COOLDOWN, append)
+    }
+
+    /// Spawns a drain worker with an explicit failure-report cooldown.
+    ///
+    /// Same as [`Self::spawn`], which supplies [`APPEND_REPORT_COOLDOWN`]. The
+    /// cooldown is a parameter so the suppression and reminder paths can be
+    /// exercised deterministically, without waiting on wall-clock time.
+    pub(crate) fn spawn_with_cooldown<F, Fut>(
+        name: &'static str,
+        capacity: usize,
+        cooldown: Duration,
+        append: F,
+    ) -> Self
+    where
+        F: Fn(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<()>>,
+    {
         let (tx, rx) = sync_channel::<Msg<T>>(capacity.max(1));
+        let append_failures = Arc::new(AtomicU64::new(0));
+        let failures = Arc::clone(&append_failures);
         let handle = std::thread::Builder::new()
             .name(format!("tinyagents-{name}-drain"))
             .spawn(move || {
@@ -96,17 +164,64 @@ impl<T: Send + 'static> AppendWorker<T> {
                     }
                 };
                 rt.block_on(async move {
+                    // Failure-run state: how many appends have failed since the
+                    // last success, and when this run last reported. Local to
+                    // the drain thread — no shared state, no timer tasks.
+                    let mut failure_run: u64 = 0;
+                    let mut last_report: Option<Instant> = None;
                     while let Ok(msg) = rx.recv() {
                         match msg {
-                            Msg::Item(item) => {
-                                if let Err(e) = append(item).await {
-                                    eprintln!("tinyagents: {name} durable append failed: {e}");
+                            Msg::Item(item) => match append(item).await {
+                                Ok(()) => {
+                                    if failure_run > 0 {
+                                        tracing::warn!(
+                                            target: "tinyagents::observability",
+                                            sink = name,
+                                            lost = failure_run,
+                                            "[observability] durable append recovered; {failure_run} observation(s) lost while the sink was failing"
+                                        );
+                                        failure_run = 0;
+                                        last_report = None;
+                                    }
                                 }
-                            }
+                                Err(error) => {
+                                    failures.fetch_add(1, Ordering::Relaxed);
+                                    failure_run += 1;
+                                    let now = Instant::now();
+                                    if failure_run == 1 {
+                                        last_report = Some(now);
+                                        tracing::error!(
+                                            target: "tinyagents::observability",
+                                            sink = name,
+                                            error = %error,
+                                            "[observability] durable append failed; the observation is lost and repeats are suppressed until the sink recovers"
+                                        );
+                                    } else if should_report(last_report, now, cooldown) {
+                                        last_report = Some(now);
+                                        tracing::warn!(
+                                            target: "tinyagents::observability",
+                                            sink = name,
+                                            error = %error,
+                                            failures = failure_run,
+                                            "[observability] durable append failed; still failing after {failure_run} consecutive observations"
+                                        );
+                                    }
+                                }
+                            },
                             Msg::Flush(ack) => {
                                 let _ = ack.send(());
                             }
                         }
+                    }
+                    // The channel closed mid-failure: report once on the way out
+                    // so a run that never recovered is not silently quiet.
+                    if failure_run > 0 {
+                        tracing::warn!(
+                            target: "tinyagents::observability",
+                            sink = name,
+                            lost = failure_run,
+                            "[observability] durable append failed; sink never recovered before shutdown, {failure_run} observation(s) lost"
+                        );
                     }
                 });
             })
@@ -114,6 +229,7 @@ impl<T: Send + 'static> AppendWorker<T> {
         Self {
             tx: Some(tx),
             dropped: Arc::new(AtomicU64::new(0)),
+            append_failures,
             handle: Some(handle),
             name,
         }
@@ -141,6 +257,17 @@ impl<T: Send + 'static> AppendWorker<T> {
         self.dropped.load(Ordering::Relaxed)
     }
 
+    /// Returns the number of payloads whose durable append returned an error.
+    ///
+    /// Distinct from [`Self::dropped`]: those never reached the sink, these were
+    /// attempted and rejected. Reporting is `tracing`-based and suppressed while
+    /// a failure run continues, so this counter is the only subscriber-free
+    /// signal of durable-log loss.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn append_failures(&self) -> u64 {
+        self.append_failures.load(Ordering::Relaxed)
+    }
+
     /// Blocks until every payload submitted before this call has been persisted.
     pub(crate) fn flush(&self) {
         let Some(tx) = self.tx.as_ref() else {
@@ -160,6 +287,10 @@ impl<T: Send + 'static> fmt::Debug for AppendWorker<T> {
         f.debug_struct("AppendWorker")
             .field("name", &self.name)
             .field("dropped", &self.dropped.load(Ordering::Relaxed))
+            .field(
+                "append_failures",
+                &self.append_failures.load(Ordering::Relaxed),
+            )
             .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
## Summary

`AppendWorker`'s drain loop reports every failed durable append with `eprintln!` — stateless, once per item, with no level and no way for the host application to filter it. Under a persistent sink failure (a volume flips read-only, a disk fills) every queued observation emits the identical line, and the host's stderr becomes that one line repeated.

This is the crate's **only** `eprintln!`. Every other diagnostic already goes through `tracing` with a target (e.g. `tinyagents::embeddings::ollama`), so an embedder can filter everything *except* this. The fix removes an outlier rather than introducing a logging regime.

Failed appends were also **uncounted**. Queue-full drops have the `dropped` counter, but an append that fails after dequeue was lost with no counter at all — so the only signal that durable-log data was being lost *was* the noise.

The prompting incident was downstream: a 200-line log tail from a live tenant contained this line and nothing else, so an investigation into an unrelated problem could see nothing.

**One correction to how this is usually described**, in case it shapes review: there is no retry loop here. Each item is attempted once and dropped on `Err`. The flood is one line per *arriving item*, not per retry — so the fix is report-collapse plus a counter, not attempt-suppression. The worker deliberately **keeps attempting** while degraded: attempts are what detect recovery, they run off the critical path on the dedicated drain thread, and skipping them would turn a transient blip into guaranteed total loss of everything queued behind it.

## API Or Behavior Changes

**Behaviour change, stated up front: the stderr line disappears.** An embedder with no `tracing` subscriber installed now sees *nothing* on append failure. That is the intended contract — the host should control this like every other tinyagents event — but it is silent-by-default for anyone who was relying on the old output, so it should be a deliberate choice rather than a surprise. The new `append_failures()` counter is the subscriber-free replacement signal.

The literal substring **`durable append failed`** is preserved in all four new messages, so existing log searches keep matching.

- First failure of a run → `tracing::error!` (target `tinyagents::observability`, `sink` field). Durable-log data is being lost, and the module docs promise callers a lossless log modulo the counted drop policy.
- Repeats suppressed, with a `warn!` reminder at most every `APPEND_REPORT_COOLDOWN` (300s) carrying the consecutive-failure count and the **latest** error text — so a changed cause (read-only → disk full) still surfaces within one cooldown without needing per-error keying.
- Recovery → one `warn!` reporting how many appends were lost. `warn!` rather than `info!` because data *was* lost.
- Shutdown while still degraded → one final `warn!` summary, so a run that never recovers is not silently quiet.
- New `append_failures: Arc<AtomicU64>` + accessor + `Debug` field, mirroring the existing `dropped` counter exactly (same `Relaxed` ordering, same accessor pattern).

**No new dependencies** — `tracing` is already a direct dependency.

**Public API is unchanged.** One addition is `pub(crate)`: `spawn_with_cooldown`, which `spawn` delegates to with the 300s constant. Reviewer's call, and easy to drop — with the cooldown hardcoded, the *reminder emission path* is unreachable from a test, so only the `should_report` decision could be covered and the live log lines would sit uncovered against the 90% gate. If you would rather keep the surface minimal and accept those uncovered lines, say so and I will collapse it.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test` — 112 suites ok
- [x] `cargo test --all-features` — 112 ok
- [x] `cargo llvm-cov --all-features --workspace --fail-under-lines 90` — **92.24%**

`worker.rs` itself goes **85.84% → 94.69%** lines, 100% function coverage. The `Debug`-output assertion is there deliberately: extending an untested `Debug` impl otherwise pushes the file's own coverage down.

Three new tests in `src/harness/observability/test.rs`, all clock-independent, following the shape of the existing `append_worker_drops_and_counts_when_queue_is_full`. Each was proven to fail against the pre-change behaviour before being kept:

```
1. removed the counter increment ->
   append_worker_counts_failed_appends
   assertion `left == right` failed: every failed durable append must be counted
     left: 0   right: 12

2. should_report -> always true ->
   assertion failed: !should_report(Some(start), start + Duration::from_secs(299), cooldown)

3. stopped attempting while degraded ->
   append_worker_failure_then_recovery_keeps_attempting
     left: 8   right: 3
   (the worker charged all 8 items as failures instead of recovering after 3)
```

The third is the one that matters most — it pins that a degraded worker keeps trying, which is the behaviour that makes recovery possible at all.

## Documentation

- `src/harness/observability/README.md` and `src/graph/observability/README.md` — the only two places in the tree claiming failures are "reported to stderr", which this change makes false. (`graph`'s `JournalGraphSink` shares this same `AppendWorker`.) `mod.rs`'s "backend errors are reported, not propagated" and `types.rs`'s pointer to the drop/error policy stay accurate and were left alone.
- The `# Error policy` section of the `worker.rs` module docs is rewritten: tracing target, first-failure level, suppression and cooldown, recovery summary, lifetime counter.

## Related

Pre-existing and deliberately untouched, but worth naming since it is adjacent: if the tokio runtime fails to build, the drain thread runs `while rx.recv().is_ok() {}` — silently draining and discarding **everything**, with no counter and no report. It does not even increment `append_failures`, so that failure mode is completely invisible. Happy to fix it here or in a follow-up, whichever you prefer.

Context for why this was found: OpenCompany vendors tinyagents and hit the flood in a tenant container. Tracked there as `tinyhumansai/opencompany#450`. That repo's fix is a submodule-pointer bump once this lands; the same flood persists at the openhuman and tinycortex pins until they bump too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persistence failures are now reported through structured logs instead of standard error output.
  * Failed writes continue retrying, with persistence resuming automatically after temporary backend issues.
  * Failure reports are rate-limited while retaining counts for suppressed errors.
  * Recovery messages and shutdown summaries improve visibility into persistence health.
* **Documentation**
  * Updated observability guidance for failure counting, reporting intervals, recovery notifications, and retries.
* **Tests**
  * Added coverage for failure counting, retries, recovery, and rate-limited reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->