### PR TITLE
feat(harness): multimodal attachment resolution behind a default-off feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +228,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -676,6 +701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,10 +1283,12 @@ name = "tinyagents"
 version = "2.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "chrono-tz",
  "dotenvy",
+ "flate2",
  "futures",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,24 @@ rusqlite = { version = "0.40", features = ["bundled"], optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.10", optional = true }
 
+# ── `multimodal` feature deps ────────────────────────────────────────────
+# Both are optional and reached only through `harness::multimodal`, so a host
+# that does not turn the feature on resolves neither.
+#
+# `base64` decodes and re-encodes `data:` URI payloads. The engine choice is
+# load-bearing rather than incidental: a complete four-character group is what
+# `STANDARD` accepts (padded or not) and only a partial group needs
+# `STANDARD_NO_PAD`, so `harness::multimodal::data_uri` picks by length instead
+# of trying both — trying both decoded a multi-MB image twice for every
+# unpadded payload.
+base64 = { version = "0.22", optional = true }
+# `flate2` decompresses `application/gzip` data URIs that carry an
+# `original_mime=` parameter — the shape a renderer emits when it compresses an
+# attachment before handing it over. Decompression is bounded by `Read::take`
+# against the caller's byte cap, so a zip bomb fails the cap rather than the
+# allocator.
+flate2 = { version = "1", optional = true }
+
 [features]
 default = []
 # Embedded SQLite-backed checkpointer (`graph::checkpoint::SqliteCheckpointer`).
@@ -72,6 +90,12 @@ sqlite = ["dep:rusqlite"]
 # Builtin generic tools (`harness::tools`) kept out of the default dependency
 # graph so host applications can choose whether they want these implementations.
 tools = ["dep:chrono-tz"]
+# Attachment resolution for `[IMAGE:…]` / `[FILE:…]` markers
+# (`harness::multimodal`): marker parsing, `data:` URI decoding, MIME
+# detection, size/count limits, and the rendered provider payload. Off by
+# default because a host that never carries attachments should not resolve
+# `base64` / `flate2`.
+multimodal = ["dep:base64", "dep:flate2"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "test-util"] }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -28,6 +28,8 @@ pub mod memory;
 pub mod message;
 pub mod middleware;
 pub mod model;
+#[cfg(feature = "multimodal")]
+pub mod multimodal;
 pub mod no_progress;
 pub mod observability;
 pub mod prompt;

--- a/src/harness/multimodal/config.rs
+++ b/src/harness/multimodal/config.rs
@@ -1,0 +1,167 @@
+//! Crate-owned attachment limits.
+//!
+//! Follows the [`harness::config`](crate::harness::config) convention: the
+//! crate defines the struct, the host maps its own schema into it. Nothing
+//! here reads a file or an environment variable.
+//!
+//! ## Why the clamps live here
+//!
+//! [`ImageLimits::effective`] and [`FileLimits::effective`] clamp the
+//! configured values into runtime bounds. That clamping is part of the
+//! resolution contract, not host policy: a host that forgot to clamp would
+//! hand an unbounded `max_image_size_mb` straight into an allocation. Hosts
+//! still choose the *configured* values; the crate only refuses to act on
+//! absurd ones.
+//!
+//! ## The one asymmetry worth knowing
+//!
+//! `max_files == 0` is a **hard-disable sentinel**, and it is checked before
+//! the clamp rather than after. The clamp lifts `0` to `1`, so a caller that
+//! only consulted [`FileLimits::effective`] would admit a single file marker
+//! from a source that asked for none. [`FileLimits::files_disabled`] is the
+//! check that must run first; [`resolve`](super::resolve) does exactly that.
+
+use serde::{Deserialize, Serialize};
+
+/// Image MIME types the provider contract accepts.
+///
+/// Not configurable: this is the set the inline-`data:`-URI path can actually
+/// encode, so a host adding to it would produce a payload no provider reads.
+pub const ALLOWED_IMAGE_MIME_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "image/bmp",
+];
+
+/// Per-turn limits for `[IMAGE:…]` markers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ImageLimits {
+    /// Maximum images accepted in one turn. Clamped to `1..=16`.
+    pub max_images: usize,
+    /// Maximum decoded size of a single image, in MiB. Clamped to `1..=20`.
+    pub max_image_size_mb: usize,
+    /// Whether `http(s)` image references may be fetched.
+    pub allow_remote_fetch: bool,
+}
+
+impl Default for ImageLimits {
+    fn default() -> Self {
+        Self {
+            max_images: 4,
+            max_image_size_mb: 8,
+            allow_remote_fetch: false,
+        }
+    }
+}
+
+impl ImageLimits {
+    /// Clamp configured values into runtime bounds: `(max_images, max_image_size_mb)`.
+    pub fn effective(&self) -> (usize, usize) {
+        (
+            self.max_images.clamp(1, 16),
+            self.max_image_size_mb.clamp(1, 20),
+        )
+    }
+
+    /// Effective per-image byte cap, saturating rather than overflowing.
+    pub fn max_image_bytes(&self) -> usize {
+        self.effective().1.saturating_mul(1024 * 1024)
+    }
+}
+
+/// Per-turn limits for `[FILE:…]` markers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FileLimits {
+    /// Maximum files accepted in one turn. Clamped to `1..=16` — except `0`,
+    /// which is the hard-disable sentinel checked by
+    /// [`FileLimits::files_disabled`] before any clamp applies.
+    pub max_files: usize,
+    /// Maximum size of a single file, in MiB. Clamped to `1..=50`.
+    pub max_file_size_mb: usize,
+    /// Maximum extracted text retained per file, in Unicode scalar values.
+    /// Clamped to `1_000..=200_000`.
+    pub max_extracted_text_chars: usize,
+    /// Whether `http(s)` file references may be fetched.
+    pub allow_remote_fetch: bool,
+    /// MIME allowlist. Unlike images this *is* host-configurable: which
+    /// document formats are acceptable is a product decision, and the
+    /// binary-only ones surface as metadata references rather than bytes.
+    pub allowed_mime_types: Vec<String>,
+}
+
+impl Default for FileLimits {
+    fn default() -> Self {
+        Self {
+            max_files: 4,
+            max_file_size_mb: 16,
+            max_extracted_text_chars: 50_000,
+            allow_remote_fetch: false,
+            allowed_mime_types: default_allowed_file_mime_types(),
+        }
+    }
+}
+
+/// The default file MIME allowlist: extractable prose formats plus the
+/// binary-only formats that surface as metadata-only references.
+pub fn default_allowed_file_mime_types() -> Vec<String> {
+    [
+        // Extractable text formats.
+        "application/pdf",
+        "text/plain",
+        "text/csv",
+        "text/markdown",
+        // Binary-only formats surfaced as metadata-only references.
+        "application/zip",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/octet-stream",
+    ]
+    .iter()
+    .map(|value| (*value).to_string())
+    .collect()
+}
+
+impl FileLimits {
+    /// Clamp configured values into runtime bounds:
+    /// `(max_files, max_file_size_mb, max_extracted_text_chars)`.
+    pub fn effective(&self) -> (usize, usize, usize) {
+        (
+            self.max_files.clamp(1, 16),
+            self.max_file_size_mb.clamp(1, 50),
+            self.max_extracted_text_chars.clamp(1_000, 200_000),
+        )
+    }
+
+    /// Effective per-file byte cap, saturating rather than overflowing.
+    pub fn max_file_bytes(&self) -> usize {
+        self.effective().1.saturating_mul(1024 * 1024)
+    }
+
+    /// `true` when file markers are disabled outright.
+    ///
+    /// The sentinel exists so a host can refuse `[FILE:…]` resolution for a
+    /// turn whose text came from somewhere it does not trust, without editing
+    /// the operator's own allowlist. It must be consulted **before**
+    /// [`FileLimits::effective`], whose clamp lifts `0` to `1`.
+    pub fn files_disabled(&self) -> bool {
+        self.max_files == 0
+    }
+
+    /// `true` iff `mime` is on the allowlist, case-insensitively.
+    pub fn is_mime_allowed(&self, mime: &str) -> bool {
+        let needle = mime.to_ascii_lowercase();
+        self.allowed_mime_types
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(&needle))
+    }
+
+    /// The allowlist rendered for an error message.
+    pub fn supported_rendered(&self) -> String {
+        self.allowed_mime_types.join(", ")
+    }
+}

--- a/src/harness/multimodal/data_uri.rs
+++ b/src/harness/multimodal/data_uri.rs
@@ -13,7 +13,7 @@
 
 use std::io::Read;
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use flate2::read::GzDecoder;
 
 /// A decoded `data:` URI.

--- a/src/harness/multimodal/data_uri.rs
+++ b/src/harness/multimodal/data_uri.rs
@@ -1,0 +1,135 @@
+//! `data:` URI parsing, including the compressed-attachment shape.
+//!
+//! A renderer that gzips an attachment before handing it over emits
+//! `data:application/gzip;base64,…` with an `original_mime=` parameter naming
+//! what the bytes decompress to. That parameter is **required** rather than
+//! guessed: without it there is no way to validate the payload against a MIME
+//! allowlist, and a gzip stream that decompresses to anything at all would pass
+//! a check keyed on `application/gzip`.
+//!
+//! Decompression is bounded by [`Read::take`] against the caller's byte cap
+//! plus one, so an over-cap payload is detected by the extra byte rather than
+//! by allocating the whole thing first.
+
+use std::io::Read;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use flate2::read::GzDecoder;
+
+/// A decoded `data:` URI.
+#[derive(Debug, Clone)]
+pub struct ParsedDataUri {
+    /// Lower-cased MIME type from the header.
+    pub mime: String,
+    /// Header parameters other than `base64`, lower-cased keys, percent-decoded
+    /// values.
+    pub params: Vec<(String, String)>,
+    /// The decoded payload.
+    pub bytes: Vec<u8>,
+}
+
+/// Parse a base64 `data:` URI.
+///
+/// Only base64 URIs are supported: the percent-encoded form has no size
+/// discipline and nothing this crate consumes emits it.
+///
+/// The `Err` is a plain reason string rather than a
+/// [`MultimodalError`](super::error::MultimodalError) because the caller knows
+/// whether it is resolving an image or a file, and that decides which variant
+/// the reason belongs in.
+pub fn parse_data_uri(source: &str) -> Result<ParsedDataUri, String> {
+    let Some(comma_idx) = source.find(',') else {
+        return Err("expected data URI payload".to_string());
+    };
+
+    let header = &source[..comma_idx];
+    let payload = source[comma_idx + 1..].trim();
+
+    if !header.contains(";base64") {
+        return Err("only base64 data URIs are supported".to_string());
+    }
+
+    let mut parts = header.trim_start_matches("data:").split(';');
+    let mime = parts.next().unwrap_or_default().trim().to_ascii_lowercase();
+    let params = parts
+        .filter_map(|part| {
+            if part.eq_ignore_ascii_case("base64") {
+                return None;
+            }
+            let (key, value) = part.split_once('=')?;
+            Some((
+                key.trim().to_ascii_lowercase(),
+                percent_decode(value.trim()).unwrap_or_else(|| value.trim().to_string()),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    let bytes = STANDARD
+        .decode(payload)
+        .map_err(|error| format!("invalid base64 payload: {error}"))?;
+
+    Ok(ParsedDataUri {
+        mime,
+        params,
+        bytes,
+    })
+}
+
+/// Look up a header parameter, case-insensitively.
+pub fn data_uri_param(params: &[(String, String)], key: &str) -> Option<String> {
+    params
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.clone())
+}
+
+/// Percent-decode a parameter value, or `None` when it is malformed.
+///
+/// Malformed input yields `None` rather than a lossy best effort so the caller
+/// can fall back to the raw value — a filename containing a bare `%` is far
+/// more likely than a filename that meant to be percent-encoded and was not.
+pub fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok()?;
+            let byte = u8::from_str_radix(hex, 16).ok()?;
+            out.push(byte);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+/// Decompress a gzip payload, refusing anything over `max_decompressed_bytes`.
+///
+/// The reader is capped at `max + 1` so an over-cap stream is caught by the
+/// spare byte instead of being fully materialised first — the difference
+/// between rejecting a zip bomb and being one.
+pub fn gunzip(bytes: &[u8], max_decompressed_bytes: usize) -> Result<Vec<u8>, String> {
+    let limit = max_decompressed_bytes.saturating_add(1) as u64;
+    let mut decoder = GzDecoder::new(bytes).take(limit);
+    let mut out = Vec::new();
+    decoder
+        .read_to_end(&mut out)
+        .map_err(|error| format!("invalid gzip payload: {error}"))?;
+    if out.len() > max_decompressed_bytes {
+        return Err(format!(
+            "decompressed payload exceeds {max_decompressed_bytes} bytes"
+        ));
+    }
+    Ok(out)
+}
+
+/// Encode `bytes` as a canonical `data:<mime>;base64,…` URI.
+pub fn encode_data_uri(mime: &str, bytes: &[u8]) -> String {
+    format!("data:{mime};base64,{}", STANDARD.encode(bytes))
+}

--- a/src/harness/multimodal/error.rs
+++ b/src/harness/multimodal/error.rs
@@ -20,7 +20,9 @@ pub enum MultimodalError {
     },
 
     /// A resolved image exceeded the configured per-image byte cap.
-    #[error("multimodal image size limit exceeded for '{input}': {size_bytes} bytes > {max_bytes} bytes")]
+    #[error(
+        "multimodal image size limit exceeded for '{input}': {size_bytes} bytes > {max_bytes} bytes"
+    )]
     ImageTooLarge {
         /// The reference as written in the marker.
         input: String,

--- a/src/harness/multimodal/error.rs
+++ b/src/harness/multimodal/error.rs
@@ -1,0 +1,162 @@
+//! Failure modes of attachment resolution.
+//!
+//! Every variant carries the offending `input` verbatim. That is deliberate:
+//! a turn can reference several attachments and the caller has to be able to
+//! say *which* one it could not use, which a bare "unsupported MIME type"
+//! cannot.
+
+use thiserror::Error;
+
+/// An attachment reference that could not be resolved into a payload.
+#[derive(Debug, Error)]
+pub enum MultimodalError {
+    /// More `[IMAGE:…]` markers in the turn than the configured cap allows.
+    #[error("multimodal image limit exceeded: max_images={max_images}, found={found}")]
+    TooManyImages {
+        /// The effective cap.
+        max_images: usize,
+        /// How many markers the turn carried.
+        found: usize,
+    },
+
+    /// A resolved image exceeded the configured per-image byte cap.
+    #[error("multimodal image size limit exceeded for '{input}': {size_bytes} bytes > {max_bytes} bytes")]
+    ImageTooLarge {
+        /// The reference as written in the marker.
+        input: String,
+        /// Measured size.
+        size_bytes: usize,
+        /// The effective cap.
+        max_bytes: usize,
+    },
+
+    /// The image's MIME type is not one the provider contract accepts.
+    #[error("multimodal image MIME type is not allowed for '{input}': {mime}")]
+    UnsupportedMime {
+        /// The reference as written in the marker.
+        input: String,
+        /// The detected MIME type.
+        mime: String,
+    },
+
+    /// An `http(s)` image reference arrived with remote fetch turned off.
+    #[error("multimodal remote image fetch is disabled for '{input}'")]
+    RemoteFetchDisabled {
+        /// The reference as written in the marker.
+        input: String,
+    },
+
+    /// A local image path did not resolve to a readable file.
+    #[error("multimodal image source not found or unreadable: '{input}'")]
+    ImageSourceNotFound {
+        /// The reference as written in the marker.
+        input: String,
+    },
+
+    /// The marker was structurally invalid (bad `data:` URI, bad gzip, …).
+    #[error("invalid multimodal image marker '{input}': {reason}")]
+    InvalidMarker {
+        /// The reference as written in the marker.
+        input: String,
+        /// What was wrong with it.
+        reason: String,
+    },
+
+    /// The remote image fetch itself failed.
+    #[error("failed to download remote image '{input}': {reason}")]
+    RemoteFetchFailed {
+        /// The reference as written in the marker.
+        input: String,
+        /// Transport or status detail.
+        reason: String,
+    },
+
+    /// The local image read itself failed.
+    #[error("failed to read local image '{input}': {reason}")]
+    LocalReadFailed {
+        /// The reference as written in the marker.
+        input: String,
+        /// I/O detail.
+        reason: String,
+    },
+
+    /// More `[FILE:…]` markers in the turn than the configured cap allows.
+    #[error("multimodal file limit exceeded: max_files={max_files}, found={found}")]
+    TooManyFiles {
+        /// The effective cap. `0` is the hard-disable sentinel — see
+        /// [`FileLimits::files_disabled`](super::config::FileLimits::files_disabled).
+        max_files: usize,
+        /// How many markers the turn carried.
+        found: usize,
+    },
+
+    /// A resolved file exceeded the configured per-file byte cap.
+    #[error(
+        "multimodal file size limit exceeded for '{input}': {size_bytes} bytes > {max_bytes} bytes"
+    )]
+    FileTooLarge {
+        /// The reference as written in the marker.
+        input: String,
+        /// Measured size.
+        size_bytes: usize,
+        /// The effective cap.
+        max_bytes: usize,
+    },
+
+    /// The file's MIME type is not on the host's allowlist.
+    #[error(
+        "multimodal file MIME type '{mime}' for '{input}' is not allowed; supported: {supported}"
+    )]
+    UnsupportedFileMime {
+        /// The reference as written in the marker.
+        input: String,
+        /// The detected MIME type.
+        mime: String,
+        /// The configured allowlist, rendered for the message.
+        supported: String,
+    },
+
+    /// A local file path did not resolve to a readable file.
+    #[error("multimodal file source not found or unreadable: '{input}'")]
+    FileSourceNotFound {
+        /// The reference as written in the marker.
+        input: String,
+    },
+
+    /// An `http(s)` file reference arrived with remote fetch turned off.
+    #[error("multimodal remote file fetch is disabled for '{input}'")]
+    RemoteFileFetchDisabled {
+        /// The reference as written in the marker.
+        input: String,
+    },
+
+    /// The remote file fetch itself failed.
+    #[error("failed to download remote file '{input}': {reason}")]
+    RemoteFileFetchFailed {
+        /// The reference as written in the marker.
+        input: String,
+        /// Transport or status detail.
+        reason: String,
+    },
+
+    /// The local file read itself failed.
+    #[error("failed to read local file '{input}': {reason}")]
+    LocalFileReadFailed {
+        /// The reference as written in the marker.
+        input: String,
+        /// I/O detail.
+        reason: String,
+    },
+
+    /// The marker was structurally invalid (bad `data:` URI, bad gzip, …).
+    #[error("invalid multimodal file marker '{input}': {reason}")]
+    InvalidFileMarker {
+        /// The reference as written in the marker.
+        input: String,
+        /// What was wrong with it.
+        reason: String,
+    },
+}
+
+/// Result alias for attachment resolution.
+pub type Result<T> = std::result::Result<T, MultimodalError>;

--- a/src/harness/multimodal/markers.rs
+++ b/src/harness/multimodal/markers.rs
@@ -22,8 +22,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use base64::{
-    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
     Engine as _,
+    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
 };
 
 /// Prefix of an inline image marker.

--- a/src/harness/multimodal/markers.rs
+++ b/src/harness/multimodal/markers.rs
@@ -1,0 +1,257 @@
+//! The marker vocabulary, and the pure string transforms over it.
+//!
+//! Four tokens make up the wire format between a host's ingress and its
+//! provider dispatch:
+//!
+//! | Token | Written by | Read by |
+//! | --- | --- | --- |
+//! | `[IMAGE:<ref>]` | the user / renderer | provider dispatch |
+//! | `[FILE:<ref>]` | the user / renderer | ingress, then dispatch |
+//! | `[Image: <name> #att:<id>]` | ingress, replacing an image marker | dispatch, rehydrating |
+//! | `[FILE-EXTRACTED:…]` / `[FILE-ATTACHED:…]` | [`payload`](super::payload) | the model |
+//!
+//! The placeholder is mixed-case on purpose: `[Image:` never collides with the
+//! `[IMAGE:` parser, so a persisted placeholder cannot be mistaken for an
+//! unresolved attachment and re-read.
+//!
+//! Everything here is a pure function over `&str`. Message-level helpers — "how
+//! many markers are in the latest user turn" — belong to the host, because only
+//! the host knows what its message type is.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use base64::{
+    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
+    Engine as _,
+};
+
+/// Prefix of an inline image marker.
+pub const IMAGE_MARKER_PREFIX: &str = "[IMAGE:";
+
+/// Prefix of an inline file marker. Resolution mirrors images: local paths,
+/// `http(s)` URLs gated by
+/// [`FileLimits::allow_remote_fetch`](super::config::FileLimits::allow_remote_fetch),
+/// and renderer-owned `data:` URIs.
+pub const FILE_MARKER_PREFIX: &str = "[FILE:";
+
+/// Prefix of the persisted image sidecar placeholder. Mixed-case so it never
+/// collides with [`IMAGE_MARKER_PREFIX`].
+pub const IMAGE_PLACEHOLDER_PREFIX: &str = "[Image:";
+
+/// Separator before the stash id inside a placeholder.
+pub const IMAGE_STASH_REF: &str = "#att:";
+
+/// Strip every `[IMAGE:…]` marker and return `(cleaned_text, refs_in_order)`.
+///
+/// An empty marker (`[IMAGE:]`) is left in the text rather than yielding an
+/// empty reference — there is nothing to resolve and dropping it would silently
+/// edit the user's message.
+pub fn parse_image_markers(content: &str) -> (String, Vec<String>) {
+    parse_markers(content, IMAGE_MARKER_PREFIX)
+}
+
+/// Strip every `[FILE:…]` marker and return `(cleaned_text, refs_in_order)`.
+/// Mirrors [`parse_image_markers`] so the two pipelines stay symmetrical.
+pub fn parse_file_markers(content: &str) -> (String, Vec<String>) {
+    parse_markers(content, FILE_MARKER_PREFIX)
+}
+
+/// Shared body of the two marker parsers.
+///
+/// An unterminated marker (no `]` before end of input) is copied through
+/// verbatim and ends the scan: the remainder cannot contain a well-formed
+/// marker that started earlier, and rewriting a half-typed marker would corrupt
+/// text the user is still editing.
+fn parse_markers(content: &str, prefix: &str) -> (String, Vec<String>) {
+    let mut refs = Vec::new();
+    let mut cleaned = String::with_capacity(content.len());
+    let mut cursor = 0usize;
+
+    while let Some(rel_start) = content[cursor..].find(prefix) {
+        let start = cursor + rel_start;
+        cleaned.push_str(&content[cursor..start]);
+
+        let marker_start = start + prefix.len();
+        let Some(rel_end) = content[marker_start..].find(']') else {
+            cleaned.push_str(&content[start..]);
+            cursor = content.len();
+            break;
+        };
+
+        let end = marker_start + rel_end;
+        let candidate = content[marker_start..end].trim();
+
+        if candidate.is_empty() {
+            cleaned.push_str(&content[start..=end]);
+        } else {
+            refs.push(candidate.to_string());
+        }
+
+        cursor = end + 1;
+    }
+
+    if cursor < content.len() {
+        cleaned.push_str(&content[cursor..]);
+    }
+
+    (cleaned.trim().to_string(), refs)
+}
+
+/// Longest bare reference still treated as a possible filesystem path.
+///
+/// 64 base64 characters decode to 48 bytes. No real image comes in under that
+/// (a minimal GIF is ~35 bytes, the smallest valid PNG ~67), so a path-prefixed
+/// reference this short cannot be image data.
+const MAX_PATH_SHAPED_REF_LEN: usize = 64;
+
+/// `true` when a **bare** reference is shaped like an absolute filesystem path
+/// rather than base64 image data.
+///
+/// Shape alone cannot decide this: `/` is in the standard base64 alphabet, and
+/// a bare base64 JPEG legitimately begins `/9j/`. The length bound is what
+/// separates the two — a real payload carrying that prefix runs to thousands of
+/// characters, while `/tmp/foo` does not.
+///
+/// Relative paths (`./x`, `~/x`, `../x`) need no check here: `.` and `~` are
+/// outside the base64 alphabet, so the decode below already rejects them, as it
+/// does every Windows path (`:` and `\` are likewise outside it).
+///
+/// **Known residual ambiguity:** a relative path built only from base64
+/// characters that also decodes cleanly — `photos/cats1` — is genuinely
+/// indistinguishable from a short payload and is still accepted. Tightening
+/// that would start rejecting real base64, so it is left alone deliberately.
+/// The window is narrower than it looks: the length must not be `4n + 1`, and a
+/// partial trailing group must carry zero spare bits, which an arbitrary word
+/// rarely does.
+fn looks_like_absolute_path(payload: &str) -> bool {
+    payload.starts_with('/') && payload.len() < MAX_PATH_SHAPED_REF_LEN
+}
+
+/// The base64 payload an Ollama-style `images` array expects, or `None` when
+/// `image_ref` does not carry one.
+///
+/// Accepts a `data:` URI (payload after the comma) or a bare base64 string.
+///
+/// **Both forms are validated as base64.** Returning a non-`data:` string
+/// verbatim would forward a filesystem path to the provider as if it were image
+/// bytes, and the resulting `illegal base64 data at input byte 19` names
+/// neither the parameter nor the path. `None` lets the caller say which
+/// reference it could not use.
+pub fn extract_ollama_image_payload(image_ref: &str) -> Option<String> {
+    let is_data_uri = image_ref.starts_with("data:");
+    let payload = if is_data_uri {
+        let comma_idx = image_ref.find(',')?;
+        image_ref.split_at(comma_idx + 1).1.trim()
+    } else {
+        image_ref.trim()
+    };
+    if payload.is_empty() {
+        return None;
+    }
+    if !is_data_uri && looks_like_absolute_path(payload) {
+        tracing::debug!(
+            "[multimodal] image reference is shaped like a filesystem path, not image bytes"
+        );
+        return None;
+    }
+    // Decode to validate only — the encoded form is what goes on the wire, and
+    // re-encoding would just burn a copy of a multi-MB image. Accept both
+    // padded and unpadded alphabets: real data URIs are padded, but some
+    // producers omit the `=`, and rejecting those would be a new regression
+    // rather than the fix this is.
+    //
+    // Length picks the engine rather than trying both: a complete group
+    // (`len % 4 == 0`) is exactly what `STANDARD` accepts, with or without
+    // trailing `=`, and only a partial group needs `STANDARD_NO_PAD`. Trying
+    // both in sequence decoded a multi-MB image twice for every unpadded
+    // payload.
+    let is_base64 = if payload.len() % 4 == 0 {
+        STANDARD.decode(payload).is_ok()
+    } else {
+        STANDARD_NO_PAD.decode(payload).is_ok()
+    };
+    if !is_base64 {
+        tracing::debug!(
+            "[multimodal] image reference is not base64 (a filesystem path is not accepted here)"
+        );
+        return None;
+    }
+    Some(payload.to_string())
+}
+
+/// Render the persisted sidecar placeholder for a stashed image `id`.
+pub fn image_placeholder(id: &str) -> String {
+    format!("{IMAGE_PLACEHOLDER_PREFIX} image {IMAGE_STASH_REF}{id}]")
+}
+
+/// `true` when `text` carries at least one resolvable sidecar placeholder.
+///
+/// Both halves are required: `[Image:` alone is also how an unresolvable
+/// placeholder (`[Image: (could not be processed)]`) renders, and that one has
+/// no id to look up.
+pub fn text_has_image_placeholders(text: &str) -> bool {
+    text.contains(IMAGE_PLACEHOLDER_PREFIX) && text.contains(IMAGE_STASH_REF)
+}
+
+/// Extract the `[Image: … #att:<id>]` placeholder tokens from `text`, in order.
+///
+/// Used to forward a user's attached images into a delegated vision sub-agent's
+/// prompt so its turn rehydrates them — the parent, on a non-vision tier, keeps
+/// the placeholder as text and never sees the image.
+pub fn extract_image_placeholders_in_text(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    while let Some(rel) = text[cursor..].find(IMAGE_PLACEHOLDER_PREFIX) {
+        let start = cursor + rel;
+        let Some(rel_end) = text[start..].find(']') else {
+            break;
+        };
+        let end = start + rel_end + 1;
+        let token = &text[start..end];
+        if token.contains(IMAGE_STASH_REF) {
+            out.push(token.to_string());
+        }
+        cursor = end;
+    }
+    out
+}
+
+/// Replace each `[Image: <name> #att:<id>]` placeholder in `text` with
+/// `[IMAGE:<path>]` when the id resolves in `index`; leave it verbatim
+/// otherwise.
+///
+/// An unresolved id is *not* an error. The attachment may have been swept, or
+/// written by a different workspace; keeping the human-readable placeholder
+/// tells the model an image was attached without inventing a path that does not
+/// exist.
+///
+/// The index is supplied by the host because where attachments live — and
+/// whether this process may read them — is a host decision.
+pub fn rehydrate_placeholders_in_text(text: &str, index: &HashMap<String, PathBuf>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0;
+    while let Some(rel) = text[cursor..].find(IMAGE_PLACEHOLDER_PREFIX) {
+        let start = cursor + rel;
+        out.push_str(&text[cursor..start]);
+        let Some(rel_end) = text[start..].find(']') else {
+            out.push_str(&text[start..]);
+            cursor = text.len();
+            break;
+        };
+        let end = start + rel_end + 1;
+        let inner = &text[start..end];
+        let replaced = inner.find(IMAGE_STASH_REF).and_then(|ai| {
+            let id = inner[ai + IMAGE_STASH_REF.len()..]
+                .trim_end_matches(']')
+                .trim();
+            index
+                .get(id)
+                .map(|path| format!("{IMAGE_MARKER_PREFIX}{}]", path.display()))
+        });
+        out.push_str(replaced.as_deref().unwrap_or(inner));
+        cursor = end;
+    }
+    out.push_str(&text[cursor..]);
+    out
+}

--- a/src/harness/multimodal/mime.rs
+++ b/src/harness/multimodal/mime.rs
@@ -39,9 +39,10 @@ pub fn detect_image_mime(
 
     if let Some(path) = path
         && let Some(ext) = path.extension().and_then(|value| value.to_str())
-            && let Some(mime) = image_mime_from_extension(ext) {
-                return Some(mime.to_string());
-            }
+        && let Some(mime) = image_mime_from_extension(ext)
+    {
+        return Some(mime.to_string());
+    }
 
     image_mime_from_magic(bytes).map(ToString::to_string)
 }
@@ -54,15 +55,17 @@ pub fn detect_file_mime(
     header_content_type: Option<&str>,
 ) -> Option<String> {
     if let Some(header_mime) = header_content_type.and_then(normalize_content_type)
-        && file_mime_known(&header_mime) {
-            return Some(header_mime);
-        }
+        && file_mime_known(&header_mime)
+    {
+        return Some(header_mime);
+    }
 
     if let Some(path) = path
         && let Some(ext) = path.extension().and_then(|value| value.to_str())
-            && let Some(mime) = file_mime_from_extension(ext) {
-                return Some(mime.to_string());
-            }
+        && let Some(mime) = file_mime_from_extension(ext)
+    {
+        return Some(mime.to_string());
+    }
 
     if let Some(mime) = file_mime_from_magic(bytes) {
         return Some(mime.to_string());

--- a/src/harness/multimodal/mime.rs
+++ b/src/harness/multimodal/mime.rs
@@ -37,13 +37,11 @@ pub fn detect_image_mime(
         return Some(header_mime);
     }
 
-    if let Some(path) = path {
-        if let Some(ext) = path.extension().and_then(|value| value.to_str()) {
-            if let Some(mime) = image_mime_from_extension(ext) {
+    if let Some(path) = path
+        && let Some(ext) = path.extension().and_then(|value| value.to_str())
+            && let Some(mime) = image_mime_from_extension(ext) {
                 return Some(mime.to_string());
             }
-        }
-    }
 
     image_mime_from_magic(bytes).map(ToString::to_string)
 }
@@ -55,19 +53,16 @@ pub fn detect_file_mime(
     bytes: &[u8],
     header_content_type: Option<&str>,
 ) -> Option<String> {
-    if let Some(header_mime) = header_content_type.and_then(normalize_content_type) {
-        if file_mime_known(&header_mime) {
+    if let Some(header_mime) = header_content_type.and_then(normalize_content_type)
+        && file_mime_known(&header_mime) {
             return Some(header_mime);
         }
-    }
 
-    if let Some(path) = path {
-        if let Some(ext) = path.extension().and_then(|value| value.to_str()) {
-            if let Some(mime) = file_mime_from_extension(ext) {
+    if let Some(path) = path
+        && let Some(ext) = path.extension().and_then(|value| value.to_str())
+            && let Some(mime) = file_mime_from_extension(ext) {
                 return Some(mime.to_string());
             }
-        }
-    }
 
     if let Some(mime) = file_mime_from_magic(bytes) {
         return Some(mime.to_string());

--- a/src/harness/multimodal/mime.rs
+++ b/src/harness/multimodal/mime.rs
@@ -83,11 +83,7 @@ pub fn detect_file_mime(
 /// Strip parameters from a `Content-Type` header and lower-case it.
 pub fn normalize_content_type(content_type: &str) -> Option<String> {
     let mime = content_type.split(';').next()?.trim().to_ascii_lowercase();
-    if mime.is_empty() {
-        None
-    } else {
-        Some(mime)
-    }
+    if mime.is_empty() { None } else { Some(mime) }
 }
 
 /// Image MIME for a file extension.

--- a/src/harness/multimodal/mime.rs
+++ b/src/harness/multimodal/mime.rs
@@ -1,0 +1,215 @@
+//! MIME detection for image and file attachments.
+//!
+//! Three signals, consulted in a deliberate order:
+//!
+//! 1. **The `Content-Type` header**, when one came from a fetch.
+//! 2. **The file extension**, when the reference was a path.
+//! 3. **Magic bytes.**
+//!
+//! Images and files order these differently, and the difference is not an
+//! oversight. For images the header wins outright: an image server is
+//! authoritative about what it served. For files the header wins only if it
+//! names a format the allowlist could contain — a great many servers answer
+//! `application/octet-stream` for everything, and taking that at face value
+//! would degrade every fetched PDF to a metadata-only reference.
+//!
+//! [`file_mime_from_magic`] cannot separate the OOXML formats from a plain
+//! zip: `.xlsx`, `.docx`, `.pptx` and `.zip` all begin `PK\x03\x04`, and
+//! telling them apart means parsing the central directory. The extension is
+//! what discriminates, which is why it is consulted before magic.
+
+use std::path::Path;
+
+use super::config::ALLOWED_IMAGE_MIME_TYPES;
+
+/// `true` when `mime` is an image type the provider contract accepts.
+pub fn is_allowed_image_mime(mime: &str) -> bool {
+    ALLOWED_IMAGE_MIME_TYPES.contains(&mime)
+}
+
+/// Detect an image's MIME type: header, then extension, then magic bytes.
+pub fn detect_image_mime(
+    path: Option<&Path>,
+    bytes: &[u8],
+    header_content_type: Option<&str>,
+) -> Option<String> {
+    if let Some(header_mime) = header_content_type.and_then(normalize_content_type) {
+        return Some(header_mime);
+    }
+
+    if let Some(path) = path {
+        if let Some(ext) = path.extension().and_then(|value| value.to_str()) {
+            if let Some(mime) = image_mime_from_extension(ext) {
+                return Some(mime.to_string());
+            }
+        }
+    }
+
+    image_mime_from_magic(bytes).map(ToString::to_string)
+}
+
+/// Detect a file's MIME type: header (only if recognised), then extension,
+/// then magic bytes, then a UTF-8 sniff.
+pub fn detect_file_mime(
+    path: Option<&Path>,
+    bytes: &[u8],
+    header_content_type: Option<&str>,
+) -> Option<String> {
+    if let Some(header_mime) = header_content_type.and_then(normalize_content_type) {
+        if file_mime_known(&header_mime) {
+            return Some(header_mime);
+        }
+    }
+
+    if let Some(path) = path {
+        if let Some(ext) = path.extension().and_then(|value| value.to_str()) {
+            if let Some(mime) = file_mime_from_extension(ext) {
+                return Some(mime.to_string());
+            }
+        }
+    }
+
+    if let Some(mime) = file_mime_from_magic(bytes) {
+        return Some(mime.to_string());
+    }
+
+    if looks_like_utf8_text(bytes) {
+        return Some("text/plain".to_string());
+    }
+
+    None
+}
+
+/// Strip parameters from a `Content-Type` header and lower-case it.
+pub fn normalize_content_type(content_type: &str) -> Option<String> {
+    let mime = content_type.split(';').next()?.trim().to_ascii_lowercase();
+    if mime.is_empty() {
+        None
+    } else {
+        Some(mime)
+    }
+}
+
+/// Image MIME for a file extension.
+pub fn image_mime_from_extension(ext: &str) -> Option<&'static str> {
+    match ext.to_ascii_lowercase().as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "gif" => Some("image/gif"),
+        "bmp" => Some("image/bmp"),
+        _ => None,
+    }
+}
+
+/// File extension for a known image MIME — the inverse of
+/// [`image_mime_from_extension`]. Used when naming a stashed attachment.
+pub fn image_ext_from_mime(mime: &str) -> Option<&'static str> {
+    match mime {
+        "image/png" => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/webp" => Some("webp"),
+        "image/gif" => Some("gif"),
+        "image/bmp" => Some("bmp"),
+        _ => None,
+    }
+}
+
+/// Image MIME from magic bytes.
+pub fn image_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() >= 8 && bytes.starts_with(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']) {
+        return Some("image/png");
+    }
+
+    if bytes.len() >= 3 && bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some("image/jpeg");
+    }
+
+    if bytes.len() >= 6 && (bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) {
+        return Some("image/gif");
+    }
+
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+
+    if bytes.len() >= 2 && bytes.starts_with(b"BM") {
+        return Some("image/bmp");
+    }
+
+    None
+}
+
+/// `true` when a `Content-Type` header names a file format worth trusting over
+/// the extension. Deliberately narrow — see the module header.
+pub fn file_mime_known(mime: &str) -> bool {
+    file_mime_from_extension(mime).is_some()
+        || matches!(
+            mime,
+            "application/pdf"
+                | "text/plain"
+                | "text/csv"
+                | "text/markdown"
+                | "application/zip"
+                | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                | "application/octet-stream"
+        )
+}
+
+/// File MIME for a file extension.
+pub fn file_mime_from_extension(ext: &str) -> Option<&'static str> {
+    match ext.to_ascii_lowercase().as_str() {
+        "pdf" => Some("application/pdf"),
+        "txt" => Some("text/plain"),
+        "md" | "markdown" => Some("text/markdown"),
+        "csv" => Some("text/csv"),
+        "zip" => Some("application/zip"),
+        "xlsx" => Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        "docx" => Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        "pptx" => Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+        _ => None,
+    }
+}
+
+/// File MIME from magic bytes.
+///
+/// Returns `application/zip` for every OOXML container — see the module header
+/// for why the extension has to discriminate.
+pub fn file_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() >= 5 && bytes.starts_with(b"%PDF-") {
+        return Some("application/pdf");
+    }
+
+    // OOXML formats (xlsx/docx/pptx) and plain zip all share the PK\x03\x04
+    // ZIP local-file-header magic; without parsing the central directory we
+    // cannot distinguish them, so callers must rely on the file extension for
+    // OOXML vs zip discrimination.
+    if bytes.len() >= 4 && bytes.starts_with(&[b'P', b'K', 0x03, 0x04]) {
+        return Some("application/zip");
+    }
+
+    None
+}
+
+/// `true` when `mime` names a format whose text is extracted by decoding the
+/// bytes directly, with no parser involved.
+pub fn is_extractable_text_mime(mime: &str) -> bool {
+    matches!(mime, "text/plain" | "text/csv" | "text/markdown")
+}
+
+/// Crude UTF-8 sniff: the bytes parse as UTF-8 and contain at least one
+/// non-control character. The last-resort fallback that lets an unlabeled
+/// `.log` / `.ini` / source file still be recognised as text.
+pub fn looks_like_utf8_text(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(text) => text
+            .chars()
+            .any(|c| !c.is_control() || matches!(c, '\n' | '\r' | '\t')),
+        Err(_) => false,
+    }
+}

--- a/src/harness/multimodal/mod.rs
+++ b/src/harness/multimodal/mod.rs
@@ -75,13 +75,13 @@ pub mod resolve;
 #[cfg(test)]
 mod test;
 
-pub use config::{FileLimits, ImageLimits, ALLOWED_IMAGE_MIME_TYPES};
+pub use config::{ALLOWED_IMAGE_MIME_TYPES, FileLimits, ImageLimits};
 pub use error::{MultimodalError, Result};
 pub use markers::{
+    FILE_MARKER_PREFIX, IMAGE_MARKER_PREFIX, IMAGE_PLACEHOLDER_PREFIX, IMAGE_STASH_REF,
     extract_image_placeholders_in_text, extract_ollama_image_payload, image_placeholder,
     parse_file_markers, parse_image_markers, rehydrate_placeholders_in_text,
-    text_has_image_placeholders, FILE_MARKER_PREFIX, IMAGE_MARKER_PREFIX,
-    IMAGE_PLACEHOLDER_PREFIX, IMAGE_STASH_REF,
+    text_has_image_placeholders,
 };
-pub use payload::{compose_multimodal_message, sha256_prefix, truncate_chars, FilePayload};
-pub use resolve::{resolve_file, resolve_image, NoTextExtractor, TextExtractor};
+pub use payload::{FilePayload, compose_multimodal_message, sha256_prefix, truncate_chars};
+pub use resolve::{NoTextExtractor, TextExtractor, resolve_file, resolve_image};

--- a/src/harness/multimodal/mod.rs
+++ b/src/harness/multimodal/mod.rs
@@ -1,0 +1,87 @@
+//! Attachment resolution for `[IMAGE:…]` and `[FILE:…]` markers.
+//!
+//! A user attaches a picture or a document. Somewhere between the text box and
+//! the provider, that attachment has to become bytes the model can read —
+//! validated, size-capped, MIME-checked, and rendered into the message. This
+//! module is that pipeline, minus every decision that belongs to a host.
+//!
+//! ## The marker convention
+//!
+//! Attachments travel inside message text as markers rather than as a parallel
+//! structured field. That is what makes them survive every hop a host already
+//! has — persistence, summarisation, delegation to a sub-agent — without each
+//! of those learning about attachments. The cost is that the text is a wire
+//! format, which is why [`markers`] is careful about malformed input.
+//!
+//! ## The two pipelines
+//!
+//! Images and files are symmetrical up to the payload and then diverge:
+//!
+//! | | Images | Files |
+//! | --- | --- | --- |
+//! | Marker | `[IMAGE:<ref>]` | `[FILE:<ref>]` |
+//! | Sources | `data:` / `http(s)` / path | same |
+//! | MIME set | fixed, five types | host allowlist |
+//! | Payload | inline base64 `data:` URI | extracted text, or metadata + hash |
+//!
+//! A file never inlines its bytes. Handing a model raw binary costs a great
+//! deal of context and tells it nothing, so an unextractable format surfaces as
+//! a header naming it and a content hash — enough for the agent to talk about
+//! the attachment, and to pass its path to a tool that can actually open it.
+//!
+//! ## What stays with the host
+//!
+//! Four things, each because it depends on the host's own runtime, storage, or
+//! threat model rather than on anything universal:
+//!
+//! | Host owns | Why |
+//! | --- | --- |
+//! | The `reqwest::Client` | proxy configuration and timeouts are host policy; this module borrows one |
+//! | [`TextExtractor`] | which document parser (if any) a host carries, and how long it may run |
+//! | The attachment stash | where bytes live between ingress and dispatch, and their lifetime |
+//! | Message-level counting | only the host knows what its message type is |
+//!
+//! The stash deserves a note, because the split is not obvious. A host that
+//! persists conversations should **not** persist a multi-megabyte `data:` URI:
+//! it floods every downstream consumer that reads message text. The convention
+//! this module supports is to replace each image marker at ingress with a
+//! compact `[Image: … #att:<id>]` placeholder ([`markers::image_placeholder`]),
+//! store the bytes out of band, and rehydrate at dispatch
+//! ([`markers::rehydrate_placeholders_in_text`]) — but only for a
+//! vision-capable model, since a text-only one gains nothing from an image it
+//! cannot see. The id-to-path index is a parameter, so where those bytes live
+//! and when they expire stay host decisions.
+//!
+//! ## Order of operations
+//!
+//! Two rules, both learned the hard way:
+//!
+//! 1. **Count before resolving.** [`config::FileLimits::files_disabled`] and the
+//!    per-turn caps are checked against the raw markers, before any read
+//!    happens. A cap enforced after the fetch is not a cap.
+//! 2. **Check the sentinel before the clamp.** `max_files == 0` means *none*,
+//!    and [`config::FileLimits::effective`] clamps it to 1. Consulting only the
+//!    clamped value admits exactly one attachment from a source that asked for
+//!    zero.
+
+pub mod config;
+pub mod data_uri;
+pub mod error;
+pub mod markers;
+pub mod mime;
+pub mod payload;
+pub mod resolve;
+
+#[cfg(test)]
+mod test;
+
+pub use config::{FileLimits, ImageLimits, ALLOWED_IMAGE_MIME_TYPES};
+pub use error::{MultimodalError, Result};
+pub use markers::{
+    extract_image_placeholders_in_text, extract_ollama_image_payload, image_placeholder,
+    parse_file_markers, parse_image_markers, rehydrate_placeholders_in_text,
+    text_has_image_placeholders, FILE_MARKER_PREFIX, IMAGE_MARKER_PREFIX,
+    IMAGE_PLACEHOLDER_PREFIX, IMAGE_STASH_REF,
+};
+pub use payload::{compose_multimodal_message, sha256_prefix, truncate_chars, FilePayload};
+pub use resolve::{resolve_file, resolve_image, NoTextExtractor, TextExtractor};

--- a/src/harness/multimodal/payload.rs
+++ b/src/harness/multimodal/payload.rs
@@ -1,0 +1,265 @@
+//! Resolved file payloads and the rendered message the model sees.
+//!
+//! ## Why files never inline bytes
+//!
+//! Images inline as base64 `data:` URIs because that is the provider contract
+//! for vision. Files do not, ever. An extractable format contributes its text;
+//! a binary-only format contributes a header naming it and a content hash.
+//! Handing a model raw binary bytes costs a great deal of context and tells it
+//! nothing, so the two pipelines converge on markers and diverge on payloads.
+//!
+//! ## The rendered shapes
+//!
+//! ```text
+//! [FILE-EXTRACTED: name="notes.md" size="4.1 KB" mime="text/markdown"]
+//! …text…
+//! [/FILE-EXTRACTED]
+//!
+//! [FILE-ATTACHED: name="sheet.xlsx" size="1.2 MB" mime="application/…sheet" sha256_prefix="a1b2…"]
+//! ```
+//!
+//! Attribute values are escaped: names are user-supplied filenames, and one
+//! containing a quote or a newline would otherwise break the header out of its
+//! own delimiters.
+
+use super::mime::is_extractable_text_mime;
+
+/// Worst-case length budget reserved for the rendered truncation suffix.
+///
+/// The emitted suffix is `"\n[…truncated {N} chars]"` with a dynamic `N`. The
+/// reservation uses the longest plausible value — `max_extracted_text_chars`
+/// clamps to 200_000, so `N` has at most 6 digits — so the truncated payload
+/// never overshoots the cap once the suffix is appended.
+pub const TEXT_TRUNCATION_SUFFIX_BUDGET: &str = "\n[…truncated 999999 chars]";
+
+/// A resolved `[FILE:…]` marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilePayload {
+    /// A format whose text was extracted and inlined.
+    Extracted {
+        /// Display name, as attached.
+        name: String,
+        /// Detected MIME type.
+        mime: String,
+        /// Size of the original bytes.
+        size_bytes: usize,
+        /// The extracted text, already truncated.
+        text: String,
+        /// How many characters truncation dropped; `0` when none.
+        truncated_chars: usize,
+    },
+    /// A binary-only format, surfaced as metadata so the agent can mention it
+    /// without seeing raw bytes.
+    Reference {
+        /// Display name, as attached.
+        name: String,
+        /// Detected MIME type.
+        mime: String,
+        /// Size of the original bytes.
+        size_bytes: usize,
+        /// First 16 hex characters of the SHA-256 digest.
+        sha256_prefix: String,
+    },
+}
+
+impl FilePayload {
+    /// A content-less placeholder for a reference that was never read.
+    ///
+    /// Used for over-cap markers and for references that failed to resolve: the
+    /// turn still tells the model something was attached, without the host
+    /// having touched the underlying bytes.
+    pub fn placeholder(name: impl Into<String>, sha256_prefix: impl Into<String>) -> Self {
+        Self::Reference {
+            name: name.into(),
+            mime: "application/octet-stream".to_string(),
+            size_bytes: 0,
+            sha256_prefix: sha256_prefix.into(),
+        }
+    }
+
+    /// Build the payload for already-resolved bytes, extracting text when the
+    /// MIME type allows it.
+    ///
+    /// `extracted` is the text a host-supplied extractor produced for a format
+    /// this crate cannot decode itself (PDF being the motivating case), or
+    /// `None` when there was none — a failed extraction and an unsupported
+    /// format both degrade to [`FilePayload::Reference`], which is what lets a
+    /// damaged document pass through without failing the turn.
+    pub fn from_resolved(
+        bytes: &[u8],
+        name: String,
+        mime: String,
+        extracted: Option<String>,
+        max_extracted_text_chars: usize,
+    ) -> Self {
+        let size_bytes = bytes.len();
+
+        let raw = if is_extractable_text_mime(&mime) {
+            Some(decode_utf8_lossy(bytes))
+        } else {
+            extracted
+        };
+
+        if let Some(raw) = raw {
+            let (text, truncated_chars) = truncate_chars(raw, max_extracted_text_chars);
+            return Self::Extracted {
+                name,
+                mime,
+                size_bytes,
+                text,
+                truncated_chars,
+            };
+        }
+
+        Self::Reference {
+            name,
+            mime,
+            size_bytes,
+            sha256_prefix: sha256_prefix(bytes),
+        }
+    }
+}
+
+/// Compose the message the provider receives: the user's text, then every
+/// image marker, then every file payload.
+///
+/// Images come back as `[IMAGE:<data-uri>]` markers rather than a structured
+/// content array because the marker form is what the host's own provider
+/// adapters already consume — this function renders the wire format, it does
+/// not choose it.
+pub fn compose_multimodal_message(
+    text: &str,
+    data_uris: &[String],
+    file_payloads: &[FilePayload],
+) -> String {
+    let mut content = String::new();
+    let trimmed = text.trim();
+
+    if !trimmed.is_empty() {
+        content.push_str(trimmed);
+        content.push_str("\n\n");
+    }
+
+    for (index, data_uri) in data_uris.iter().enumerate() {
+        if index > 0 {
+            content.push('\n');
+        }
+        content.push_str(super::markers::IMAGE_MARKER_PREFIX);
+        content.push_str(data_uri);
+        content.push(']');
+    }
+
+    for payload in file_payloads {
+        if !content.is_empty() && !content.ends_with('\n') {
+            content.push('\n');
+        }
+        if !content.is_empty() {
+            content.push('\n');
+        }
+        match payload {
+            FilePayload::Extracted {
+                name,
+                mime,
+                size_bytes,
+                text,
+                truncated_chars,
+            } => {
+                content.push_str(&format!(
+                    "[FILE-EXTRACTED: name=\"{}\" size=\"{}\" mime=\"{}\"]\n",
+                    escape_attr(name),
+                    format_size(*size_bytes),
+                    mime
+                ));
+                content.push_str(text);
+                if *truncated_chars > 0 {
+                    content.push_str(&format!("\n[…truncated {} chars]", truncated_chars));
+                }
+                content.push_str("\n[/FILE-EXTRACTED]");
+            }
+            FilePayload::Reference {
+                name,
+                mime,
+                size_bytes,
+                sha256_prefix,
+            } => {
+                content.push_str(&format!(
+                    "[FILE-ATTACHED: name=\"{}\" size=\"{}\" mime=\"{}\" sha256_prefix=\"{}\"]",
+                    escape_attr(name),
+                    format_size(*size_bytes),
+                    mime,
+                    sha256_prefix
+                ));
+            }
+        }
+    }
+
+    content
+}
+
+/// Strip characters that would break the attribute-style serialization of a
+/// [`FilePayload`] header. Names are user-supplied filenames, so they must not
+/// be trusted to be quote-free.
+pub fn escape_attr(value: &str) -> String {
+    value.replace(['"', '\n', '\r'], "_")
+}
+
+/// Render a byte count for a payload header.
+pub fn format_size(size_bytes: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = 1024 * 1024;
+    if size_bytes >= MB {
+        format!("{:.1} MB", size_bytes as f64 / MB as f64)
+    } else if size_bytes >= KB {
+        format!("{:.1} KB", size_bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", size_bytes)
+    }
+}
+
+/// Best-effort UTF-8 decode: strict decode wins, invalid sequences otherwise
+/// become U+FFFD.
+///
+/// Lossy rather than failing because the alternative — degrading a text file to
+/// a metadata reference over one bad byte — loses the whole document to save
+/// one character.
+pub fn decode_utf8_lossy(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(text) => text.to_string(),
+        Err(_) => String::from_utf8_lossy(bytes).into_owned(),
+    }
+}
+
+/// Truncate `text` to at most `max_chars` Unicode scalar values, leaving room
+/// for the rendered truncation suffix.
+///
+/// The reservation uses [`TEXT_TRUNCATION_SUFFIX_BUDGET`] — the worst-case
+/// rendered length — so `text + suffix` always stays inside `max_chars`
+/// regardless of the actual dropped-digit count. Returns the text and the
+/// number of characters dropped (`0` when none were).
+pub fn truncate_chars(text: String, max_chars: usize) -> (String, usize) {
+    let total = text.chars().count();
+    if total <= max_chars {
+        return (text, 0);
+    }
+
+    let suffix_chars = TEXT_TRUNCATION_SUFFIX_BUDGET.chars().count();
+    let keep = max_chars.saturating_sub(suffix_chars);
+    let truncated: String = text.chars().take(keep).collect();
+    let dropped = total.saturating_sub(keep);
+    (truncated, dropped)
+}
+
+/// First 16 hex characters of the SHA-256 digest of `bytes`.
+///
+/// A prefix rather than the full digest: it identifies an attachment across
+/// turns and deduplicates the on-disk stash, and neither needs collision
+/// resistance against an adversary who already supplied the bytes.
+pub fn sha256_prefix(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|byte| format!("{:02x}", byte)).collect();
+    hex.chars().take(16).collect()
+}

--- a/src/harness/multimodal/resolve.rs
+++ b/src/harness/multimodal/resolve.rs
@@ -50,7 +50,18 @@ use super::payload::FilePayload;
 /// reference.
 #[async_trait]
 pub trait TextExtractor: Send + Sync {
+    /// Whether this extractor has anything to say about `mime`.
+    ///
+    /// Required rather than defaulted, and consulted before every call.
+    /// Extraction can be expensive well before it fails — a host that runs its
+    /// parser out-of-process pays a round trip and a copy of the bytes — so
+    /// "offer it everything and let it refuse" would charge every `.zip` and
+    /// `.xlsx` attachment for a refusal that was knowable from the MIME type.
+    fn handles(&self, mime: &str) -> bool;
+
     /// Extract text from `bytes` of type `mime`, or explain why not.
+    ///
+    /// Called only when [`TextExtractor::handles`] returned `true`.
     ///
     /// `Err` is a plain reason string because the caller never branches on it —
     /// every failure takes the same degrade-to-reference path, and the string
@@ -68,6 +79,10 @@ pub struct NoTextExtractor;
 
 #[async_trait]
 impl TextExtractor for NoTextExtractor {
+    fn handles(&self, _mime: &str) -> bool {
+        false
+    }
+
     async fn extract(&self, mime: &str, _bytes: &[u8]) -> std::result::Result<String, String> {
         Err(format!("no text extractor is configured for '{mime}'"))
     }
@@ -369,10 +384,12 @@ async fn build_file_payload(
         "[multimodal::files] resolved file ref"
     );
 
-    // Plain-text formats decode here; anything else is offered to the host's
-    // extractor, and a refusal degrades the file to a metadata reference rather
-    // than failing the turn.
-    let extracted = if super::mime::is_extractable_text_mime(&mime) {
+    // Plain-text formats decode in `FilePayload::from_resolved`; a format the
+    // host's extractor claims is offered to it, and a refusal degrades the file
+    // to a metadata reference rather than failing the turn. Everything else —
+    // the binary-only formats — goes straight to a reference without the
+    // extractor ever seeing the bytes.
+    let extracted = if super::mime::is_extractable_text_mime(&mime) || !extractor.handles(&mime) {
         None
     } else {
         match extractor.extract(&mime, &bytes).await {

--- a/src/harness/multimodal/resolve.rs
+++ b/src/harness/multimodal/resolve.rs
@@ -413,8 +413,7 @@ async fn build_file_payload(
         truncated_chars,
         ..
     } = &payload
-    {
-        if *truncated_chars > 0 {
+        && *truncated_chars > 0 {
             tracing::info!(
                 target: "multimodal",
                 file = %name,
@@ -423,7 +422,6 @@ async fn build_file_payload(
                 "[multimodal::files] truncated extracted text"
             );
         }
-    }
 
     Ok(payload)
 }

--- a/src/harness/multimodal/resolve.rs
+++ b/src/harness/multimodal/resolve.rs
@@ -1,0 +1,514 @@
+//! Turning one marker reference into one payload.
+//!
+//! Three source shapes are accepted for both images and files, and they are
+//! tried in a fixed order because only the first is self-describing:
+//!
+//! | Shape | Gate |
+//! | --- | --- |
+//! | `data:…;base64,…` | none — the renderer already owns these bytes |
+//! | `http(s)://…` | `allow_remote_fetch`, off by default |
+//! | anything else | treated as a local path |
+//!
+//! ## What this module deliberately does not decide
+//!
+//! **Which paths may be read.** A local reference is read as given. That is not
+//! an oversight — a crate cannot know a host's filesystem threat model, and
+//! guessing one would either block a desktop user from attaching their own
+//! files or wave through a marker smuggled in from a chat channel. The host
+//! decides, and the lever it has is
+//! [`FileLimits::files_disabled`](super::config::FileLimits::files_disabled):
+//! a turn whose text came from somewhere untrusted resolves no file markers at
+//! all. See that method's docs.
+//!
+//! **How long an extraction may take.** [`TextExtractor`] has no deadline in
+//! its signature. The cost of parsing a document is set by the document, and
+//! only the host knows how long an attachment is worth waiting for — so the
+//! host wraps its own implementation in whatever timeout it wants, and a
+//! blown deadline arrives here as an ordinary `Err`.
+//!
+//! Both failures degrade rather than propagate: a file that cannot be extracted
+//! becomes a [`FilePayload::Reference`], so a damaged PDF costs the model its
+//! text and not the turn.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use super::config::{FileLimits, ImageLimits};
+use super::data_uri::{data_uri_param, encode_data_uri, gunzip, parse_data_uri};
+use super::error::{MultimodalError, Result};
+use super::mime::{detect_file_mime, detect_image_mime, is_allowed_image_mime};
+use super::payload::FilePayload;
+
+/// Host-supplied text extraction for formats this crate cannot decode itself.
+///
+/// Implemented for exactly one reason: PDF text extraction needs a parser, a
+/// parser is a large dependency with its own failure modes, and which one (if
+/// any) a host is willing to carry is a host decision. A host with no extractor
+/// passes [`NoTextExtractor`] and every such file degrades to a metadata
+/// reference.
+#[async_trait]
+pub trait TextExtractor: Send + Sync {
+    /// Extract text from `bytes` of type `mime`, or explain why not.
+    ///
+    /// `Err` is a plain reason string because the caller never branches on it —
+    /// every failure takes the same degrade-to-reference path, and the string
+    /// exists to be logged.
+    async fn extract(&self, mime: &str, bytes: &[u8]) -> std::result::Result<String, String>;
+}
+
+/// A [`TextExtractor`] that extracts nothing.
+///
+/// The correct choice for a host that carries no document parser: every
+/// non-plaintext format surfaces as a [`FilePayload::Reference`], which is the
+/// same outcome as a parser that failed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoTextExtractor;
+
+#[async_trait]
+impl TextExtractor for NoTextExtractor {
+    async fn extract(&self, mime: &str, _bytes: &[u8]) -> std::result::Result<String, String> {
+        Err(format!("no text extractor is configured for '{mime}'"))
+    }
+}
+
+// ── Images ───────────────────────────────────────────────────────────────
+
+/// Resolve one `[IMAGE:…]` reference into a canonical `data:` URI.
+///
+/// The return value is always re-encoded rather than passed through, so a
+/// caller downstream can rely on the MIME type in the header matching the
+/// bytes — which is what makes the allowlist check meaningful rather than
+/// advisory.
+pub async fn resolve_image(
+    source: &str,
+    limits: &ImageLimits,
+    max_bytes: usize,
+    remote_client: &Client,
+) -> Result<String> {
+    if source.starts_with("data:") {
+        return resolve_image_data_uri(source, max_bytes);
+    }
+
+    if source.starts_with("http://") || source.starts_with("https://") {
+        if !limits.allow_remote_fetch {
+            return Err(MultimodalError::RemoteFetchDisabled {
+                input: source.to_string(),
+            });
+        }
+
+        return resolve_remote_image(source, max_bytes, remote_client).await;
+    }
+
+    resolve_local_image(source, max_bytes).await
+}
+
+fn resolve_image_data_uri(source: &str, max_bytes: usize) -> Result<String> {
+    let parsed = parse_data_uri(source).map_err(|reason| MultimodalError::InvalidMarker {
+        input: source.to_string(),
+        reason,
+    })?;
+
+    let (mime, decoded) = if parsed.mime == "application/gzip" {
+        let original_mime = data_uri_param(&parsed.params, "original_mime").ok_or_else(|| {
+            MultimodalError::InvalidMarker {
+                input: source.to_string(),
+                reason: "compressed image data URI missing original_mime parameter".to_string(),
+            }
+        })?;
+        let bytes =
+            gunzip(&parsed.bytes, max_bytes).map_err(|reason| MultimodalError::InvalidMarker {
+                input: source.to_string(),
+                reason,
+            })?;
+        (original_mime.to_ascii_lowercase(), bytes)
+    } else {
+        (parsed.mime, parsed.bytes)
+    };
+
+    check_image_mime(source, &mime)?;
+    check_image_size(source, decoded.len(), max_bytes)?;
+
+    Ok(encode_data_uri(&mime, &decoded))
+}
+
+async fn resolve_remote_image(
+    source: &str,
+    max_bytes: usize,
+    remote_client: &Client,
+) -> Result<String> {
+    let response =
+        remote_client
+            .get(source)
+            .send()
+            .await
+            .map_err(|error| MultimodalError::RemoteFetchFailed {
+                input: source.to_string(),
+                reason: error.to_string(),
+            })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(MultimodalError::RemoteFetchFailed {
+            input: source.to_string(),
+            reason: format!("HTTP {status}"),
+        });
+    }
+
+    // Checked twice on purpose: `Content-Length` lets an over-cap response be
+    // refused before its body is read, and the measured length catches a server
+    // that lied or sent none.
+    if let Some(content_length) = response.content_length() {
+        check_image_size(source, content_length as usize, max_bytes)?;
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToString::to_string);
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| MultimodalError::RemoteFetchFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        })?;
+
+    check_image_size(source, bytes.len(), max_bytes)?;
+
+    let mime = detect_image_mime(None, bytes.as_ref(), content_type.as_deref()).ok_or_else(|| {
+        MultimodalError::UnsupportedMime {
+            input: source.to_string(),
+            mime: "unknown".to_string(),
+        }
+    })?;
+
+    check_image_mime(source, &mime)?;
+
+    Ok(encode_data_uri(&mime, bytes.as_ref()))
+}
+
+async fn resolve_local_image(source: &str, max_bytes: usize) -> Result<String> {
+    let path = Path::new(source);
+    if !path.exists() || !path.is_file() {
+        return Err(MultimodalError::ImageSourceNotFound {
+            input: source.to_string(),
+        });
+    }
+
+    let metadata =
+        tokio::fs::metadata(path)
+            .await
+            .map_err(|error| MultimodalError::LocalReadFailed {
+                input: source.to_string(),
+                reason: error.to_string(),
+            })?;
+
+    check_image_size(source, metadata.len() as usize, max_bytes)?;
+
+    let bytes = tokio::fs::read(path)
+        .await
+        .map_err(|error| MultimodalError::LocalReadFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        })?;
+
+    check_image_size(source, bytes.len(), max_bytes)?;
+
+    let mime = detect_image_mime(Some(path), &bytes, None).ok_or_else(|| {
+        MultimodalError::UnsupportedMime {
+            input: source.to_string(),
+            mime: "unknown".to_string(),
+        }
+    })?;
+
+    check_image_mime(source, &mime)?;
+
+    Ok(encode_data_uri(&mime, &bytes))
+}
+
+fn check_image_size(source: &str, size_bytes: usize, max_bytes: usize) -> Result<()> {
+    if size_bytes > max_bytes {
+        return Err(MultimodalError::ImageTooLarge {
+            input: source.to_string(),
+            size_bytes,
+            max_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn check_image_mime(source: &str, mime: &str) -> Result<()> {
+    if is_allowed_image_mime(mime) {
+        return Ok(());
+    }
+    Err(MultimodalError::UnsupportedMime {
+        input: source.to_string(),
+        mime: mime.to_string(),
+    })
+}
+
+// ── Files ────────────────────────────────────────────────────────────────
+
+/// Resolve one `[FILE:…]` reference into a [`FilePayload`].
+///
+/// The MIME allowlist is checked **after** the bytes are in hand, because the
+/// type is detected from them; an over-cap or unreadable file therefore fails
+/// on that first, which is the more useful message.
+pub async fn resolve_file(
+    source: &str,
+    limits: &FileLimits,
+    max_bytes: usize,
+    max_extracted_text_chars: usize,
+    remote_client: &Client,
+    extractor: &dyn TextExtractor,
+) -> Result<FilePayload> {
+    if source.starts_with("data:") {
+        let (bytes, name, mime) = resolve_file_data_uri(source, max_bytes)?;
+        return build_file_payload(
+            source,
+            bytes,
+            name,
+            mime,
+            limits,
+            max_extracted_text_chars,
+            extractor,
+        )
+        .await;
+    }
+
+    let (bytes, path_hint, name, header_content_type) =
+        if source.starts_with("http://") || source.starts_with("https://") {
+            if !limits.allow_remote_fetch {
+                return Err(MultimodalError::RemoteFileFetchDisabled {
+                    input: source.to_string(),
+                });
+            }
+            let (bytes, name, content_type) =
+                fetch_remote_file(source, max_bytes, remote_client).await?;
+            (bytes, None, name, content_type)
+        } else {
+            let (bytes, path, name) = read_local_file(source, max_bytes).await?;
+            (bytes, Some(path), name, None)
+        };
+
+    let mime = detect_file_mime(path_hint.as_deref(), &bytes, header_content_type.as_deref())
+        .ok_or_else(|| MultimodalError::UnsupportedFileMime {
+            input: source.to_string(),
+            mime: "unknown".to_string(),
+            supported: limits.supported_rendered(),
+        })?;
+
+    build_file_payload(
+        source,
+        bytes,
+        name,
+        mime,
+        limits,
+        max_extracted_text_chars,
+        extractor,
+    )
+    .await
+}
+
+fn resolve_file_data_uri(source: &str, max_bytes: usize) -> Result<(Vec<u8>, String, String)> {
+    let parsed = parse_data_uri(source).map_err(|reason| MultimodalError::InvalidFileMarker {
+        input: source.to_string(),
+        reason,
+    })?;
+    let name = data_uri_param(&parsed.params, "name").unwrap_or_else(|| "attachment".to_string());
+
+    let (mime, bytes) = if parsed.mime == "application/gzip" {
+        let original_mime = data_uri_param(&parsed.params, "original_mime").ok_or_else(|| {
+            MultimodalError::InvalidFileMarker {
+                input: source.to_string(),
+                reason: "compressed file data URI missing original_mime parameter".to_string(),
+            }
+        })?;
+        let bytes = gunzip(&parsed.bytes, max_bytes).map_err(|reason| {
+            MultimodalError::InvalidFileMarker {
+                input: source.to_string(),
+                reason,
+            }
+        })?;
+        (original_mime.to_ascii_lowercase(), bytes)
+    } else {
+        (parsed.mime, parsed.bytes)
+    };
+
+    check_file_size(source, bytes.len(), max_bytes)?;
+
+    Ok((bytes, name, mime))
+}
+
+async fn build_file_payload(
+    source: &str,
+    bytes: Vec<u8>,
+    name: String,
+    mime: String,
+    limits: &FileLimits,
+    max_extracted_text_chars: usize,
+    extractor: &dyn TextExtractor,
+) -> Result<FilePayload> {
+    if !limits.is_mime_allowed(&mime) {
+        return Err(MultimodalError::UnsupportedFileMime {
+            input: source.to_string(),
+            mime: mime.clone(),
+            supported: limits.supported_rendered(),
+        });
+    }
+
+    tracing::debug!(
+        target: "multimodal",
+        file = %name,
+        mime = %mime,
+        size_bytes = bytes.len(),
+        "[multimodal::files] resolved file ref"
+    );
+
+    // Plain-text formats decode here; anything else is offered to the host's
+    // extractor, and a refusal degrades the file to a metadata reference rather
+    // than failing the turn.
+    let extracted = if super::mime::is_extractable_text_mime(&mime) {
+        None
+    } else {
+        match extractor.extract(&mime, &bytes).await {
+            Ok(text) => Some(text),
+            Err(reason) => {
+                tracing::warn!(
+                    target: "multimodal",
+                    file = %name,
+                    mime = %mime,
+                    reason = %reason,
+                    "[multimodal::files] text extraction failed, degrading to reference"
+                );
+                None
+            }
+        }
+    };
+
+    let payload =
+        FilePayload::from_resolved(&bytes, name, mime, extracted, max_extracted_text_chars);
+
+    if let FilePayload::Extracted {
+        name,
+        truncated_chars,
+        ..
+    } = &payload
+    {
+        if *truncated_chars > 0 {
+            tracing::info!(
+                target: "multimodal",
+                file = %name,
+                truncated_chars,
+                max_extracted_text_chars,
+                "[multimodal::files] truncated extracted text"
+            );
+        }
+    }
+
+    Ok(payload)
+}
+
+async fn read_local_file(source: &str, max_bytes: usize) -> Result<(Vec<u8>, PathBuf, String)> {
+    let path = Path::new(source).to_path_buf();
+    if !path.exists() || !path.is_file() {
+        return Err(MultimodalError::FileSourceNotFound {
+            input: source.to_string(),
+        });
+    }
+
+    let metadata =
+        tokio::fs::metadata(&path)
+            .await
+            .map_err(|error| MultimodalError::LocalFileReadFailed {
+                input: source.to_string(),
+                reason: error.to_string(),
+            })?;
+
+    check_file_size(source, metadata.len() as usize, max_bytes)?;
+
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|error| MultimodalError::LocalFileReadFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        })?;
+
+    check_file_size(source, bytes.len(), max_bytes)?;
+
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| source.to_string());
+
+    Ok((bytes, path, name))
+}
+
+async fn fetch_remote_file(
+    source: &str,
+    max_bytes: usize,
+    remote_client: &Client,
+) -> Result<(Vec<u8>, String, Option<String>)> {
+    let response = remote_client.get(source).send().await.map_err(|error| {
+        MultimodalError::RemoteFileFetchFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        }
+    })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(MultimodalError::RemoteFileFetchFailed {
+            input: source.to_string(),
+            reason: format!("HTTP {status}"),
+        });
+    }
+
+    if let Some(content_length) = response.content_length() {
+        check_file_size(source, content_length as usize, max_bytes)?;
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToString::to_string);
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| MultimodalError::RemoteFileFetchFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        })?;
+
+    check_file_size(source, bytes.len(), max_bytes)?;
+
+    // The last path segment, not a `Content-Disposition` filename: the header
+    // is attacker-controlled on a fetched URL and has its own escaping rules,
+    // and the payload header escapes whatever lands here anyway.
+    let name = source
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or(source)
+        .to_string();
+
+    Ok((bytes.to_vec(), name, content_type))
+}
+
+fn check_file_size(source: &str, size_bytes: usize, max_bytes: usize) -> Result<()> {
+    if size_bytes > max_bytes {
+        return Err(MultimodalError::FileTooLarge {
+            input: source.to_string(),
+            size_bytes,
+            max_bytes,
+        });
+    }
+    Ok(())
+}

--- a/src/harness/multimodal/resolve.rs
+++ b/src/harness/multimodal/resolve.rs
@@ -153,15 +153,12 @@ async fn resolve_remote_image(
     max_bytes: usize,
     remote_client: &Client,
 ) -> Result<String> {
-    let response =
-        remote_client
-            .get(source)
-            .send()
-            .await
-            .map_err(|error| MultimodalError::RemoteFetchFailed {
-                input: source.to_string(),
-                reason: error.to_string(),
-            })?;
+    let response = remote_client.get(source).send().await.map_err(|error| {
+        MultimodalError::RemoteFetchFailed {
+            input: source.to_string(),
+            reason: error.to_string(),
+        }
+    })?;
 
     let status = response.status();
     if !status.is_success() {
@@ -194,12 +191,13 @@ async fn resolve_remote_image(
 
     check_image_size(source, bytes.len(), max_bytes)?;
 
-    let mime = detect_image_mime(None, bytes.as_ref(), content_type.as_deref()).ok_or_else(|| {
-        MultimodalError::UnsupportedMime {
-            input: source.to_string(),
-            mime: "unknown".to_string(),
-        }
-    })?;
+    let mime =
+        detect_image_mime(None, bytes.as_ref(), content_type.as_deref()).ok_or_else(|| {
+            MultimodalError::UnsupportedMime {
+                input: source.to_string(),
+                mime: "unknown".to_string(),
+            }
+        })?;
 
     check_image_mime(source, &mime)?;
 
@@ -448,12 +446,13 @@ async fn read_local_file(source: &str, max_bytes: usize) -> Result<(Vec<u8>, Pat
 
     check_file_size(source, metadata.len() as usize, max_bytes)?;
 
-    let bytes = tokio::fs::read(&path)
-        .await
-        .map_err(|error| MultimodalError::LocalFileReadFailed {
-            input: source.to_string(),
-            reason: error.to_string(),
-        })?;
+    let bytes =
+        tokio::fs::read(&path)
+            .await
+            .map_err(|error| MultimodalError::LocalFileReadFailed {
+                input: source.to_string(),
+                reason: error.to_string(),
+            })?;
 
     check_file_size(source, bytes.len(), max_bytes)?;
 

--- a/src/harness/multimodal/resolve.rs
+++ b/src/harness/multimodal/resolve.rs
@@ -413,15 +413,16 @@ async fn build_file_payload(
         truncated_chars,
         ..
     } = &payload
-        && *truncated_chars > 0 {
-            tracing::info!(
-                target: "multimodal",
-                file = %name,
-                truncated_chars,
-                max_extracted_text_chars,
-                "[multimodal::files] truncated extracted text"
-            );
-        }
+        && *truncated_chars > 0
+    {
+        tracing::info!(
+            target: "multimodal",
+            file = %name,
+            truncated_chars,
+            max_extracted_text_chars,
+            "[multimodal::files] truncated extracted text"
+        );
+    }
 
     Ok(payload)
 }

--- a/src/harness/multimodal/test.rs
+++ b/src/harness/multimodal/test.rs
@@ -674,7 +674,7 @@ async fn the_extractor_is_consulted_for_what_it_claims_and_nothing_else() {
     // bytes.
     let zip = format!(
         "data:application/zip;name=a.zip;base64,{}",
-        STANDARD.encode(&[b'P', b'K', 0x03, 0x04])
+        STANDARD.encode([b'P', b'K', 0x03, 0x04])
     );
     let payload = resolve_file(
         &zip,

--- a/src/harness/multimodal/test.rs
+++ b/src/harness/multimodal/test.rs
@@ -1,0 +1,718 @@
+//! Tests for attachment resolution.
+//!
+//! The bias here is toward the decisions that are easy to get subtly wrong and
+//! that no type checks: the sentinel-before-clamp ordering, the two different
+//! header-vs-extension precedences, the truncation budget, and the cases where
+//! a malformed marker must be left alone rather than rewritten.
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+use super::config::{FileLimits, ImageLimits};
+use super::data_uri::{data_uri_param, gunzip, parse_data_uri, percent_decode};
+use super::error::MultimodalError;
+use super::markers::{
+    extract_image_placeholders_in_text, extract_ollama_image_payload, image_placeholder,
+    parse_file_markers, parse_image_markers, rehydrate_placeholders_in_text,
+    text_has_image_placeholders,
+};
+use super::mime::{
+    detect_file_mime, detect_image_mime, file_mime_from_extension, file_mime_from_magic,
+    image_ext_from_mime, image_mime_from_magic, is_extractable_text_mime, looks_like_utf8_text,
+};
+use super::payload::{
+    compose_multimodal_message, escape_attr, format_size, truncate_chars, FilePayload,
+};
+use super::resolve::{resolve_file, resolve_image, NoTextExtractor, TextExtractor};
+
+/// A 1×1 PNG. Small enough to inline, real enough to sniff.
+const PNG_BYTES: &[u8] = &[
+    0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n', 0x00, 0x00, 0x00, 0x0d, b'I', b'H', b'D',
+    b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+    0x15, 0xc4, 0x89,
+];
+
+fn png_data_uri() -> String {
+    format!("data:image/png;base64,{}", STANDARD.encode(PNG_BYTES))
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+// ── markers ──────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_image_markers_extracts_every_reference_in_order() {
+    let (text, refs) = parse_image_markers("before [IMAGE:/a.png] middle [IMAGE:/b.png] after");
+    assert_eq!(refs, vec!["/a.png".to_string(), "/b.png".to_string()]);
+    assert_eq!(text, "before  middle  after");
+}
+
+/// An empty marker has nothing to resolve, so removing it would be a silent
+/// edit of the user's own text.
+#[test]
+fn parse_image_markers_leaves_an_empty_marker_in_the_text() {
+    let (text, refs) = parse_image_markers("look: [IMAGE:]");
+    assert!(refs.is_empty());
+    assert_eq!(text, "look: [IMAGE:]");
+}
+
+/// A half-typed marker is text someone is still writing. Rewriting it would
+/// corrupt the message mid-edit.
+#[test]
+fn parse_image_markers_passes_an_unterminated_marker_through() {
+    let (text, refs) = parse_image_markers("oops [IMAGE:/a.png");
+    assert!(refs.is_empty());
+    assert_eq!(text, "oops [IMAGE:/a.png");
+}
+
+#[test]
+fn the_two_marker_parsers_do_not_consume_each_others_markers() {
+    let input = "[IMAGE:/a.png] and [FILE:/b.pdf]";
+
+    let (after_images, image_refs) = parse_image_markers(input);
+    assert_eq!(image_refs, vec!["/a.png".to_string()]);
+    assert!(after_images.contains("[FILE:/b.pdf]"));
+
+    let (cleaned, file_refs) = parse_file_markers(&after_images);
+    assert_eq!(file_refs, vec!["/b.pdf".to_string()]);
+    assert_eq!(cleaned, "and");
+}
+
+#[test]
+fn ollama_payload_accepts_a_data_uri_and_returns_only_the_payload() {
+    let encoded = STANDARD.encode(PNG_BYTES);
+    let extracted = extract_ollama_image_payload(&format!("data:image/png;base64,{encoded}"));
+    assert_eq!(extracted, Some(encoded));
+}
+
+/// The bug this guards: a filesystem path forwarded to the provider as if it
+/// were image bytes, producing an error that names neither the path nor the
+/// parameter.
+#[test]
+fn ollama_payload_rejects_a_filesystem_path() {
+    assert_eq!(extract_ollama_image_payload("/tmp/photo.png"), None);
+}
+
+/// `/9j/…` is how a bare base64 JPEG legitimately starts, so the absolute-path
+/// heuristic must not reject a real payload carrying that prefix. Length is
+/// what separates them.
+#[test]
+fn ollama_payload_still_accepts_a_long_bare_payload_beginning_with_a_slash() {
+    let payload = format!("/9j/{}", "A".repeat(200));
+    assert_eq!(
+        extract_ollama_image_payload(&payload),
+        Some(payload.clone())
+    );
+}
+
+#[test]
+fn ollama_payload_accepts_both_padded_and_unpadded_base64() {
+    // "hello!" encodes to a partial trailing group; "hello" to a padded one.
+    let padded = STANDARD.encode(b"hello");
+    assert!(padded.ends_with('='));
+    assert_eq!(
+        extract_ollama_image_payload(&padded),
+        Some(padded.clone()),
+        "padded payloads take the STANDARD engine"
+    );
+
+    let unpadded = padded.trim_end_matches('=').to_string();
+    assert_eq!(
+        extract_ollama_image_payload(&unpadded),
+        Some(unpadded.clone()),
+        "an unpadded payload must not be rejected as non-base64"
+    );
+}
+
+#[test]
+fn ollama_payload_rejects_a_data_uri_whose_payload_is_not_base64() {
+    assert_eq!(
+        extract_ollama_image_payload("data:image/png;base64,not base64!!"),
+        None
+    );
+}
+
+#[test]
+fn placeholders_round_trip_through_the_stash_index() {
+    let text = format!("here it is\n{}", image_placeholder("abc123"));
+    assert!(text_has_image_placeholders(&text));
+    assert_eq!(
+        extract_image_placeholders_in_text(&text),
+        vec![image_placeholder("abc123")]
+    );
+
+    let mut index = HashMap::new();
+    index.insert("abc123".to_string(), PathBuf::from("/stash/abc123.png"));
+    assert_eq!(
+        rehydrate_placeholders_in_text(&text, &index),
+        "here it is\n[IMAGE:/stash/abc123.png]"
+    );
+}
+
+/// A swept or foreign attachment keeps its human-readable placeholder rather
+/// than becoming a path that does not exist.
+#[test]
+fn an_unresolved_placeholder_keeps_its_text() {
+    let text = image_placeholder("gone");
+    let rehydrated = rehydrate_placeholders_in_text(&text, &HashMap::new());
+    assert_eq!(rehydrated, text);
+}
+
+/// `[Image: (could not be processed)]` has no id, so it is not a rehydration
+/// candidate even though it shares the prefix.
+#[test]
+fn a_placeholder_without_a_stash_id_is_not_a_candidate() {
+    let text = "[Image: (could not be processed)]";
+    assert!(!text_has_image_placeholders(text));
+    assert!(extract_image_placeholders_in_text(text).is_empty());
+}
+
+// ── data URIs ────────────────────────────────────────────────────────────
+
+#[test]
+fn data_uri_parsing_lower_cases_the_mime_and_percent_decodes_parameters() {
+    let uri = format!(
+        "data:TEXT/Plain;name=my%20notes.txt;base64,{}",
+        STANDARD.encode(b"hi")
+    );
+    let parsed = parse_data_uri(&uri).expect("parses");
+    assert_eq!(parsed.mime, "text/plain");
+    assert_eq!(
+        data_uri_param(&parsed.params, "NAME"),
+        Some("my notes.txt".to_string())
+    );
+    assert_eq!(parsed.bytes, b"hi");
+}
+
+#[test]
+fn data_uri_parsing_rejects_the_non_base64_form() {
+    let error = parse_data_uri("data:text/plain,hello").expect_err("rejected");
+    assert!(error.contains("base64"), "unexpected reason: {error}");
+}
+
+/// A malformed escape falls back to the raw value: a filename containing a bare
+/// `%` is far likelier than one that meant to be encoded and was not.
+#[test]
+fn percent_decode_returns_none_on_a_truncated_escape() {
+    assert_eq!(percent_decode("100%"), None);
+    assert_eq!(percent_decode("plain"), Some("plain".to_string()));
+}
+
+#[test]
+fn gunzip_refuses_a_payload_that_decompresses_past_the_cap() {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&vec![b'a'; 4096]).expect("write");
+    let compressed = encoder.finish().expect("finish");
+
+    assert_eq!(gunzip(&compressed, 4096).expect("within cap").len(), 4096);
+
+    let error = gunzip(&compressed, 100).expect_err("over cap");
+    assert!(error.contains("exceeds 100 bytes"), "unexpected: {error}");
+}
+
+// ── MIME ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn an_image_content_type_header_wins_over_everything_else() {
+    // JPEG magic, PNG header: the header is authoritative for images.
+    let detected = detect_image_mime(None, &[0xff, 0xd8, 0xff], Some("image/png; charset=binary"));
+    assert_eq!(detected.as_deref(), Some("image/png"));
+}
+
+/// The mirror-image rule for files: a server answering `application/octet-stream`
+/// for a PDF must not cost that PDF its text layer.
+#[test]
+fn an_unrecognised_file_content_type_header_loses_to_magic_bytes() {
+    let detected = detect_file_mime(None, b"%PDF-1.7 ...", Some("application/x-nonsense"));
+    assert_eq!(detected.as_deref(), Some("application/pdf"));
+}
+
+/// OOXML containers are all `PK\x03\x04`, so only the extension separates them.
+#[test]
+fn the_extension_is_what_separates_ooxml_from_a_plain_zip() {
+    let zip_magic = &[b'P', b'K', 0x03, 0x04, 0x00];
+    assert_eq!(file_mime_from_magic(zip_magic), Some("application/zip"));
+    assert_eq!(
+        detect_file_mime(Some(&PathBuf::from("book.xlsx")), zip_magic, None).as_deref(),
+        Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    );
+    assert_eq!(
+        detect_file_mime(Some(&PathBuf::from("archive.zip")), zip_magic, None).as_deref(),
+        Some("application/zip")
+    );
+}
+
+#[test]
+fn an_unlabeled_text_file_falls_back_to_the_utf8_sniff() {
+    assert!(looks_like_utf8_text(b"log line\n"));
+    assert!(!looks_like_utf8_text(b""));
+    assert!(!looks_like_utf8_text(&[0xff, 0xfe, 0x00]));
+    assert_eq!(
+        detect_file_mime(Some(&PathBuf::from("server.log")), b"boot ok\n", None).as_deref(),
+        Some("text/plain")
+    );
+}
+
+#[test]
+fn image_magic_and_extension_tables_agree_with_each_other() {
+    for (ext, mime) in [
+        ("png", "image/png"),
+        ("jpg", "image/jpeg"),
+        ("webp", "image/webp"),
+        ("gif", "image/gif"),
+        ("bmp", "image/bmp"),
+    ] {
+        let detected = detect_image_mime(Some(&PathBuf::from(format!("a.{ext}"))), &[], None);
+        assert_eq!(detected.as_deref(), Some(mime));
+        assert!(image_ext_from_mime(mime).is_some());
+    }
+    assert_eq!(image_mime_from_magic(PNG_BYTES), Some("image/png"));
+}
+
+#[test]
+fn only_the_plaintext_formats_are_extractable_without_a_parser() {
+    assert!(is_extractable_text_mime("text/plain"));
+    assert!(is_extractable_text_mime("text/csv"));
+    assert!(is_extractable_text_mime("text/markdown"));
+    assert!(!is_extractable_text_mime("application/pdf"));
+    assert_eq!(file_mime_from_extension("PDF"), Some("application/pdf"));
+}
+
+// ── config ───────────────────────────────────────────────────────────────
+
+#[test]
+fn limits_clamp_absurd_configuration_into_runtime_bounds() {
+    let images = ImageLimits {
+        max_images: 9_000,
+        max_image_size_mb: 0,
+        allow_remote_fetch: false,
+    };
+    assert_eq!(images.effective(), (16, 1));
+
+    let files = FileLimits {
+        max_files: 9_000,
+        max_file_size_mb: 9_000,
+        max_extracted_text_chars: 1,
+        ..FileLimits::default()
+    };
+    assert_eq!(files.effective(), (16, 50, 1_000));
+}
+
+/// The whole point of the sentinel: it must be read before the clamp, which
+/// would otherwise turn "no files" into "one file".
+#[test]
+fn the_disable_sentinel_survives_the_clamp() {
+    let disabled = FileLimits {
+        max_files: 0,
+        ..FileLimits::default()
+    };
+    assert!(disabled.files_disabled());
+    assert_eq!(
+        disabled.effective().0,
+        1,
+        "the clamp lifts 0 to 1 — which is exactly why files_disabled exists"
+    );
+    assert!(!FileLimits::default().files_disabled());
+}
+
+#[test]
+fn the_file_mime_allowlist_is_case_insensitive() {
+    let limits = FileLimits::default();
+    assert!(limits.is_mime_allowed("APPLICATION/PDF"));
+    assert!(!limits.is_mime_allowed("application/x-executable"));
+    assert!(limits.supported_rendered().contains("application/pdf"));
+}
+
+// ── payload ──────────────────────────────────────────────────────────────
+
+#[test]
+fn truncation_reserves_room_for_its_own_suffix() {
+    let (text, dropped) = truncate_chars("abc".to_string(), 100);
+    assert_eq!((text.as_str(), dropped), ("abc", 0));
+
+    let cap = 1_000;
+    let (text, dropped) = truncate_chars("x".repeat(5_000), cap);
+    assert!(dropped > 0);
+    let rendered = format!("{text}\n[…truncated {dropped} chars]");
+    assert!(
+        rendered.chars().count() <= cap,
+        "text plus suffix must stay inside the cap, got {}",
+        rendered.chars().count()
+    );
+}
+
+#[test]
+fn truncation_counts_characters_not_bytes() {
+    let (text, dropped) = truncate_chars("é".repeat(50), 30);
+    assert_eq!(text.chars().count() + dropped, 50);
+}
+
+/// A filename is user-supplied, and one containing a quote would otherwise
+/// break the header out of its own delimiters.
+#[test]
+fn attribute_escaping_neutralises_quotes_and_newlines() {
+    assert_eq!(escape_attr("a\"b\nc\rd"), "a_b_c_d");
+}
+
+#[test]
+fn sizes_render_in_the_largest_unit_that_fits() {
+    assert_eq!(format_size(512), "512 B");
+    assert_eq!(format_size(2 * 1024), "2.0 KB");
+    assert_eq!(format_size(3 * 1024 * 1024), "3.0 MB");
+}
+
+#[test]
+fn a_plaintext_payload_extracts_and_a_binary_one_references() {
+    let extracted = FilePayload::from_resolved(
+        b"hello world",
+        "notes.txt".to_string(),
+        "text/plain".to_string(),
+        None,
+        1_000,
+    );
+    assert!(matches!(
+        &extracted,
+        FilePayload::Extracted { text, .. } if text == "hello world"
+    ));
+
+    let referenced = FilePayload::from_resolved(
+        &[b'P', b'K', 0x03, 0x04],
+        "archive.zip".to_string(),
+        "application/zip".to_string(),
+        None,
+        1_000,
+    );
+    assert!(matches!(
+        &referenced,
+        FilePayload::Reference { sha256_prefix, .. } if sha256_prefix.len() == 16
+    ));
+}
+
+/// A host extractor's output is used for a format this crate cannot decode
+/// itself; a refusal degrades to a reference rather than failing.
+#[test]
+fn a_host_extraction_is_used_and_its_absence_degrades() {
+    let with_text = FilePayload::from_resolved(
+        b"%PDF-1.7",
+        "report.pdf".to_string(),
+        "application/pdf".to_string(),
+        Some("page one".to_string()),
+        1_000,
+    );
+    assert!(matches!(
+        &with_text,
+        FilePayload::Extracted { text, .. } if text == "page one"
+    ));
+
+    let without = FilePayload::from_resolved(
+        b"%PDF-1.7",
+        "report.pdf".to_string(),
+        "application/pdf".to_string(),
+        None,
+        1_000,
+    );
+    assert!(matches!(&without, FilePayload::Reference { .. }));
+}
+
+#[test]
+fn composing_renders_text_then_images_then_files() {
+    let rendered = compose_multimodal_message(
+        "look at these",
+        &["data:image/png;base64,AAAA".to_string()],
+        &[FilePayload::Extracted {
+            name: "notes.txt".to_string(),
+            mime: "text/plain".to_string(),
+            size_bytes: 11,
+            text: "hello world".to_string(),
+            truncated_chars: 0,
+        }],
+    );
+
+    assert!(rendered.starts_with("look at these"));
+    assert!(rendered.contains("[IMAGE:data:image/png;base64,AAAA]"));
+    assert!(rendered.contains(r#"[FILE-EXTRACTED: name="notes.txt" size="11 B" mime="text/plain"]"#));
+    assert!(rendered.trim_end().ends_with("[/FILE-EXTRACTED]"));
+    assert!(!rendered.contains("truncated"));
+}
+
+#[test]
+fn a_truncated_payload_says_so_in_the_rendered_block() {
+    let rendered = compose_multimodal_message(
+        "",
+        &[],
+        &[FilePayload::Extracted {
+            name: "big.txt".to_string(),
+            mime: "text/plain".to_string(),
+            size_bytes: 4_096,
+            text: "start".to_string(),
+            truncated_chars: 4_091,
+        }],
+    );
+    assert!(rendered.contains("[…truncated 4091 chars]"));
+}
+
+// ── resolve ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_image_data_uri_round_trips_to_a_canonical_data_uri() {
+    let limits = ImageLimits::default();
+    let resolved = resolve_image(
+        &png_data_uri(),
+        &limits,
+        limits.max_image_bytes(),
+        &client(),
+    )
+    .await
+    .expect("resolves");
+    assert_eq!(resolved, png_data_uri());
+}
+
+#[tokio::test]
+async fn an_oversized_image_is_refused_by_size_before_anything_else() {
+    let limits = ImageLimits::default();
+    let error = resolve_image(&png_data_uri(), &limits, 4, &client())
+        .await
+        .expect_err("refused");
+    assert!(matches!(error, MultimodalError::ImageTooLarge { .. }));
+}
+
+#[tokio::test]
+async fn a_disallowed_image_mime_is_refused_even_as_a_data_uri() {
+    let limits = ImageLimits::default();
+    let uri = format!("data:image/tiff;base64,{}", STANDARD.encode(b"II*\0"));
+    let error = resolve_image(&uri, &limits, 1_024, &client())
+        .await
+        .expect_err("refused");
+    assert!(matches!(error, MultimodalError::UnsupportedMime { .. }));
+}
+
+#[tokio::test]
+async fn remote_references_are_refused_while_remote_fetch_is_off() {
+    let images = ImageLimits::default();
+    assert!(!images.allow_remote_fetch);
+    let error = resolve_image("https://example.com/a.png", &images, 1_024, &client())
+        .await
+        .expect_err("refused");
+    assert!(matches!(error, MultimodalError::RemoteFetchDisabled { .. }));
+
+    let files = FileLimits::default();
+    assert!(!files.allow_remote_fetch);
+    let error = resolve_file(
+        "https://example.com/a.pdf",
+        &files,
+        1_024,
+        1_000,
+        &client(),
+        &NoTextExtractor,
+    )
+    .await
+    .expect_err("refused");
+    assert!(matches!(
+        error,
+        MultimodalError::RemoteFileFetchDisabled { .. }
+    ));
+}
+
+#[tokio::test]
+async fn a_missing_local_reference_is_reported_as_not_found() {
+    let images = ImageLimits::default();
+    let error = resolve_image("/definitely/not/here.png", &images, 1_024, &client())
+        .await
+        .expect_err("refused");
+    assert!(matches!(error, MultimodalError::ImageSourceNotFound { .. }));
+
+    let files = FileLimits::default();
+    let error = resolve_file(
+        "/definitely/not/here.pdf",
+        &files,
+        1_024,
+        1_000,
+        &client(),
+        &NoTextExtractor,
+    )
+    .await
+    .expect_err("refused");
+    assert!(matches!(error, MultimodalError::FileSourceNotFound { .. }));
+}
+
+#[tokio::test]
+async fn a_gzipped_data_uri_decompresses_when_it_names_its_original_mime() {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(PNG_BYTES).expect("write");
+    let compressed = encoder.finish().expect("finish");
+
+    let uri = format!(
+        "data:application/gzip;original_mime=image/png;base64,{}",
+        STANDARD.encode(&compressed)
+    );
+    let limits = ImageLimits::default();
+    let resolved = resolve_image(&uri, &limits, limits.max_image_bytes(), &client())
+        .await
+        .expect("resolves");
+    assert_eq!(resolved, png_data_uri());
+}
+
+/// Without `original_mime` the payload cannot be validated against any
+/// allowlist, so it is refused rather than guessed at.
+#[tokio::test]
+async fn a_gzipped_data_uri_without_original_mime_is_refused() {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(PNG_BYTES).expect("write");
+    let compressed = encoder.finish().expect("finish");
+
+    let uri = format!(
+        "data:application/gzip;base64,{}",
+        STANDARD.encode(&compressed)
+    );
+    let limits = ImageLimits::default();
+    let error = resolve_image(&uri, &limits, limits.max_image_bytes(), &client())
+        .await
+        .expect_err("refused");
+    assert!(matches!(error, MultimodalError::InvalidMarker { .. }));
+}
+
+#[tokio::test]
+async fn a_file_data_uri_takes_its_name_from_the_header_parameter() {
+    let uri = format!(
+        "data:text/plain;name=notes.txt;base64,{}",
+        STANDARD.encode(b"hello world")
+    );
+    let limits = FileLimits::default();
+    let payload = resolve_file(
+        &uri,
+        &limits,
+        limits.max_file_bytes(),
+        1_000,
+        &client(),
+        &NoTextExtractor,
+    )
+    .await
+    .expect("resolves");
+
+    match payload {
+        FilePayload::Extracted { name, text, .. } => {
+            assert_eq!(name, "notes.txt");
+            assert_eq!(text, "hello world");
+        }
+        other => panic!("expected extracted text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn a_file_whose_mime_is_not_allowlisted_is_refused_after_detection() {
+    let uri = format!(
+        "data:application/x-executable;base64,{}",
+        STANDARD.encode(b"\x7fELF")
+    );
+    let limits = FileLimits::default();
+    let error = resolve_file(
+        &uri,
+        &limits,
+        limits.max_file_bytes(),
+        1_000,
+        &client(),
+        &NoTextExtractor,
+    )
+    .await
+    .expect_err("refused");
+    assert!(matches!(
+        error,
+        MultimodalError::UnsupportedFileMime { .. }
+    ));
+}
+
+/// Counts how often the extractor is consulted, so the `handles` short-circuit
+/// is observable.
+#[derive(Default)]
+struct CountingExtractor {
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait]
+impl TextExtractor for CountingExtractor {
+    fn handles(&self, mime: &str) -> bool {
+        mime == "application/pdf"
+    }
+
+    async fn extract(&self, _mime: &str, _bytes: &[u8]) -> std::result::Result<String, String> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok("extracted page".to_string())
+    }
+}
+
+#[tokio::test]
+async fn the_extractor_is_consulted_for_what_it_claims_and_nothing_else() {
+    let extractor = CountingExtractor::default();
+    let limits = FileLimits::default();
+
+    let pdf = format!(
+        "data:application/pdf;name=a.pdf;base64,{}",
+        STANDARD.encode(b"%PDF-1.7")
+    );
+    let payload = resolve_file(
+        &pdf,
+        &limits,
+        limits.max_file_bytes(),
+        1_000,
+        &client(),
+        &extractor,
+    )
+    .await
+    .expect("resolves");
+    assert!(matches!(
+        &payload,
+        FilePayload::Extracted { text, .. } if text == "extracted page"
+    ));
+
+    // A binary format the extractor does not claim must not cost a call — for
+    // an out-of-process parser that call is a round trip and a copy of the
+    // bytes.
+    let zip = format!(
+        "data:application/zip;name=a.zip;base64,{}",
+        STANDARD.encode(&[b'P', b'K', 0x03, 0x04])
+    );
+    let payload = resolve_file(
+        &zip,
+        &limits,
+        limits.max_file_bytes(),
+        1_000,
+        &client(),
+        &extractor,
+    )
+    .await
+    .expect("resolves");
+    assert!(matches!(&payload, FilePayload::Reference { .. }));
+
+    assert_eq!(
+        extractor.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only the claimed MIME type should reach the extractor"
+    );
+}
+
+#[tokio::test]
+async fn a_host_with_no_extractor_degrades_a_pdf_to_a_reference() {
+    let uri = format!(
+        "data:application/pdf;name=a.pdf;base64,{}",
+        STANDARD.encode(b"%PDF-1.7")
+    );
+    let limits = FileLimits::default();
+    let payload = resolve_file(
+        &uri,
+        &limits,
+        limits.max_file_bytes(),
+        1_000,
+        &client(),
+        &NoTextExtractor,
+    )
+    .await
+    .expect("resolves");
+    assert!(matches!(payload, FilePayload::Reference { .. }));
+}

--- a/src/harness/multimodal/test.rs
+++ b/src/harness/multimodal/test.rs
@@ -10,7 +10,7 @@ use std::io::Write as _;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 
 use super::config::{FileLimits, ImageLimits};
 use super::data_uri::{data_uri_param, gunzip, parse_data_uri, percent_decode};
@@ -25,15 +25,15 @@ use super::mime::{
     image_ext_from_mime, image_mime_from_magic, is_extractable_text_mime, looks_like_utf8_text,
 };
 use super::payload::{
-    compose_multimodal_message, escape_attr, format_size, truncate_chars, FilePayload,
+    FilePayload, compose_multimodal_message, escape_attr, format_size, truncate_chars,
 };
-use super::resolve::{resolve_file, resolve_image, NoTextExtractor, TextExtractor};
+use super::resolve::{NoTextExtractor, TextExtractor, resolve_file, resolve_image};
 
 /// A 1×1 PNG. Small enough to inline, real enough to sniff.
 const PNG_BYTES: &[u8] = &[
     0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n', 0x00, 0x00, 0x00, 0x0d, b'I', b'H', b'D',
-    b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
-    0x15, 0xc4, 0x89,
+    b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15,
+    0xc4, 0x89,
 ];
 
 fn png_data_uri() -> String {
@@ -436,7 +436,9 @@ fn composing_renders_text_then_images_then_files() {
 
     assert!(rendered.starts_with("look at these"));
     assert!(rendered.contains("[IMAGE:data:image/png;base64,AAAA]"));
-    assert!(rendered.contains(r#"[FILE-EXTRACTED: name="notes.txt" size="11 B" mime="text/plain"]"#));
+    assert!(
+        rendered.contains(r#"[FILE-EXTRACTED: name="notes.txt" size="11 B" mime="text/plain"]"#)
+    );
     assert!(rendered.trim_end().ends_with("[/FILE-EXTRACTED]"));
     assert!(!rendered.contains("truncated"));
 }
@@ -621,10 +623,7 @@ async fn a_file_whose_mime_is_not_allowlisted_is_refused_after_detection() {
     )
     .await
     .expect_err("refused");
-    assert!(matches!(
-        error,
-        MultimodalError::UnsupportedFileMime { .. }
-    ));
+    assert!(matches!(error, MultimodalError::UnsupportedFileMime { .. }));
 }
 
 /// Counts how often the extractor is consulted, so the `handles` short-circuit
@@ -641,8 +640,7 @@ impl TextExtractor for CountingExtractor {
     }
 
     async fn extract(&self, _mime: &str, _bytes: &[u8]) -> std::result::Result<String, String> {
-        self.calls
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok("extracted page".to_string())
     }
 }


### PR DESCRIPTION
## Summary

Adds `harness::multimodal`: attachment resolution for `[IMAGE:…]` and `[FILE:…]`
markers, behind a new default-off `multimodal` cargo feature.

The code is extracted from OpenHuman's `agent/multimodal.rs`, which has carried
this pipeline for a while and is where its edge cases were found. The split
follows the usual rule — the crate owns what is the same for every host, the
host keeps what depends on its own runtime, storage, or threat model — so this
PR takes marker parsing, `data:` URI decoding, MIME detection, the limit clamps
and the rendered payload, and leaves the rest behind a seam.

| Module | Owns |
| --- | --- |
| `markers` | the four-token wire format, both marker parsers, the Ollama payload validator, placeholder extract/rehydrate |
| `data_uri` | base64 `data:` parsing, header parameters, percent-decode, bounded gunzip |
| `mime` | image + file detection, with the two different header-vs-extension precedences |
| `payload` | `FilePayload`, the rendered `[FILE-EXTRACTED]` / `[FILE-ATTACHED]` blocks, truncation, attribute escaping |
| `config` | `ImageLimits` / `FileLimits` and their clamps, following the `harness::config` convention |
| `resolve` | the three source shapes, and the `TextExtractor` seam |

Four things stay with the host, each for a reason that is in the module docs:
the `reqwest::Client` (proxy and timeouts are host policy — this module borrows
one), the `TextExtractor` impl (which document parser a host carries, and how
long it may run), the attachment stash (where bytes live between ingress and
dispatch), and message-level counting (only the host knows its message type).

## API Or Behavior Changes

**New public surface, all of it new** — `harness::multimodal` does not exist on
`main`, and nothing outside it changed. The feature is **off by default**, so a
host that does not opt in resolves neither `base64` nor `flate2` and sees no
change at all.

Two decisions worth a reviewer's attention, because both are load-bearing and
neither is obvious from the signature:

- **`TextExtractor::handles(&self, mime)` is required, not defaulted.**
  The first cut offered every non-plaintext file to the extractor and let it
  refuse. That is wrong for a host whose parser runs out-of-process: a `.zip` or
  `.xlsx` would cost a round trip and a copy of the file to reach a refusal that
  was knowable from the MIME type alone. `handles` is consulted before every
  call, and `the_extractor_is_consulted_for_what_it_claims_and_nothing_else`
  counts the calls to prove it.

- **`FileLimits::files_disabled()` is deliberately separate from `effective()`.**
  `max_files == 0` means *none* — it is the sentinel a host sets for a turn whose
  text came from somewhere it does not trust. `effective()` clamps to `1..=16`,
  so a caller consulting only the clamped value admits exactly one attachment
  from a source that asked for zero. `resolve` checks the sentinel first, and
  `the_disable_sentinel_survives_the_clamp` pins the ordering.

`resolve` also does **not** decide which local paths may be read, and
`TextExtractor` carries **no deadline**. Both are host decisions and both are
argued in the module header rather than left to be inferred.

## Tests

44 new tests in `harness::multimodal::test`, biased toward the decisions that no
type checks: the sentinel-before-clamp ordering, the two MIME precedences, the
truncation budget, and the cases where a malformed marker must be left alone
rather than rewritten (an empty `[IMAGE:]`, an unterminated marker, a
placeholder with no stash id).

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test`
- [x] `cargo test --all-features`

Also verified downstream, since OpenHuman is the first consumer: its 50
multimodal tests pass against this branch under both its product feature set and
`--no-default-features`, and its kernel-floor ratchet does not move —
`base64`, `flate2` and `sha2` were already resolved there, so enabling the
feature adds **zero packages and zero native builds**.

## Documentation

Module-level rustdoc on `multimodal/mod.rs` covers the marker convention, the
two pipelines and where they diverge, the host/crate split with a reason per
row, and the two ordering rules. Every submodule carries its own header
explaining the non-obvious choices — why the file MIME precedence differs from
the image one, why gunzip caps at `max + 1`, why a percent-decode failure falls
back to the raw value.
