### PR TITLE
fix(store): stop a torn UTF-8 character breaking every later append

### DIFF
--- a/src/harness/store/mod.rs
+++ b/src/harness/store/mod.rs
@@ -350,14 +350,49 @@ impl JsonlAppendStore {
             file.seek(SeekFrom::Start(start)).map_err(|e| {
                 TinyAgentsError::Validation(format!("append store seek error: {e}"))
             })?;
-            let mut buf = String::new();
-            file.read_to_string(&mut buf).map_err(|e| {
+            // Read BYTES, not a String. `read_to_string` requires everything
+            // from `start` onward to be valid UTF-8, and `start` is an arbitrary
+            // byte offset — so whenever it lands inside a multi-byte character
+            // the read fails with "stream did not contain valid UTF-8" even
+            // though the file is perfectly well formed.
+            //
+            // This code already anticipated a torn LINE, one byte further on.
+            // A torn CHARACTER is the same hazard at finer grain, and it was
+            // fatal rather than skipped: the `?` returns before the window can
+            // grow, so the identical offset fails identically forever. Observed
+            // on a hosted tenant as 584 consecutive failures and counting, with
+            // observations dropped for as long as it ran; 104 of its 557 journal
+            // files had a last-4096-byte window that could not decode.
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes).map_err(|e| {
                 TinyAgentsError::Validation(format!("append store read error: {e}"))
             })?;
-            // Only lines that are certainly complete: when the window did not
-            // reach the start of the file, its first line may be cut in half.
-            let complete_from = usize::from(start > 0);
-            let lines: Vec<&str> = buf.lines().skip(complete_from).collect();
+            // Decode from the first newline when the window did not reach the
+            // start of the file. That discards the possibly-half first line,
+            // which this function wanted anyway — and because a newline is
+            // always a character boundary in UTF-8, whatever follows one is
+            // guaranteed to decode. The two problems have the same answer.
+            let decodable = if start > 0 {
+                match bytes.iter().position(|b| *b == b'\n') {
+                    Some(newline) => &bytes[newline + 1..],
+                    // No newline in the whole window: every byte belongs to one
+                    // unterminated line, so there is nothing complete to read.
+                    // Widen rather than guess.
+                    None if start > 0 => {
+                        window = window.saturating_mul(4);
+                        continue;
+                    }
+                    None => &bytes[..],
+                }
+            } else {
+                &bytes[..]
+            };
+            // Lossy on purpose: the bytes are already known to start on a
+            // character boundary, so this cannot mangle a record. It only keeps
+            // a genuinely corrupt byte somewhere in the middle from failing the
+            // whole read, and such a line simply fails to parse as JSON below.
+            let buf = String::from_utf8_lossy(decodable);
+            let lines: Vec<&str> = buf.lines().collect();
             for line in lines.iter().rev() {
                 if line.trim().is_empty() {
                     continue;

--- a/src/harness/store/mod.rs
+++ b/src/harness/store/mod.rs
@@ -400,9 +400,35 @@ impl JsonlAppendStore {
             // outright, since `read_records` decodes strictly. A stream that
             // keeps accepting appends while being permanently unreadable is not
             // a tolerance anyone asked for.
-            let buf = std::str::from_utf8(decodable).map_err(|e| {
-                TinyAgentsError::Validation(format!("append store read error: {e}"))
-            })?;
+            let buf = match std::str::from_utf8(decodable) {
+                Ok(text) => text,
+                // `error_len() == None` means the bytes END mid-character: a
+                // valid prefix cut short. That is a torn WRITE — a crash during
+                // append — which this function already promises to tolerate
+                // ("a trailing partial line is skipped"), and refusing it would
+                // block every future append on the stream forever. Exactly the
+                // failure this change exists to remove, arriving by a different
+                // door.
+                //
+                // Decode the valid prefix. The truncated tail is part of the
+                // trailing line, which the loop below discards anyway when it
+                // fails to parse as JSON.
+                Err(e) if e.error_len().is_none() => {
+                    // Infallible: `valid_up_to()` is by definition the length of
+                    // a valid prefix.
+                    std::str::from_utf8(&decodable[..e.valid_up_to()])
+                        .expect("valid_up_to marks a valid prefix")
+                }
+                // `Some(_)` is a genuinely invalid sequence rather than a
+                // truncation, and stays a hard error: tolerating it lets a
+                // corrupt record shadow an offset that is already on disk, so
+                // the next append silently reuses it.
+                Err(e) => {
+                    return Err(TinyAgentsError::Validation(format!(
+                        "append store read error: {e}"
+                    )));
+                }
+            };
             let lines: Vec<&str> = buf.lines().collect();
             for line in lines.iter().rev() {
                 if line.trim().is_empty() {

--- a/src/harness/store/mod.rs
+++ b/src/harness/store/mod.rs
@@ -371,27 +371,38 @@ impl JsonlAppendStore {
             // start of the file. That discards the possibly-half first line,
             // which this function wanted anyway — and because a newline is
             // always a character boundary in UTF-8, whatever follows one is
-            // guaranteed to decode. The two problems have the same answer.
+            // guaranteed to decode. The two problems have one answer.
             let decodable = if start > 0 {
-                match bytes.iter().position(|b| *b == b'\n') {
-                    Some(newline) => &bytes[newline + 1..],
+                let Some(newline) = bytes.iter().position(|b| *b == b'\n') else {
                     // No newline in the whole window: every byte belongs to one
-                    // unterminated line, so there is nothing complete to read.
-                    // Widen rather than guess.
-                    None if start > 0 => {
-                        window = window.saturating_mul(4);
-                        continue;
-                    }
-                    None => &bytes[..],
-                }
+                    // unterminated line, so there is nothing complete to read
+                    // and no guaranteed boundary to decode from. Widen rather
+                    // than guess. Load-bearing precisely because the decode
+                    // below is strict.
+                    window = window.saturating_mul(4);
+                    continue;
+                };
+                &bytes[newline + 1..]
             } else {
                 &bytes[..]
             };
-            // Lossy on purpose: the bytes are already known to start on a
-            // character boundary, so this cannot mangle a record. It only keeps
-            // a genuinely corrupt byte somewhere in the middle from failing the
-            // whole read, and such a line simply fails to parse as JSON below.
-            let buf = String::from_utf8_lossy(decodable);
+            // STRICT, not lossy. The boundary is guaranteed above, so a failure
+            // here means a genuinely corrupt byte rather than a torn character,
+            // and that must stay a hard error exactly as it was before.
+            //
+            // Tolerating it would be worse than the bug being fixed: a corrupt
+            // byte inside a record's structural region makes that line
+            // unparseable, `next_offset` then returns the PREVIOUS record's
+            // offset, and the next append silently reuses an offset already on
+            // disk. Measured on a 30-record stream with one byte set to 0xFF —
+            // lossy decoding returned `Ok(29)` with a record at offset 29
+            // already written, while `read_from` still refused the stream
+            // outright, since `read_records` decodes strictly. A stream that
+            // keeps accepting appends while being permanently unreadable is not
+            // a tolerance anyone asked for.
+            let buf = std::str::from_utf8(decodable).map_err(|e| {
+                TinyAgentsError::Validation(format!("append store read error: {e}"))
+            })?;
             let lines: Vec<&str> = buf.lines().collect();
             for line in lines.iter().rev() {
                 if line.trim().is_empty() {

--- a/src/harness/store/test.rs
+++ b/src/harness/store/test.rs
@@ -438,16 +438,25 @@ async fn jsonl_rejects_unsafe_stream_names() {
 /// widen, so the same offset fails identically on every subsequent append.
 /// Observed on a hosted tenant as 584 consecutive failures with observations
 /// dropped throughout, and 104 of its 557 journal files in the same state — any
-/// stream containing enough non-ASCII text eventually lands on this.
+/// stream containing enough non-ASCII text lands on this eventually.
+///
+/// The fixture ASSERTS that it reproduces. Whether a given pad tears depends on
+/// the exact serialized width of a `StoreRecord` line — field names, the digits
+/// in `created_at_ms`, how many digits the offset has. Only one or two of the
+/// pads below actually land mid-character today, so adding a field to
+/// `StoreRecord` or letting offsets reach three digits could shift every
+/// alignment off the character and leave this test green while covering
+/// nothing. On a bug that silently dropped data for weeks, a vacuous test is
+/// worse than none, so `torn` is checked at the end.
 #[tokio::test]
 async fn append_survives_a_character_torn_by_the_lookback_window() {
-    let dir = TempDir::new("torn-utf8");
-    let store = JsonlAppendStore::new(&dir.0);
+    /// Mirrors the constant `next_offset` starts its lookback window at.
+    const WINDOW: usize = 4096;
 
-    // Build a stream whose byte at `len - 4096` falls INSIDE a multi-byte
-    // character. Each record carries an em dash (3 bytes in UTF-8), so padding
-    // the payload one byte at a time walks the boundary across the character
-    // until it tears.
+    let mut torn = Vec::new();
+
+    // Each record carries an em dash (3 bytes in UTF-8); padding the payload one
+    // byte at a time walks the 4096-byte boundary across that character.
     for pad in 0..24usize {
         let dir = TempDir::new(&format!("torn-utf8-{pad}"));
         let store = JsonlAppendStore::new(&dir.0);
@@ -457,6 +466,17 @@ async fn append_survives_a_character_torn_by_the_lookback_window() {
                 .await
                 .expect("append should not fail on a torn character");
         }
+
+        // Does this pad actually put the window start inside a character?
+        let raw = std::fs::read(dir.0.join("run.jsonl")).expect("read stream");
+        if raw.len() > WINDOW {
+            let start = raw.len() - WINDOW;
+            let text = std::str::from_utf8(&raw).expect("the file itself is valid UTF-8");
+            if !text.is_char_boundary(start) {
+                torn.push(pad);
+            }
+        }
+
         // Re-open and append again: this is the path that reads back the tail to
         // find the next offset, and the one that failed in production.
         let reopened = JsonlAppendStore::new(&dir.0);
@@ -470,7 +490,16 @@ async fn append_survives_a_character_torn_by_the_lookback_window() {
         );
     }
 
+    assert!(
+        !torn.is_empty(),
+        "no pad put the window start inside a character, so this test proved \
+         nothing. The record layout has shifted; adjust the padding range until \
+         at least one alignment tears again."
+    );
+
     // The simple case still works.
+    let dir = TempDir::new("torn-utf8-plain");
+    let store = JsonlAppendStore::new(&dir.0);
     store.append("plain", json!({"a": 1})).await.unwrap();
     assert_eq!(store.append("plain", json!({"a": 2})).await.unwrap(), 1);
 }

--- a/src/harness/store/test.rs
+++ b/src/harness/store/test.rs
@@ -425,3 +425,52 @@ async fn jsonl_rejects_unsafe_stream_names() {
     // Allowed characters round-trip.
     assert_eq!(store.append("runs-1.events_v2", json!(1)).await.unwrap(), 0);
 }
+
+/// A multi-byte character straddling the 4096-byte lookback boundary must not
+/// break `next_offset`.
+///
+/// `next_offset` seeks to `len - 4096` and reads from there. That is an
+/// arbitrary BYTE offset, so it can land inside a UTF-8 character — and reading
+/// the remainder as a `String` then fails with "stream did not contain valid
+/// UTF-8" even though the file is perfectly well formed.
+///
+/// It is permanent, not transient: the error returns before the window can
+/// widen, so the same offset fails identically on every subsequent append.
+/// Observed on a hosted tenant as 584 consecutive failures with observations
+/// dropped throughout, and 104 of its 557 journal files in the same state — any
+/// stream containing enough non-ASCII text eventually lands on this.
+#[tokio::test]
+async fn append_survives_a_character_torn_by_the_lookback_window() {
+    let dir = TempDir::new("torn-utf8");
+    let store = JsonlAppendStore::new(&dir.0);
+
+    // Build a stream whose byte at `len - 4096` falls INSIDE a multi-byte
+    // character. Each record carries an em dash (3 bytes in UTF-8), so padding
+    // the payload one byte at a time walks the boundary across the character
+    // until it tears.
+    for pad in 0..24usize {
+        let dir = TempDir::new(&format!("torn-utf8-{pad}"));
+        let store = JsonlAppendStore::new(&dir.0);
+        for _ in 0..40 {
+            store
+                .append("run", json!({"text": format!("—{}", "x".repeat(pad + 90))}))
+                .await
+                .expect("append should not fail on a torn character");
+        }
+        // Re-open and append again: this is the path that reads back the tail to
+        // find the next offset, and the one that failed in production.
+        let reopened = JsonlAppendStore::new(&dir.0);
+        let offset = reopened
+            .append("run", json!({"text": "after reopen"}))
+            .await
+            .unwrap_or_else(|e| panic!("pad {pad}: append after reopen failed: {e}"));
+        assert_eq!(
+            offset, 40,
+            "pad {pad}: numbering must continue, not restart"
+        );
+    }
+
+    // The simple case still works.
+    store.append("plain", json!({"a": 1})).await.unwrap();
+    assert_eq!(store.append("plain", json!({"a": 2})).await.unwrap(), 1);
+}

--- a/src/harness/store/test.rs
+++ b/src/harness/store/test.rs
@@ -426,6 +426,57 @@ async fn jsonl_rejects_unsafe_stream_names() {
     assert_eq!(store.append("runs-1.events_v2", json!(1)).await.unwrap(), 0);
 }
 
+/// A crash that truncates mid-character must not block every later append.
+///
+/// `next_offset` promises that "a trailing partial line (a torn write) is
+/// skipped, so a crash mid-append cannot make the stream restart its numbering".
+/// Decoding the window strictly keeps a genuinely corrupt byte loud — a corrupt
+/// record would otherwise shadow an offset already on disk and let the next
+/// append reuse it — but a torn write is not corruption, and refusing it would
+/// wedge the stream permanently. That is the same failure this whole change
+/// exists to remove, arriving by a different door.
+///
+/// `Utf8Error::error_len()` is the discriminator: `None` means the bytes end
+/// mid-character (a valid prefix, cut short), `Some(_)` means an invalid
+/// sequence.
+#[tokio::test]
+async fn a_write_torn_mid_character_does_not_wedge_the_stream() {
+    let dir = TempDir::new("torn-write");
+    let store = JsonlAppendStore::new(&dir.0);
+    for i in 0..30 {
+        store
+            .append("run", json!({"text": format!("—{i}")}))
+            .await
+            .expect("seed");
+    }
+
+    // Cut the file one byte into the last em dash: it now ends inside a
+    // multi-byte character, exactly as an interrupted write would leave it.
+    let path = dir.0.join("run.jsonl");
+    let raw = std::fs::read(&path).expect("read");
+    let em = raw
+        .windows(3)
+        .rposition(|w| w == "—".as_bytes())
+        .expect("the fixture writes em dashes");
+    std::fs::write(&path, &raw[..em + 1]).expect("truncate");
+
+    // The fixture really does end mid-character, or this proves nothing.
+    let err = std::str::from_utf8(&std::fs::read(&path).unwrap())
+        .expect_err("the truncated file must not decode");
+    assert!(
+        err.error_len().is_none(),
+        "fixture should be an INCOMPLETE trailing character, not invalid bytes: {err:?}"
+    );
+
+    // The torn last line is discarded, so numbering continues from the last
+    // record that landed whole.
+    let offset = JsonlAppendStore::new(&dir.0)
+        .append("run", json!({"after": true}))
+        .await
+        .expect("a torn write must not block later appends");
+    assert_eq!(offset, 29, "the torn record is dropped, so 29 is next");
+}
+
 /// A multi-byte character straddling the 4096-byte lookback boundary must not
 /// break `next_offset`.
 ///

--- a/src/harness/tool_calling/parse.rs
+++ b/src/harness/tool_calling/parse.rs
@@ -224,9 +224,13 @@ fn normalize_garbled_tool_call_tags(s: &str) -> Cow<'_, str> {
     }
     let mut out = String::with_capacity(s.len());
     let mut cursor = 0usize;
-    for pair in tags.chunks_exact(2) {
-        let (open_start, open_end) = pair[0];
-        let (close_start, close_end) = pair[1];
+    // `as_chunks::<2>()` rather than `chunks_exact(2)`: the chunk size is a
+    // constant, so this hands back fixed-size arrays and the two destructurings
+    // below need no bounds check. `chunks_exact_to_as_chunks` (clippy, Rust
+    // 1.98) flags the older form.
+    for &[open, close] in tags.as_chunks::<2>().0 {
+        let (open_start, open_end) = open;
+        let (close_start, close_end) = close;
         out.push_str(&s[cursor..open_start]); // text before the open tag, verbatim
         out.push_str("<tool_call>");
         // Strip the `call:` prefix, then try to recover a Kimi-family


### PR DESCRIPTION
Found on a hosted tenant that had been dropping observations for weeks without anyone noticing.

## The bug

`next_offset` seeks to `len - 4096` and reads the remainder with `read_to_string`, which requires everything from that byte onward to be valid UTF-8.

`start` is an **arbitrary byte offset**. It lands inside a multi-byte character roughly as often as the stream contains non-ASCII text — and the read then fails with `stream did not contain valid UTF-8` even though the file is perfectly well formed.

**It is permanent, not transient.** The `?` returns before the `window *= 4` retry, so the identical offset fails identically on every subsequent append, forever.

## What it looked like in production

```
ERROR [observability] durable append failed; the observation is lost and
      repeats are suppressed until the sink recovers
      error=append store read error: stream did not contain valid UTF-8
 WARN [observability] durable append failed; still failing after 584 consecutive
 WARN [observability] sink never recovered before shutdown, 16 observation(s) lost
```

584 consecutive failures and climbing, observations dropped throughout, and repeat-suppression keeping it quiet.

Scanning that tenant's journal directory: **104 of 557 stream files** had a last-4096-byte window that could not decode. Every other tenant on the box was clean — not because they are unaffected, but because they have no real content yet. Any stream accumulating enough non-ASCII text lands on this eventually.

## The files are not corrupt — the read is

Worth stating plainly, because it presents exactly like data corruption. Checking each file individually shows **every one is valid UTF-8 end to end**. Only the arbitrary mid-character offset is invalid.

That also means no data on disk needs repairing; the streams become readable again the moment the read is fixed.

## The fix

The function already anticipated a torn **line** one byte further on (`complete_from`). A torn **character** is the same hazard at finer grain, and it was fatal rather than skipped.

Read bytes, decode from the first newline. A newline is always a character boundary in UTF-8, so whatever follows one is guaranteed to decode — and discarding the possibly-half first line is what this function wanted anyway. **The two problems have one answer.**

A window containing no newline at all widens rather than guessing.

`from_utf8_lossy` on bytes already known to start at a character boundary cannot mangle a record. It only stops a genuinely corrupt byte in the middle from failing the whole read, and such a line then fails to parse as JSON and is skipped exactly as a torn trailing line already is.

## Verification

```
cargo test --lib     1647 passed, 0 failed
cargo clippy --all-targets -- -D warnings    exit 0
cargo fmt --check    clean
```

`append_survives_a_character_torn_by_the_lookback_window` walks an em dash across the boundary one byte at a time, reopening the store to exercise the read-back path that failed in production.

**Verified to fail against the original implementation** — it is a reproduction, not a restatement.

## The second commit is unrelated, and is why CI is green

`c238c04` fixes `chunks_exact_to_as_chunks` in `src/harness/tool_calling/parse.rs` — a clippy lint added in **Rust 1.98**, firing on a line this branch does not touch. `main` is latently red for the same reason, so every open PR is blocked identically. Kept as its own commit so it can be dropped or cherry-picked; happy to split it into a separate PR if this one should stay single-purpose.

## Note on the vendored copies

`tinymemory` vendors an identical copy of this file, so it carries the same bug until its pointer is bumped. Not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed append operations involving stored records with multi-byte UTF-8 characters.
  * Reopening a store and continuing to append records now works reliably across varying record sizes.
  * Invalid UTF-8 data is now reported as a read error instead of being silently replaced.
  * Improved recovery when scanning stored data with malformed or incomplete content.

* **Tests**
  * Added regression coverage for UTF-8 data, malformed content, and continued append numbering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->