### PR TITLE
feat(tool_calling): make the module usable by a host

### DIFF
--- a/src/harness/tool_calling/mod.rs
+++ b/src/harness/tool_calling/mod.rs
@@ -41,7 +41,15 @@
 pub(crate) mod parse;
 pub(crate) mod pformat;
 
-pub use parse::{ParsedToolCall, parse_tool_calls, parse_tool_calls_with_pformat};
+// The two entry points, plus the building blocks a host legitimately reaches
+// for on its own. `extract_json_values` in particular is not a test helper:
+// pulling the first JSON object out of model prose is how a host checks a
+// required-output contract, which has nothing to do with tool calls.
+pub use parse::{
+    ParsedToolCall, extract_json_values, parse_arguments_value, parse_glm_style_tool_calls,
+    parse_tool_call_value, parse_tool_calls, parse_tool_calls_from_json_value,
+    parse_tool_calls_with_pformat,
+};
 pub use pformat::{
     PFormatParamType, PFormatRegistry, PFormatToolParams, build_registry, parse_call,
     render_signature, render_signature_from_schema,

--- a/src/harness/tool_calling/parse.rs
+++ b/src/harness/tool_calling/parse.rs
@@ -42,7 +42,13 @@ fn first_args_by_keys(obj: &serde_json::Value) -> serde_json::Value {
     parse_arguments_value(None)
 }
 
-#[cfg(test)]
+/// Parse a single JSON value as a tool call, honouring the argument-key
+/// aliases.
+///
+/// The permissive entry point: callers reach a value through an explicit
+/// tool-call marker (a `tool_calls` array, a `<tool_call>` tag, a fenced
+/// block), which is what licenses the aliases. Do not use it on arbitrary
+/// model output — see the module docs.
 pub fn parse_tool_call_value(value: &serde_json::Value) -> Option<ParsedToolCall> {
     // Default to the permissive (tagged) behaviour: callers that reach a
     // value through an explicit tool-call marker (`tool_calls` array,

--- a/src/harness/tool_calling/pformat.rs
+++ b/src/harness/tool_calling/pformat.rs
@@ -150,14 +150,19 @@ pub type PFormatRegistry = HashMap<String, PFormatToolParams>;
 /// type is its own vocabulary, and requiring it here would make this module
 /// depend on the very thing it exists to stay independent of. Hosts keep a
 /// one-line adapter over their own tool slice.
-pub fn build_registry<'a, I, N>(tools: I) -> PFormatRegistry
+///
+/// The schema is `Borrow<Value>` rather than `&Value` so a host whose tool
+/// trait *returns* a schema by value — the common shape — can map straight
+/// into this without collecting into a temporary first.
+pub fn build_registry<I, N, S>(tools: I) -> PFormatRegistry
 where
-    I: IntoIterator<Item = (N, &'a Value)>,
+    I: IntoIterator<Item = (N, S)>,
     N: Into<String>,
+    S: std::borrow::Borrow<Value>,
 {
     tools
         .into_iter()
-        .map(|(name, schema)| (name.into(), PFormatToolParams::from_schema(schema)))
+        .map(|(name, schema)| (name.into(), PFormatToolParams::from_schema(schema.borrow())))
         .collect()
 }
 


### PR DESCRIPTION
Follow-up to #102 / #105, found by wiring the first real consumer. **The module could not be compiled against** without the host keeping private copies of the code it had just stopped owning.

No behaviour change — exports and one signature widening. 24 lines.

## The three gaps

**`extract_json_values` was not exported, and it is not a test helper.** Pulling the first JSON object out of model prose is how a host validates a *required-output contract* — nothing to do with tool calls. OpenHuman calls it from **production** code (`required_output.rs`), not just tests. Exported alongside `parse_arguments_value`, `parse_glm_style_tool_calls` and `parse_tool_calls_from_json_value`, which its tests drive directly.

**`parse_tool_call_value` was `#[cfg(test)]`** — inherited from a host where it happened to be test-only. It is a reasonable public primitive (parse one JSON value as a tool call), so it is un-gated and documented rather than duplicated downstream. Its doc states what licenses the argument-key aliases, so a caller cannot reach for it on arbitrary model output by mistake.

**`build_registry` took `&Value`.** A host tool trait that *returns* a schema by value — the common shape, and OpenHuman's — then has to collect into a temporary purely to hand out references:

```rust
// before: unavoidable temporary
let schemas: Vec<(&str, Value)> = tools.iter().map(|t| (t.name(), t.parameters_schema())).collect();
build_registry(schemas.iter().map(|(n, s)| (*n, s)))

// after
build_registry(tools.iter().map(|t| (t.name(), t.parameters_schema())))
```

It takes `Borrow<Value>` now, so `Value` and `&Value` both work. This is the API wart the first consumer was always going to find.

## Why it matters

Without these the host either shadows the parsers it just moved — defeating the point of the extraction — or drops the tests covering them. With them, **all 62 of OpenHuman's parser tests run against the crate**, no coverage lost.

## Note on provenance

These changes were originally pushed onto `glm-drop-to-main` while #105 was open, but #105 merged at the earlier commit, so they never reached `main`. This re-lands them cleanly off current `main`, with the GLM fix excluded since it is already there.

## Verification

- `cargo test --all-features --lib` — **1823 passed, 0 failed, 0 ignored**
- `cargo clippy --all-features --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved tool-call parsing support, including additional argument formats and permissive parsing of explicitly marked tool calls.
  * Expanded access to tool-call parsing capabilities for integrations.
  * Tool registries can now be built from a broader range of schema value types without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->