### PR TITLE
Bound one run's journal stream

### DIFF
--- a/src/harness/observability/mod.rs
+++ b/src/harness/observability/mod.rs
@@ -162,8 +162,31 @@ impl InMemoryEventJournal {
     /// append) once exceeded. `0` means unbounded.
     pub fn with_max_runs(max_runs: usize) -> Self {
         Self {
-            state: Arc::new(Mutex::new(EventJournalState::default())),
             max_runs,
+            ..Self::default()
+        }
+    }
+
+    /// Creates a new, empty in-memory journal that retains at most
+    /// `max_entries_per_run` observations **within** each run's stream,
+    /// dropping the oldest once exceeded. `0` means unbounded, which is the
+    /// default.
+    ///
+    /// This bounds a dimension [`Self::with_max_runs`] cannot: a single
+    /// long-lived run is one stream, so it is never evicted and its entries
+    /// grow for as long as the run does. See
+    /// [`DEFAULT_JOURNAL_MAX_ENTRIES_PER_RUN`] for the measured shape that
+    /// motivates it.
+    ///
+    /// **Trimming loses observations.** A dropped entry is gone, and
+    /// [`Self::read_from`] will refuse an offset below what survives rather
+    /// than silently returning a short answer — so this is for a consumer that
+    /// exports as it goes and only ever reads recent offsets. A consumer that
+    /// reads the whole stream once at the end of the run must not use it.
+    pub fn with_max_entries_per_run(max_entries_per_run: usize) -> Self {
+        Self {
+            max_entries_per_run,
+            ..Self::default()
         }
     }
 
@@ -243,6 +266,17 @@ impl HarnessEventJournal for InMemoryEventJournal {
         });
         let offset = stream.base_offset + stream.entries.len() as u64;
         stream.entries.push(obs);
+        // Drop the oldest entries once this run's stream is over its cap,
+        // advancing `base_offset` by exactly as many as were dropped. That
+        // field already exists for run-level eviction and means the same thing
+        // here — "the first entry retained is this offset" — so `read_from`
+        // keeps numbering correctly and refuses a stale offset rather than
+        // silently returning a short answer.
+        if self.max_entries_per_run > 0 && stream.entries.len() > self.max_entries_per_run {
+            let excess = stream.entries.len() - self.max_entries_per_run;
+            stream.entries.drain(..excess);
+            stream.base_offset += excess as u64;
+        }
         Ok(offset)
     }
 

--- a/src/harness/observability/test.rs
+++ b/src/harness/observability/test.rs
@@ -754,3 +754,76 @@ async fn in_memory_backends_recover_len_from_poisoned_lock() {
     assert_eq!(store.len(), 1);
     assert!(!store.is_empty());
 }
+
+#[tokio::test]
+async fn a_long_lived_run_is_trimmed_to_its_per_run_cap() {
+    // `max_runs` bounds the wrong dimension for a run that never ends: one
+    // run is one stream, so it is never evicted and its entries grow for as
+    // long as the run does. With payload capture on, every ModelCompleted
+    // carries the whole conversation so far, so the growth is quadratic in the
+    // number of model calls — measured downstream at 1.8 GiB over 337 calls.
+    let journal = InMemoryEventJournal::with_max_entries_per_run(3);
+
+    for _ in 0..10 {
+        journal
+            .append(obs("run-0", 0, AgentEvent::StateUpdate))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(
+        journal.len("run-0"),
+        3,
+        "the cap must bound one run's stream"
+    );
+    assert_eq!(journal.run_count(), 1);
+}
+
+#[tokio::test]
+async fn a_trimmed_run_keeps_numbering_and_refuses_a_stale_offset() {
+    // The offset a trimmed stream reports must keep counting from where the
+    // run actually is, not from what survives — otherwise a consumer that
+    // exports incrementally would re-export entries it has already shipped.
+    // And an offset that has been trimmed away must *error* rather than
+    // return a short answer, which is the same contract run-level eviction
+    // already has: silently skipping entries is the failure worth refusing.
+    let journal = InMemoryEventJournal::with_max_entries_per_run(2);
+
+    let mut offsets = Vec::new();
+    for _ in 0..5 {
+        offsets.push(
+            journal
+                .append(obs("run-0", 0, AgentEvent::StateUpdate))
+                .await
+                .unwrap(),
+        );
+    }
+    assert_eq!(offsets, vec![0, 1, 2, 3, 4], "numbering must not restart");
+
+    // The last two survive, and reading from the first of them works.
+    let recent = journal.read_from("run-0", 3).await.unwrap();
+    assert_eq!(recent.len(), 2);
+
+    // Everything before that was trimmed, and asking for it is an error.
+    assert!(
+        journal.read_from("run-0", 0).await.is_err(),
+        "an offset trimmed away must be refused, never silently skipped"
+    );
+}
+
+#[tokio::test]
+async fn an_uncapped_journal_retains_everything() {
+    // The default is unbounded, because trimming loses observations and is
+    // only safe for a consumer that has already exported what it drops.
+    let journal = InMemoryEventJournal::new();
+
+    for _ in 0..50 {
+        journal
+            .append(obs("run-0", 0, AgentEvent::StateUpdate))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(journal.len("run-0"), 50);
+    assert_eq!(journal.read_from("run-0", 0).await.unwrap().len(), 50);
+}

--- a/src/harness/observability/types.rs
+++ b/src/harness/observability/types.rs
@@ -199,6 +199,29 @@ pub trait HarnessEventJournal: Send + Sync {
 /// retains before evicting the oldest (by insertion order) to bound memory.
 pub const DEFAULT_JOURNAL_MAX_RUNS: usize = 10_000;
 
+/// Default number of observations retained **within** one run's stream.
+///
+/// `0`, meaning unbounded, which is the behaviour every existing caller has.
+/// The per-run cap exists because `max_runs` bounds the wrong dimension for a
+/// long-lived run: a run that never ends is one stream, so it is never evicted,
+/// and its `Vec` grows for as long as the run does.
+///
+/// That is not a theoretical shape. With
+/// [`PayloadCapture::model_io`][crate::harness::runtime::PayloadCapture::model_io]
+/// enabled, every
+/// [`ModelCompleted`][crate::harness::events::AgentEvent::ModelCompleted]
+/// carries the request messages — which are the whole conversation so far — so
+/// observation *n* retains a copy of what observations `1..n` already retained
+/// and the stream grows quadratically in the number of model calls. Measured on
+/// a downstream agent run: 337 model calls against 1.8 GiB of resident memory,
+/// about 5.5 MB per call at inputs of ~114k tokens, climbing monotonically at
+/// ~1.9 MiB/s.
+///
+/// Left unbounded by default because trimming *loses* observations: it is only
+/// safe for a consumer that has already exported what it drops, so the caller
+/// has to opt in with [`InMemoryEventJournal::with_max_entries_per_run`].
+pub const DEFAULT_JOURNAL_MAX_ENTRIES_PER_RUN: usize = 0;
+
 /// A single run's retained observations, plus the offset its first retained
 /// entry corresponds to.
 ///
@@ -243,6 +266,9 @@ pub(crate) struct EventJournalState {
 pub struct InMemoryEventJournal {
     pub(crate) state: Arc<Mutex<EventJournalState>>,
     pub(crate) max_runs: usize,
+    /// Observations retained within one run's stream, oldest dropped first.
+    /// `0` is unbounded; see [`DEFAULT_JOURNAL_MAX_ENTRIES_PER_RUN`].
+    pub(crate) max_entries_per_run: usize,
 }
 
 impl Default for InMemoryEventJournal {
@@ -250,6 +276,7 @@ impl Default for InMemoryEventJournal {
         Self {
             state: Arc::new(Mutex::new(EventJournalState::default())),
             max_runs: DEFAULT_JOURNAL_MAX_RUNS,
+            max_entries_per_run: DEFAULT_JOURNAL_MAX_ENTRIES_PER_RUN,
         }
     }
 }


### PR DESCRIPTION
Adds `InMemoryEventJournal::with_max_entries_per_run`, so a single long-lived run cannot grow its own stream without bound.

## Why

`max_runs` bounds the number of distinct runs, which is the wrong dimension for a run that never ends: one run is one stream, so it is never evicted and its `Vec` grows for as long as the run does.

With `PayloadCapture::model_io` enabled that growth is quadratic, not linear. Every `ModelCompleted` carries the request messages — which are the whole conversation so far — so observation *n* retains a copy of what observations `1..n` already retained.

Measured on a downstream agent run (a long-lived multi-agent research loop):

- 337 model calls against **1.8 GiB** of resident anonymous memory
- ~5.5 MB retained per call, at inputs of ~114k tokens
- climbing monotonically at ~1.9 MiB/s, until the container memory cap killed the run

## What

`with_max_entries_per_run(n)` drops the oldest entries once a run's stream exceeds `n` and advances `base_offset` by exactly as many as it dropped.

`base_offset` already exists for run-level eviction and means the same thing here — "the first entry retained is at this offset" — so this reuses the existing contract rather than adding a second one:

- `append` keeps numbering from where the run actually is, so a consumer exporting incrementally never re-ships an entry
- `read_from` refuses an offset that was trimmed away, rather than silently returning a short answer

## Compatibility

Unbounded by default (`DEFAULT_JOURNAL_MAX_ENTRIES_PER_RUN = 0`), so no existing behaviour changes. Trimming *loses* observations, so it is only correct for a consumer that has already exported what it drops — a consumer that reads the whole stream once at the end of a run must not opt in. That constraint is stated on the constructor.

## Tests

Three added: the cap bounds one run's stream; a trimmed run keeps its numbering and refuses a stale offset; an uncapped journal still retains everything.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all-features` (1712 passing) are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retention limits for observations within each run.
  * Older observations are automatically removed when the configured limit is reached.
  * Observation offsets remain consistent, while reads of removed entries are rejected.
  * The default journal remains unbounded unless a limit is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->