### PR TITLE
feat(graph): shared-workspace claim arbitration, task-store registry, orphan reconciliation

### DIFF
--- a/src/graph/orchestration/mod.rs
+++ b/src/graph/orchestration/mod.rs
@@ -18,8 +18,7 @@ mod tool;
 mod types;
 
 pub use reconcile::{
-    ReconcileOutcome, ReconcileReport, ReconciledTask, reconcile_orphaned_tasks,
-    task_status_label,
+    ReconcileOutcome, ReconcileReport, ReconciledTask, reconcile_orphaned_tasks, task_status_label,
 };
 pub use runtime::DetachedTaskRegistry;
 pub use store::{InMemoryTaskStore, JsonlTaskStore, TaskStore};

--- a/src/graph/orchestration/mod.rs
+++ b/src/graph/orchestration/mod.rs
@@ -10,13 +10,22 @@
 //! [`register_orchestration_tools`] to insert them into a
 //! [`crate::harness::tool::ToolRegistry`] alongside any other tools.
 
+mod reconcile;
 mod runtime;
 mod store;
+mod store_registry;
 mod tool;
 mod types;
 
+pub use reconcile::{
+    ReconcileOutcome, ReconcileReport, ReconciledTask, reconcile_orphaned_tasks,
+    task_status_label,
+};
 pub use runtime::DetachedTaskRegistry;
 pub use store::{InMemoryTaskStore, JsonlTaskStore, TaskStore};
+pub use store_registry::{
+    TaskStoreRegistry, TaskStoreRegistryError, open_jsonl_task_store_or_memory,
+};
 pub use tool::{
     OrchestrationTool, SteeringRegistry, orchestration_tool_schema, orchestration_tool_schemas,
     orchestration_tools, orchestration_tools_with_steering, register_orchestration_tools,

--- a/src/graph/orchestration/reconcile.rs
+++ b/src/graph/orchestration/reconcile.rs
@@ -1,0 +1,160 @@
+//! Settling orphaned tasks left behind by a dead executor.
+//!
+//! A detached task runs on an executor owned by the process that spawned it.
+//! When that process dies, the executor, its abort handle and its cancellation
+//! token die with it — but a durable [`TaskStore`] still holds a non-terminal
+//! record. Nothing will ever complete that record, so without reconciliation it
+//! reads as perpetually live: a supervisor waits forever, and a ledger renders a
+//! run that has not existed since the last restart.
+//!
+//! [`reconcile_orphaned_tasks`] settles those records. It owns the state machine
+//! — which statuses count as live, and which terminal state each becomes — and
+//! nothing else. The failure *reason* is supplied by the caller, because the
+//! sentence a user reads about their own product is not this crate's to write.
+//!
+//! Reconciliation is best-effort by construction: a record that races to
+//! terminal between the listing and the transition is expected, not exceptional,
+//! so per-task failures are captured in the report and the sweep continues.
+
+use crate::harness::ids::TaskId;
+
+use super::store::TaskStore;
+use super::types::{OrchestrationTaskFilter, OrchestrationTaskRecord, OrchestrationTaskStatus};
+
+/// What reconciliation did to one task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcileOutcome {
+    /// The task had a cancellation pending and was settled as cancelled.
+    Cancelled,
+    /// The task was live with no cancellation pending and was settled as failed.
+    Failed,
+    /// The transition itself failed; the task may still be non-terminal.
+    Error(String),
+}
+
+impl ReconcileOutcome {
+    /// `true` when the task reached a terminal state.
+    pub fn is_settled(&self) -> bool {
+        matches!(self, Self::Cancelled | Self::Failed)
+    }
+}
+
+/// One task considered by a reconciliation sweep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciledTask {
+    /// The task that was swept.
+    pub task_id: TaskId,
+    /// The non-terminal status it held before the sweep.
+    pub prior_status: OrchestrationTaskStatus,
+    /// What the sweep did to it.
+    pub outcome: ReconcileOutcome,
+    /// The record as it stood before the transition, so callers can read their
+    /// own metadata off it when emitting lifecycle events.
+    pub record: OrchestrationTaskRecord,
+}
+
+/// The result of one reconciliation sweep.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReconcileReport {
+    /// Every orphan considered, in store order.
+    pub tasks: Vec<ReconciledTask>,
+}
+
+impl ReconcileReport {
+    /// How many tasks reached a terminal state.
+    pub fn reconciled_count(&self) -> usize {
+        self.settled().count()
+    }
+
+    /// How many tasks could not be transitioned.
+    pub fn error_count(&self) -> usize {
+        self.tasks
+            .iter()
+            .filter(|task| matches!(task.outcome, ReconcileOutcome::Error(_)))
+            .count()
+    }
+
+    /// The tasks that reached a terminal state.
+    pub fn settled(&self) -> impl Iterator<Item = &ReconciledTask> {
+        self.tasks.iter().filter(|task| task.outcome.is_settled())
+    }
+
+    /// `true` when the sweep found no orphans at all.
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+}
+
+/// Stable lowercase label for a task status, for logs and audit records.
+pub fn task_status_label(status: OrchestrationTaskStatus) -> &'static str {
+    match status {
+        OrchestrationTaskStatus::Pending => "pending",
+        OrchestrationTaskStatus::Running => "running",
+        OrchestrationTaskStatus::Awaiting => "awaiting",
+        OrchestrationTaskStatus::CancelRequested => "cancel_requested",
+        OrchestrationTaskStatus::Completed => "completed",
+        OrchestrationTaskStatus::Failed => "failed",
+        OrchestrationTaskStatus::Cancelled => "cancelled",
+        OrchestrationTaskStatus::TimedOut => "timed_out",
+    }
+}
+
+/// Settles every live task matching `filter` into a terminal state.
+///
+/// A task with a cancellation already requested settles as cancelled — honouring
+/// the intent that was recorded before the executor died. Every other live task
+/// settles as failed with the caller's `reason`, because its driver went away
+/// without producing a terminal event.
+///
+/// Already-terminal records are left untouched and do not appear in the report.
+/// Per-task transition failures are recorded as [`ReconcileOutcome::Error`] and
+/// never abort the sweep.
+pub fn reconcile_orphaned_tasks(
+    store: &dyn TaskStore,
+    filter: OrchestrationTaskFilter,
+    reason: &dyn Fn(&OrchestrationTaskRecord) -> String,
+) -> ReconcileReport {
+    let orphans: Vec<OrchestrationTaskRecord> = store
+        .list(filter)
+        .into_iter()
+        .filter(|record| record.status.is_live())
+        .collect();
+
+    let mut report = ReconcileReport {
+        tasks: Vec::with_capacity(orphans.len()),
+    };
+
+    for record in orphans {
+        let task_id = record.spec.task_id.clone();
+        let prior_status = record.status;
+
+        let outcome = match prior_status {
+            OrchestrationTaskStatus::CancelRequested => match store.mark_cancelled(&task_id) {
+                Ok(_) => ReconcileOutcome::Cancelled,
+                Err(err) => ReconcileOutcome::Error(err.to_string()),
+            },
+            _ => match store.fail(&task_id, reason(&record)) {
+                Ok(_) => ReconcileOutcome::Failed,
+                Err(err) => ReconcileOutcome::Error(err.to_string()),
+            },
+        };
+
+        if let ReconcileOutcome::Error(detail) = &outcome {
+            tracing::warn!(
+                task_id = %task_id.as_str(),
+                prior_status = task_status_label(prior_status),
+                error = %detail,
+                "[orchestration] failed to reconcile orphaned task"
+            );
+        }
+
+        report.tasks.push(ReconciledTask {
+            task_id,
+            prior_status,
+            outcome,
+            record,
+        });
+    }
+
+    report
+}

--- a/src/graph/orchestration/reconcile.rs
+++ b/src/graph/orchestration/reconcile.rs
@@ -96,6 +96,7 @@ pub fn task_status_label(status: OrchestrationTaskStatus) -> &'static str {
         OrchestrationTaskStatus::Failed => "failed",
         OrchestrationTaskStatus::Cancelled => "cancelled",
         OrchestrationTaskStatus::TimedOut => "timed_out",
+        OrchestrationTaskStatus::Abandoned => "abandoned",
     }
 }
 

--- a/src/graph/orchestration/reconcile.rs
+++ b/src/graph/orchestration/reconcile.rs
@@ -40,7 +40,7 @@ impl ReconcileOutcome {
 }
 
 /// One task considered by a reconciliation sweep.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReconciledTask {
     /// The task that was swept.
     pub task_id: TaskId,
@@ -54,7 +54,7 @@ pub struct ReconciledTask {
 }
 
 /// The result of one reconciliation sweep.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ReconcileReport {
     /// Every orphan considered, in store order.
     pub tasks: Vec<ReconciledTask>,

--- a/src/graph/orchestration/store_registry.rs
+++ b/src/graph/orchestration/store_registry.rs
@@ -1,0 +1,173 @@
+//! Keyed, cached provider of [`TaskStore`]s — one store per logical scope.
+//!
+//! A host that serves several isolated scopes (one workspace directory per
+//! project, one per tenant) needs exactly one durable store per scope, opened
+//! once and shared thereafter. Opening a second store over the same append log
+//! gives two writers with independently replayed state.
+//!
+//! [`TaskStoreRegistry`] is that cache. It is deliberately unopinionated about
+//! what a scope *is*: the key is whatever the host uses to tell scopes apart,
+//! and the opener is a host closure, so path layout and durability policy stay
+//! with the caller.
+//!
+//! # Lock poisoning
+//!
+//! Every accessor returns [`TaskStoreRegistryError`] rather than unwrapping, for
+//! the same reason [`DetachedTaskRegistry`](super::DetachedTaskRegistry) does: a
+//! panic in an unrelated task must not turn every later store lookup into a
+//! second panic.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use super::store::{InMemoryTaskStore, JsonlTaskStore, TaskStore};
+
+/// Why a registry lookup could not complete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskStoreRegistryError {
+    /// The registry mutex was poisoned by a panic in another task.
+    Lock(String),
+}
+
+impl std::fmt::Display for TaskStoreRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lock(detail) => write!(f, "task store registry lock poisoned: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for TaskStoreRegistryError {}
+
+type OpenFn<K> = dyn Fn(&K) -> Arc<dyn TaskStore> + Send + Sync;
+
+/// A process-wide cache of [`TaskStore`]s keyed by scope.
+pub struct TaskStoreRegistry<K: Eq + Hash + Clone + Send + Sync> {
+    stores: Mutex<HashMap<K, Arc<dyn TaskStore>>>,
+    open: Arc<OpenFn<K>>,
+}
+
+impl<K: Eq + Hash + Clone + Send + Sync> TaskStoreRegistry<K> {
+    /// Builds a registry that opens missing stores with `open`.
+    ///
+    /// `open` is infallible by design: a store that cannot be made durable
+    /// should degrade to an in-memory one rather than take the caller's
+    /// orchestration surface down with it. See
+    /// [`open_jsonl_task_store_or_memory`].
+    pub fn new(open: impl Fn(&K) -> Arc<dyn TaskStore> + Send + Sync + 'static) -> Self {
+        Self {
+            stores: Mutex::new(HashMap::new()),
+            open: Arc::new(open),
+        }
+    }
+
+    /// Returns the store for `key`, opening and caching it on first use.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn get_or_open(&self, key: &K) -> Result<Arc<dyn TaskStore>, TaskStoreRegistryError> {
+        let mut stores = self.lock()?;
+        if let Some(existing) = stores.get(key) {
+            return Ok(Arc::clone(existing));
+        }
+        let opened = (self.open)(key);
+        stores.insert(key.clone(), Arc::clone(&opened));
+        Ok(opened)
+    }
+
+    /// Returns the store for `key` only if it has already been opened.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn get(&self, key: &K) -> Result<Option<Arc<dyn TaskStore>>, TaskStoreRegistryError> {
+        Ok(self.lock()?.get(key).map(Arc::clone))
+    }
+
+    /// Number of scopes with an open store.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn len(&self) -> Result<usize, TaskStoreRegistryError> {
+        Ok(self.lock()?.len())
+    }
+
+    /// `true` when no store has been opened yet.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn is_empty(&self) -> Result<bool, TaskStoreRegistryError> {
+        Ok(self.lock()?.is_empty())
+    }
+
+    /// Drops every cached store, so the next lookup reopens.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn clear(&self) -> Result<(), TaskStoreRegistryError> {
+        self.lock()?.clear();
+        Ok(())
+    }
+
+    fn lock(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<K, Arc<dyn TaskStore>>>, TaskStoreRegistryError>
+    {
+        self.stores
+            .lock()
+            .map_err(|err| TaskStoreRegistryError::Lock(err.to_string()))
+    }
+}
+
+impl<K: Eq + Hash + Clone + Send + Sync> std::fmt::Debug for TaskStoreRegistry<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let open = self.stores.lock().map(|s| s.len());
+        f.debug_struct("TaskStoreRegistry")
+            .field("open_stores", &open.ok())
+            .finish()
+    }
+}
+
+/// Opens a durable [`JsonlTaskStore`] at `path`, degrading to an in-memory store.
+///
+/// The parent directory is created first. A failure at either step — an
+/// unwritable directory, a corrupt or unreadable log — yields an
+/// [`InMemoryTaskStore`] instead of an error: losing durability across a restart
+/// is a far smaller harm than refusing to run orchestration at all, and a host
+/// on a read-only volume should still be able to spawn work.
+pub fn open_jsonl_task_store_or_memory(path: &Path) -> Arc<dyn TaskStore> {
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                dir = %parent.display(),
+                error = %err,
+                "[orchestration] task store directory unavailable; falling back to memory"
+            );
+            return Arc::new(InMemoryTaskStore::new());
+        }
+    }
+
+    match JsonlTaskStore::open(path) {
+        Ok(store) => {
+            tracing::debug!(
+                path = %path.display(),
+                "[orchestration] opened durable task store"
+            );
+            Arc::new(store)
+        }
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "[orchestration] durable task store unavailable; falling back to memory"
+            );
+            Arc::new(InMemoryTaskStore::new())
+        }
+    }
+}

--- a/src/graph/orchestration/store_registry.rs
+++ b/src/graph/orchestration/store_registry.rs
@@ -90,6 +90,19 @@ impl<K: Eq + Hash + Clone + Send + Sync> TaskStoreRegistry<K> {
         Ok(self.lock()?.get(key).map(Arc::clone))
     }
 
+    /// Every store opened so far, in unspecified order.
+    ///
+    /// For supervisors that need a view across scopes — reconciling or
+    /// reporting over every workspace this process has touched — without
+    /// knowing the key set in advance.
+    ///
+    /// # Errors
+    ///
+    /// [`TaskStoreRegistryError::Lock`] when the registry mutex is poisoned.
+    pub fn values(&self) -> Result<Vec<Arc<dyn TaskStore>>, TaskStoreRegistryError> {
+        Ok(self.lock()?.values().map(Arc::clone).collect())
+    }
+
     /// Number of scopes with an open store.
     ///
     /// # Errors

--- a/src/graph/orchestration/store_registry.rs
+++ b/src/graph/orchestration/store_registry.rs
@@ -43,6 +43,9 @@ impl std::error::Error for TaskStoreRegistryError {}
 
 type OpenFn<K> = dyn Fn(&K) -> Arc<dyn TaskStore> + Send + Sync;
 
+/// The registry's cache, guarded for the lifetime of one accessor call.
+type StoreGuard<'a, K> = std::sync::MutexGuard<'a, HashMap<K, Arc<dyn TaskStore>>>;
+
 /// A process-wide cache of [`TaskStore`]s keyed by scope.
 pub struct TaskStoreRegistry<K: Eq + Hash + Clone + Send + Sync> {
     stores: Mutex<HashMap<K, Arc<dyn TaskStore>>>,
@@ -115,10 +118,7 @@ impl<K: Eq + Hash + Clone + Send + Sync> TaskStoreRegistry<K> {
         Ok(())
     }
 
-    fn lock(
-        &self,
-    ) -> Result<std::sync::MutexGuard<'_, HashMap<K, Arc<dyn TaskStore>>>, TaskStoreRegistryError>
-    {
+    fn lock(&self) -> Result<StoreGuard<'_, K>, TaskStoreRegistryError> {
         self.stores
             .lock()
             .map_err(|err| TaskStoreRegistryError::Lock(err.to_string()))
@@ -142,15 +142,15 @@ impl<K: Eq + Hash + Clone + Send + Sync> std::fmt::Debug for TaskStoreRegistry<K
 /// is a far smaller harm than refusing to run orchestration at all, and a host
 /// on a read-only volume should still be able to spawn work.
 pub fn open_jsonl_task_store_or_memory(path: &Path) -> Arc<dyn TaskStore> {
-    if let Some(parent) = path.parent() {
-        if let Err(err) = std::fs::create_dir_all(parent) {
-            tracing::warn!(
-                dir = %parent.display(),
-                error = %err,
-                "[orchestration] task store directory unavailable; falling back to memory"
-            );
-            return Arc::new(InMemoryTaskStore::new());
-        }
+    if let Some(parent) = path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!(
+            dir = %parent.display(),
+            error = %err,
+            "[orchestration] task store directory unavailable; falling back to memory"
+        );
+        return Arc::new(InMemoryTaskStore::new());
     }
 
     match JsonlTaskStore::open(path) {

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -1099,8 +1099,8 @@ fn reconcile_respects_the_filter() {
     store
         .insert(OrchestrationTaskSpec::new(
             "agent-task",
-            OrchestrationTaskKind::Agent {
-                agent_id: "worker".into(),
+            OrchestrationTaskKind::SubAgent {
+                agent: "worker".into(),
             },
         ))
         .expect("insert");
@@ -1108,7 +1108,7 @@ fn reconcile_respects_the_filter() {
 
     let report = reconcile_orphaned_tasks(
         &store,
-        OrchestrationTaskFilter::default().with_kind("agent"),
+        OrchestrationTaskFilter::default().with_kind("sub_agent"),
         &|_| "driver died".to_string(),
     );
 

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -914,3 +914,246 @@ async fn jsonl_store_persists_inside_current_thread_runtime() {
     assert_eq!(store.history(&task_id).len(), 2);
     let _ = std::fs::remove_file(&path);
 }
+
+// --- TaskStoreRegistry ---------------------------------------------------
+
+#[test]
+fn registry_opens_each_key_once_and_shares_the_same_store() {
+    let opens = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counter = Arc::clone(&opens);
+    let registry: TaskStoreRegistry<String> = TaskStoreRegistry::new(move |_key| {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>
+    });
+
+    let first = registry.get_or_open(&"a".to_string()).expect("opens");
+    let second = registry.get_or_open(&"a".to_string()).expect("reuses");
+
+    assert!(Arc::ptr_eq(&first, &second), "same key must reuse one store");
+    assert_eq!(opens.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(registry.len().expect("len"), 1);
+}
+
+#[test]
+fn registry_keeps_distinct_keys_isolated() {
+    let registry: TaskStoreRegistry<String> =
+        TaskStoreRegistry::new(|_key| Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>);
+
+    let a = registry.get_or_open(&"a".to_string()).expect("opens a");
+    let b = registry.get_or_open(&"b".to_string()).expect("opens b");
+    assert!(!Arc::ptr_eq(&a, &b), "distinct keys must not share a store");
+
+    a.insert(graph_spec("only-in-a")).expect("insert");
+    assert_eq!(a.list(OrchestrationTaskFilter::default()).len(), 1);
+    assert!(
+        b.list(OrchestrationTaskFilter::default()).is_empty(),
+        "records must not leak across scopes"
+    );
+    assert_eq!(registry.len().expect("len"), 2);
+}
+
+#[test]
+fn registry_get_does_not_open_and_clear_forces_a_reopen() {
+    let registry: TaskStoreRegistry<String> =
+        TaskStoreRegistry::new(|_key| Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>);
+
+    assert!(registry.is_empty().expect("is_empty"));
+    assert!(registry.get(&"a".to_string()).expect("get").is_none());
+    assert!(registry.is_empty().expect("still empty"));
+
+    let first = registry.get_or_open(&"a".to_string()).expect("opens");
+    assert!(registry.get(&"a".to_string()).expect("get").is_some());
+
+    registry.clear().expect("clear");
+    assert!(registry.is_empty().expect("cleared"));
+
+    let reopened = registry.get_or_open(&"a".to_string()).expect("reopens");
+    assert!(!Arc::ptr_eq(&first, &reopened), "clear must force a reopen");
+}
+
+#[test]
+fn registry_debug_reports_open_store_count() {
+    let registry: TaskStoreRegistry<String> =
+        TaskStoreRegistry::new(|_key| Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>);
+    registry.get_or_open(&"a".to_string()).expect("opens");
+    assert!(format!("{registry:?}").contains("TaskStoreRegistry"));
+}
+
+#[test]
+fn registry_lock_error_displays_the_poison_detail() {
+    let err = TaskStoreRegistryError::Lock("poisoned".to_string());
+    assert!(err.to_string().contains("poisoned"));
+}
+
+#[test]
+fn jsonl_fallback_opens_a_durable_store_and_replays_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nested").join("tasks.jsonl");
+
+    let store = open_jsonl_task_store_or_memory(&path);
+    store.insert(graph_spec("t1")).expect("insert");
+    assert!(path.exists(), "durable store must create its log");
+
+    // Reopening replays the log rather than starting empty.
+    let reopened = open_jsonl_task_store_or_memory(&path);
+    assert_eq!(reopened.list(OrchestrationTaskFilter::default()).len(), 1);
+}
+
+#[test]
+fn jsonl_fallback_degrades_to_memory_when_the_log_is_unreadable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A directory where the log file should be: `JsonlTaskStore::open` cannot
+    // use it, so the caller must still get a working store.
+    let path = dir.path().join("tasks.jsonl");
+    std::fs::create_dir(&path).expect("create dir in the log's place");
+
+    let store = open_jsonl_task_store_or_memory(&path);
+    store.insert(graph_spec("t1")).expect("memory store still accepts work");
+    assert_eq!(store.list(OrchestrationTaskFilter::default()).len(), 1);
+}
+
+// --- reconcile_orphaned_tasks -------------------------------------------
+
+#[test]
+fn reconcile_settles_live_tasks_and_leaves_terminal_ones_alone() {
+    let store = InMemoryTaskStore::new();
+
+    store.insert(graph_spec("pending")).expect("insert");
+
+    store.insert(graph_spec("running")).expect("insert");
+    store.mark_running(&TaskId::new("running")).expect("running");
+
+    store.insert(graph_spec("awaiting")).expect("insert");
+    store.mark_running(&TaskId::new("awaiting")).expect("running");
+    store.mark_awaiting(&TaskId::new("awaiting")).expect("awaiting");
+
+    store.insert(graph_spec("done")).expect("insert");
+    store.mark_running(&TaskId::new("done")).expect("running");
+    store
+        .complete(&TaskId::new("done"), OrchestrationTaskResult::text("ok"))
+        .expect("complete");
+
+    let report = reconcile_orphaned_tasks(&store, OrchestrationTaskFilter::default(), &|_record| {
+        "driver died".to_string()
+    });
+
+    assert_eq!(report.reconciled_count(), 3, "three live tasks were settled");
+    assert_eq!(report.error_count(), 0);
+    assert!(
+        report.tasks.iter().all(|task| task.outcome == ReconcileOutcome::Failed),
+        "live-but-not-cancelling tasks settle as failed"
+    );
+
+    for id in ["pending", "running", "awaiting"] {
+        let record = store.get(&TaskId::new(id)).expect("record");
+        assert_eq!(record.status, OrchestrationTaskStatus::Failed);
+        assert_eq!(record.error.as_deref(), Some("driver died"));
+    }
+    // The already-terminal task was not touched.
+    let done = store.get(&TaskId::new("done")).expect("record");
+    assert_eq!(done.status, OrchestrationTaskStatus::Completed);
+}
+
+#[test]
+fn reconcile_honours_a_pending_cancellation() {
+    let store = InMemoryTaskStore::new();
+    store.insert(graph_spec("cancelling")).expect("insert");
+    store.mark_running(&TaskId::new("cancelling")).expect("running");
+    store.request_cancel(&TaskId::new("cancelling")).expect("cancel");
+
+    let report = reconcile_orphaned_tasks(&store, OrchestrationTaskFilter::default(), &|_| {
+        "driver died".to_string()
+    });
+
+    assert_eq!(report.tasks.len(), 1);
+    assert_eq!(report.tasks[0].outcome, ReconcileOutcome::Cancelled);
+    assert_eq!(
+        report.tasks[0].prior_status,
+        OrchestrationTaskStatus::CancelRequested
+    );
+    assert_eq!(
+        store.get(&TaskId::new("cancelling")).expect("record").status,
+        OrchestrationTaskStatus::Cancelled
+    );
+}
+
+#[test]
+fn reconcile_reason_closure_sees_the_record_being_settled() {
+    let store = InMemoryTaskStore::new();
+    store.insert(graph_spec("t1")).expect("insert");
+    store.mark_running(&TaskId::new("t1")).expect("running");
+
+    reconcile_orphaned_tasks(&store, OrchestrationTaskFilter::default(), &|record| {
+        format!("orphaned (was `{}`)", task_status_label(record.status))
+    });
+
+    assert_eq!(
+        store.get(&TaskId::new("t1")).expect("record").error.as_deref(),
+        Some("orphaned (was `running`)")
+    );
+}
+
+#[test]
+fn reconcile_respects_the_filter() {
+    let store = InMemoryTaskStore::new();
+    store
+        .insert(OrchestrationTaskSpec::new(
+            "agent-task",
+            OrchestrationTaskKind::Agent {
+                agent_id: "worker".into(),
+            },
+        ))
+        .expect("insert");
+    store.insert(graph_spec("graph-task")).expect("insert");
+
+    let report = reconcile_orphaned_tasks(
+        &store,
+        OrchestrationTaskFilter::default().with_kind("agent"),
+        &|_| "driver died".to_string(),
+    );
+
+    assert_eq!(report.tasks.len(), 1);
+    assert_eq!(report.tasks[0].task_id.as_str(), "agent-task");
+    assert_eq!(
+        store.get(&TaskId::new("graph-task")).expect("record").status,
+        OrchestrationTaskStatus::Pending,
+        "a filtered-out task must not be swept"
+    );
+}
+
+#[test]
+fn reconcile_on_an_empty_store_reports_nothing() {
+    let store = InMemoryTaskStore::new();
+    let report = reconcile_orphaned_tasks(&store, OrchestrationTaskFilter::default(), &|_| {
+        "driver died".to_string()
+    });
+    assert!(report.is_empty());
+    assert_eq!(report.reconciled_count(), 0);
+    assert_eq!(report.error_count(), 0);
+    assert_eq!(report.settled().count(), 0);
+}
+
+#[test]
+fn reconcile_outcome_error_is_not_counted_as_settled() {
+    let error = ReconcileOutcome::Error("boom".to_string());
+    assert!(!error.is_settled());
+    assert!(ReconcileOutcome::Failed.is_settled());
+    assert!(ReconcileOutcome::Cancelled.is_settled());
+}
+
+#[test]
+fn task_status_label_covers_every_status() {
+    for (status, expected) in [
+        (OrchestrationTaskStatus::Pending, "pending"),
+        (OrchestrationTaskStatus::Running, "running"),
+        (OrchestrationTaskStatus::Awaiting, "awaiting"),
+        (OrchestrationTaskStatus::CancelRequested, "cancel_requested"),
+        (OrchestrationTaskStatus::Completed, "completed"),
+        (OrchestrationTaskStatus::Failed, "failed"),
+        (OrchestrationTaskStatus::Cancelled, "cancelled"),
+        (OrchestrationTaskStatus::TimedOut, "timed_out"),
+        (OrchestrationTaskStatus::Abandoned, "abandoned"),
+    ] {
+        assert_eq!(task_status_label(status), expected);
+    }
+}

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -929,7 +929,10 @@ fn registry_opens_each_key_once_and_shares_the_same_store() {
     let first = registry.get_or_open(&"a".to_string()).expect("opens");
     let second = registry.get_or_open(&"a".to_string()).expect("reuses");
 
-    assert!(Arc::ptr_eq(&first, &second), "same key must reuse one store");
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "same key must reuse one store"
+    );
     assert_eq!(opens.load(std::sync::atomic::Ordering::SeqCst), 1);
     assert_eq!(registry.len().expect("len"), 1);
 }
@@ -1008,7 +1011,9 @@ fn jsonl_fallback_degrades_to_memory_when_the_log_is_unreadable() {
     std::fs::create_dir(&path).expect("create dir in the log's place");
 
     let store = open_jsonl_task_store_or_memory(&path);
-    store.insert(graph_spec("t1")).expect("memory store still accepts work");
+    store
+        .insert(graph_spec("t1"))
+        .expect("memory store still accepts work");
     assert_eq!(store.list(OrchestrationTaskFilter::default()).len(), 1);
 }
 
@@ -1021,11 +1026,17 @@ fn reconcile_settles_live_tasks_and_leaves_terminal_ones_alone() {
     store.insert(graph_spec("pending")).expect("insert");
 
     store.insert(graph_spec("running")).expect("insert");
-    store.mark_running(&TaskId::new("running")).expect("running");
+    store
+        .mark_running(&TaskId::new("running"))
+        .expect("running");
 
     store.insert(graph_spec("awaiting")).expect("insert");
-    store.mark_running(&TaskId::new("awaiting")).expect("running");
-    store.mark_awaiting(&TaskId::new("awaiting")).expect("awaiting");
+    store
+        .mark_running(&TaskId::new("awaiting"))
+        .expect("running");
+    store
+        .mark_awaiting(&TaskId::new("awaiting"))
+        .expect("awaiting");
 
     store.insert(graph_spec("done")).expect("insert");
     store.mark_running(&TaskId::new("done")).expect("running");
@@ -1037,10 +1048,17 @@ fn reconcile_settles_live_tasks_and_leaves_terminal_ones_alone() {
         "driver died".to_string()
     });
 
-    assert_eq!(report.reconciled_count(), 3, "three live tasks were settled");
+    assert_eq!(
+        report.reconciled_count(),
+        3,
+        "three live tasks were settled"
+    );
     assert_eq!(report.error_count(), 0);
     assert!(
-        report.tasks.iter().all(|task| task.outcome == ReconcileOutcome::Failed),
+        report
+            .tasks
+            .iter()
+            .all(|task| task.outcome == ReconcileOutcome::Failed),
         "live-but-not-cancelling tasks settle as failed"
     );
 
@@ -1058,8 +1076,12 @@ fn reconcile_settles_live_tasks_and_leaves_terminal_ones_alone() {
 fn reconcile_honours_a_pending_cancellation() {
     let store = InMemoryTaskStore::new();
     store.insert(graph_spec("cancelling")).expect("insert");
-    store.mark_running(&TaskId::new("cancelling")).expect("running");
-    store.request_cancel(&TaskId::new("cancelling")).expect("cancel");
+    store
+        .mark_running(&TaskId::new("cancelling"))
+        .expect("running");
+    store
+        .request_cancel(&TaskId::new("cancelling"))
+        .expect("cancel");
 
     let report = reconcile_orphaned_tasks(&store, OrchestrationTaskFilter::default(), &|_| {
         "driver died".to_string()
@@ -1072,7 +1094,10 @@ fn reconcile_honours_a_pending_cancellation() {
         OrchestrationTaskStatus::CancelRequested
     );
     assert_eq!(
-        store.get(&TaskId::new("cancelling")).expect("record").status,
+        store
+            .get(&TaskId::new("cancelling"))
+            .expect("record")
+            .status,
         OrchestrationTaskStatus::Cancelled
     );
 }
@@ -1088,7 +1113,11 @@ fn reconcile_reason_closure_sees_the_record_being_settled() {
     });
 
     assert_eq!(
-        store.get(&TaskId::new("t1")).expect("record").error.as_deref(),
+        store
+            .get(&TaskId::new("t1"))
+            .expect("record")
+            .error
+            .as_deref(),
         Some("orphaned (was `running`)")
     );
 }
@@ -1115,7 +1144,10 @@ fn reconcile_respects_the_filter() {
     assert_eq!(report.tasks.len(), 1);
     assert_eq!(report.tasks[0].task_id.as_str(), "agent-task");
     assert_eq!(
-        store.get(&TaskId::new("graph-task")).expect("record").status,
+        store
+            .get(&TaskId::new("graph-task"))
+            .expect("record")
+            .status,
         OrchestrationTaskStatus::Pending,
         "a filtered-out task must not be swept"
     );

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -975,6 +975,32 @@ fn registry_get_does_not_open_and_clear_forces_a_reopen() {
 }
 
 #[test]
+fn registry_values_returns_every_open_store() {
+    let registry: TaskStoreRegistry<String> =
+        TaskStoreRegistry::new(|_key| Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>);
+    assert!(registry.values().expect("values").is_empty());
+
+    registry.get_or_open(&"a".to_string()).expect("opens a");
+    registry.get_or_open(&"b".to_string()).expect("opens b");
+
+    let stores = registry.values().expect("values");
+    assert_eq!(stores.len(), 2);
+
+    // A record written through one store is visible through exactly one of the
+    // returned handles, so callers can sweep across scopes.
+    registry
+        .get_or_open(&"a".to_string())
+        .expect("reuses a")
+        .insert(graph_spec("only-in-a"))
+        .expect("insert");
+    let total: usize = stores
+        .iter()
+        .map(|store| store.list(OrchestrationTaskFilter::default()).len())
+        .sum();
+    assert_eq!(total, 1);
+}
+
+#[test]
 fn registry_debug_reports_open_store_count() {
     let registry: TaskStoreRegistry<String> =
         TaskStoreRegistry::new(|_key| Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>);

--- a/src/graph/parallel/claims/mod.rs
+++ b/src/graph/parallel/claims/mod.rs
@@ -33,9 +33,7 @@
 
 mod types;
 
-pub use types::{
-    ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan, WorkspaceClaim,
-};
+pub use types::{ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan, WorkspaceClaim};
 
 use std::path::{Component, Path, PathBuf};
 

--- a/src/graph/parallel/claims/mod.rs
+++ b/src/graph/parallel/claims/mod.rs
@@ -1,0 +1,168 @@
+//! Shared-workspace claim arbitration for parallel agent fan-out.
+//!
+//! [`map_reduce`](super::map_reduce) answers "run these N items with bounded
+//! concurrency". It cannot answer whether running them concurrently is *safe*.
+//! When fanned-out workers share one filesystem root, two of them mutating the
+//! same file at the same time corrupts it silently — there is no error, just a
+//! plausible-looking result built on a torn tree.
+//!
+//! This module owns that decision, and only that decision. Given a set of
+//! [`WorkspaceClaim`]s it returns a [`DispatchPlan`] saying which workers may
+//! run concurrently, which must be serialized, and which cannot be scheduled at
+//! all. It performs no I/O, spawns nothing, and never renders a message.
+//!
+//! # The rule
+//!
+//! A worker is safe to run in parallel when it either has its own root
+//! (`isolated`) or never writes (`!writes`). A worker that writes a *shared*
+//! root must declare the paths it owns; it is then serialized, and its claim is
+//! checked against every claim already granted.
+//!
+//! Claims are granted in **input order, first-writer-wins**. That ordering is
+//! load-bearing: it makes the plan a pure function of the input, independent of
+//! how quickly any worker happens to finish, so the same request always yields
+//! the same rejection.
+//!
+//! # What stays with the caller
+//!
+//! The crate reports a [`ClaimConflict`] as data; it never decides what a host
+//! does about one. Whether an unbounded write is a hard rejection or a warning,
+//! and what sentence the user reads, are product decisions. Likewise the syntax
+//! a claim arrives in: [`parse_relative_claim_paths`] takes the *body* of a
+//! claim list, not whatever prefix or key a host wraps it in.
+
+mod types;
+
+pub use types::{
+    ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan, WorkspaceClaim,
+};
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::harness::tool::ToolSideEffects;
+
+/// Parses a claim list into safe, sorted, deduplicated relative paths.
+///
+/// Entries are separated by commas or newlines and may carry a leading `-` or
+/// `*` bullet. Empty entries are skipped, so a trailing separator is harmless.
+///
+/// # Errors
+///
+/// Returns [`ClaimPathError::Absolute`] for an absolute path and
+/// [`ClaimPathError::Escaping`] for one containing `..` or a platform prefix —
+/// either would let a claim reach outside the shared root it is meant to
+/// partition.
+pub fn parse_relative_claim_paths(spec: &str) -> Result<Vec<PathBuf>, ClaimPathError> {
+    let mut paths = Vec::new();
+    for raw in spec.split([',', '\n']) {
+        let trimmed = raw.trim().trim_start_matches(['-', '*']).trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let path = PathBuf::from(trimmed);
+        if path.is_absolute() {
+            return Err(ClaimPathError::Absolute {
+                raw: trimmed.to_string(),
+            });
+        }
+        if path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+        {
+            return Err(ClaimPathError::Escaping {
+                raw: trimmed.to_string(),
+            });
+        }
+        paths.push(path);
+    }
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+/// `true` when two claimed paths cannot be held by different workers at once.
+///
+/// Comparison is **component-wise**, not textual: `src/a` and `src/ab` are
+/// distinct, while `src/a` and `src/a/inner.rs` collide because one contains the
+/// other.
+pub fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
+}
+
+/// `true` when a tool's declared effects can mutate a shared workspace.
+///
+/// Reads the declaration rather than a name or a host permission enum, so any
+/// host can derive a claim from the tool metadata it already publishes.
+/// `read_only` wins over the mutating flags: a tool that declares both is taken
+/// at its most conservative word.
+pub fn writes_shared_workspace(effects: &ToolSideEffects) -> bool {
+    if effects.read_only {
+        return false;
+    }
+    effects.writes_files || effects.installs_dependencies || effects.destructive
+}
+
+/// Decides which workers may run concurrently against one shared workspace.
+///
+/// Claims are considered in input order; each writing worker's paths are checked
+/// against those already granted, and on the first overlap that worker is
+/// rejected (the earlier holder keeps its claim). Rejected workers get `None` in
+/// [`DispatchPlan::modes`] and an entry in [`DispatchPlan::conflicts`].
+pub fn plan_shared_workspace_dispatch(claims: &[WorkspaceClaim]) -> DispatchPlan {
+    let mut plan = DispatchPlan {
+        modes: Vec::with_capacity(claims.len()),
+        conflicts: Vec::new(),
+    };
+    // Granted (path, worker_id) pairs, accumulated in input order.
+    let mut granted: Vec<(PathBuf, String)> = Vec::new();
+
+    for (index, claim) in claims.iter().enumerate() {
+        if claim.isolated || !claim.writes {
+            plan.modes.push(Some(DispatchMode::Parallel));
+            continue;
+        }
+
+        if claim.paths.is_empty() {
+            plan.modes.push(None);
+            plan.conflicts.push((
+                index,
+                ClaimConflict::UnboundedWrite {
+                    worker_id: claim.worker_id.clone(),
+                },
+            ));
+            continue;
+        }
+
+        let overlap = claim.paths.iter().find_map(|path| {
+            granted
+                .iter()
+                .find(|(claimed, _)| paths_overlap(path, claimed))
+                .map(|(claimed, holder)| (claimed.clone(), holder.clone()))
+        });
+
+        match overlap {
+            Some((path, other_worker_id)) => {
+                plan.modes.push(None);
+                plan.conflicts.push((
+                    index,
+                    ClaimConflict::Overlap {
+                        worker_id: claim.worker_id.clone(),
+                        other_worker_id,
+                        path,
+                    },
+                ));
+            }
+            None => {
+                for path in &claim.paths {
+                    granted.push((path.clone(), claim.worker_id.clone()));
+                }
+                plan.modes.push(Some(DispatchMode::Serial));
+            }
+        }
+    }
+
+    plan
+}
+
+#[cfg(test)]
+mod test;

--- a/src/graph/parallel/claims/test.rs
+++ b/src/graph/parallel/claims/test.rs
@@ -1,0 +1,292 @@
+//! Unit tests for shared-workspace claim arbitration.
+
+use super::*;
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+// --- parse_relative_claim_paths -----------------------------------------
+
+#[test]
+fn parses_comma_and_newline_separated_entries() {
+    let parsed = parse_relative_claim_paths("src/a.rs, src/b.rs\nsrc/c.rs").expect("parses");
+    assert_eq!(parsed, vec![p("src/a.rs"), p("src/b.rs"), p("src/c.rs")]);
+}
+
+#[test]
+fn strips_bullet_markers_and_surrounding_space() {
+    let parsed = parse_relative_claim_paths("  - src/a.rs \n * src/b.rs").expect("parses");
+    assert_eq!(parsed, vec![p("src/a.rs"), p("src/b.rs")]);
+}
+
+#[test]
+fn sorts_and_deduplicates() {
+    let parsed = parse_relative_claim_paths("src/b.rs, src/a.rs, src/b.rs").expect("parses");
+    assert_eq!(parsed, vec![p("src/a.rs"), p("src/b.rs")]);
+}
+
+#[test]
+fn skips_empty_entries_so_trailing_separators_are_harmless() {
+    let parsed = parse_relative_claim_paths("src/a.rs,,\n  \n").expect("parses");
+    assert_eq!(parsed, vec![p("src/a.rs")]);
+}
+
+#[test]
+fn empty_spec_yields_no_paths() {
+    assert_eq!(parse_relative_claim_paths("").expect("parses"), Vec::<PathBuf>::new());
+}
+
+#[test]
+fn rejects_absolute_paths() {
+    let err = parse_relative_claim_paths("/etc/passwd").expect_err("absolute is rejected");
+    assert_eq!(err, ClaimPathError::Absolute { raw: "/etc/passwd".to_string() });
+}
+
+#[test]
+fn rejects_parent_dir_escapes() {
+    let err = parse_relative_claim_paths("../outside.rs").expect_err("escape is rejected");
+    assert_eq!(err, ClaimPathError::Escaping { raw: "../outside.rs".to_string() });
+}
+
+#[test]
+fn rejects_escape_hidden_mid_path() {
+    let err = parse_relative_claim_paths("src/../../outside.rs").expect_err("escape is rejected");
+    assert!(matches!(err, ClaimPathError::Escaping { .. }));
+}
+
+// --- paths_overlap -------------------------------------------------------
+
+#[test]
+fn identical_paths_overlap() {
+    assert!(paths_overlap(&p("src/a.rs"), &p("src/a.rs")));
+}
+
+#[test]
+fn a_directory_overlaps_a_file_beneath_it() {
+    assert!(paths_overlap(&p("src"), &p("src/a.rs")));
+    assert!(paths_overlap(&p("src/a.rs"), &p("src")));
+}
+
+#[test]
+fn sibling_paths_sharing_a_textual_prefix_do_not_overlap() {
+    // The classic bug: `starts_with` on strings would call these an overlap.
+    // `Path::starts_with` is component-wise, and this pins that.
+    assert!(!paths_overlap(&p("src/a"), &p("src/ab")));
+    assert!(!paths_overlap(&p("src/ab"), &p("src/a")));
+    assert!(!paths_overlap(&p("a.rs"), &p("ab.rs")));
+}
+
+#[test]
+fn unrelated_paths_do_not_overlap() {
+    assert!(!paths_overlap(&p("src/a.rs"), &p("docs/b.md")));
+}
+
+// --- writes_shared_workspace --------------------------------------------
+
+#[test]
+fn read_only_never_writes_even_when_other_flags_are_set() {
+    let effects = ToolSideEffects {
+        read_only: true,
+        writes_files: true,
+        destructive: true,
+        ..Default::default()
+    };
+    assert!(!writes_shared_workspace(&effects));
+}
+
+#[test]
+fn file_writes_installs_and_destructive_all_count_as_writing() {
+    for effects in [
+        ToolSideEffects { writes_files: true, ..Default::default() },
+        ToolSideEffects { installs_dependencies: true, ..Default::default() },
+        ToolSideEffects { destructive: true, ..Default::default() },
+    ] {
+        assert!(writes_shared_workspace(&effects), "{effects:?} should count as writing");
+    }
+}
+
+#[test]
+fn network_and_payment_alone_do_not_touch_the_workspace() {
+    let effects = ToolSideEffects {
+        network: true,
+        payment: true,
+        external_service: true,
+        ..Default::default()
+    };
+    assert!(!writes_shared_workspace(&effects));
+}
+
+#[test]
+fn default_effects_do_not_write() {
+    assert!(!writes_shared_workspace(&ToolSideEffects::default()));
+}
+
+// --- plan_shared_workspace_dispatch -------------------------------------
+
+#[test]
+fn isolated_and_read_only_workers_all_run_in_parallel() {
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::isolated("w1"),
+        WorkspaceClaim::read_only("w2"),
+    ]);
+    assert_eq!(
+        plan.modes,
+        vec![Some(DispatchMode::Parallel), Some(DispatchMode::Parallel)]
+    );
+    assert!(plan.conflicts.is_empty());
+    assert!(!plan.has_serial_work());
+    assert_eq!(plan.parallel_indices(), vec![0, 1]);
+    assert!(plan.serial_indices().is_empty());
+}
+
+#[test]
+fn an_isolated_worker_that_writes_still_runs_in_parallel() {
+    // Isolation short-circuits the write check: its root is its own.
+    let mut claim = WorkspaceClaim::isolated("w1");
+    claim.writes = true;
+    let plan = plan_shared_workspace_dispatch(&[claim]);
+    assert_eq!(plan.modes, vec![Some(DispatchMode::Parallel)]);
+    assert!(plan.conflicts.is_empty());
+}
+
+#[test]
+fn a_shared_writer_with_a_claim_is_serialized() {
+    let plan = plan_shared_workspace_dispatch(&[WorkspaceClaim::writing("w1", vec![p("src/a.rs")])]);
+    assert_eq!(plan.modes, vec![Some(DispatchMode::Serial)]);
+    assert!(plan.conflicts.is_empty());
+    assert!(plan.has_serial_work());
+    assert_eq!(plan.serial_indices(), vec![0]);
+}
+
+#[test]
+fn a_shared_writer_without_a_claim_is_rejected_as_unbounded() {
+    let plan = plan_shared_workspace_dispatch(&[WorkspaceClaim::writing("w1", vec![])]);
+    assert_eq!(plan.modes, vec![None]);
+    assert_eq!(
+        plan.conflicts,
+        vec![(0, ClaimConflict::UnboundedWrite { worker_id: "w1".to_string() })]
+    );
+}
+
+#[test]
+fn two_writers_with_disjoint_claims_are_both_serialized() {
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("w1", vec![p("src/a.rs")]),
+        WorkspaceClaim::writing("w2", vec![p("src/b.rs")]),
+    ]);
+    assert_eq!(
+        plan.modes,
+        vec![Some(DispatchMode::Serial), Some(DispatchMode::Serial)]
+    );
+    assert!(plan.conflicts.is_empty());
+    assert_eq!(plan.serial_indices(), vec![0, 1]);
+}
+
+#[test]
+fn on_overlap_the_later_worker_is_rejected_and_the_earlier_keeps_its_claim() {
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("w1", vec![p("src/a.rs")]),
+        WorkspaceClaim::writing("w2", vec![p("src/a.rs")]),
+    ]);
+    assert_eq!(plan.modes, vec![Some(DispatchMode::Serial), None]);
+    assert_eq!(
+        plan.conflicts,
+        vec![(
+            1,
+            ClaimConflict::Overlap {
+                worker_id: "w2".to_string(),
+                other_worker_id: "w1".to_string(),
+                path: p("src/a.rs"),
+            }
+        )]
+    );
+}
+
+#[test]
+fn overlap_is_detected_through_directory_containment() {
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("w1", vec![p("src")]),
+        WorkspaceClaim::writing("w2", vec![p("src/a.rs")]),
+    ]);
+    assert_eq!(plan.modes, vec![Some(DispatchMode::Serial), None]);
+    assert_eq!(plan.conflicts.len(), 1);
+}
+
+#[test]
+fn a_rejected_worker_does_not_reserve_its_paths_for_later_workers() {
+    // w2 is rejected against w1, so w2's *other* path stays free for w3.
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("w1", vec![p("src/a.rs")]),
+        WorkspaceClaim::writing("w2", vec![p("src/a.rs"), p("src/z.rs")]),
+        WorkspaceClaim::writing("w3", vec![p("src/z.rs")]),
+    ]);
+    assert_eq!(
+        plan.modes,
+        vec![Some(DispatchMode::Serial), None, Some(DispatchMode::Serial)]
+    );
+    assert_eq!(plan.conflicts.len(), 1);
+    assert_eq!(plan.conflicts[0].0, 1);
+}
+
+#[test]
+fn rejection_follows_input_order_not_claim_content() {
+    // Swapping the inputs swaps who is rejected — the plan is a pure function
+    // of input order, which is what makes it reproducible across runs.
+    let forward = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("first", vec![p("shared.rs")]),
+        WorkspaceClaim::writing("second", vec![p("shared.rs")]),
+    ]);
+    let reversed = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::writing("second", vec![p("shared.rs")]),
+        WorkspaceClaim::writing("first", vec![p("shared.rs")]),
+    ]);
+    assert_eq!(forward.conflicts[0].1.worker_id(), "second");
+    assert_eq!(reversed.conflicts[0].1.worker_id(), "first");
+}
+
+#[test]
+fn mixed_batches_keep_every_index_aligned_with_the_input() {
+    let plan = plan_shared_workspace_dispatch(&[
+        WorkspaceClaim::isolated("isolated"),
+        WorkspaceClaim::read_only("reader"),
+        WorkspaceClaim::writing("writer", vec![p("src/a.rs")]),
+        WorkspaceClaim::writing("clasher", vec![p("src/a.rs")]),
+        WorkspaceClaim::writing("unbounded", vec![]),
+    ]);
+    assert_eq!(
+        plan.modes,
+        vec![
+            Some(DispatchMode::Parallel),
+            Some(DispatchMode::Parallel),
+            Some(DispatchMode::Serial),
+            None,
+            None,
+        ]
+    );
+    assert_eq!(plan.parallel_indices(), vec![0, 1]);
+    assert_eq!(plan.serial_indices(), vec![2]);
+    assert_eq!(
+        plan.conflicts.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+        vec![3, 4]
+    );
+}
+
+#[test]
+fn an_empty_batch_plans_nothing() {
+    let plan = plan_shared_workspace_dispatch(&[]);
+    assert_eq!(plan, DispatchPlan::default());
+    assert!(!plan.has_serial_work());
+}
+
+#[test]
+fn claim_conflict_reports_the_worker_it_rejected() {
+    let unbounded = ClaimConflict::UnboundedWrite { worker_id: "w1".to_string() };
+    assert_eq!(unbounded.worker_id(), "w1");
+    let overlap = ClaimConflict::Overlap {
+        worker_id: "w2".to_string(),
+        other_worker_id: "w1".to_string(),
+        path: p("src/a.rs"),
+    };
+    assert_eq!(overlap.worker_id(), "w2");
+}

--- a/src/graph/parallel/claims/test.rs
+++ b/src/graph/parallel/claims/test.rs
@@ -34,19 +34,32 @@ fn skips_empty_entries_so_trailing_separators_are_harmless() {
 
 #[test]
 fn empty_spec_yields_no_paths() {
-    assert_eq!(parse_relative_claim_paths("").expect("parses"), Vec::<PathBuf>::new());
+    assert_eq!(
+        parse_relative_claim_paths("").expect("parses"),
+        Vec::<PathBuf>::new()
+    );
 }
 
 #[test]
 fn rejects_absolute_paths() {
     let err = parse_relative_claim_paths("/etc/passwd").expect_err("absolute is rejected");
-    assert_eq!(err, ClaimPathError::Absolute { raw: "/etc/passwd".to_string() });
+    assert_eq!(
+        err,
+        ClaimPathError::Absolute {
+            raw: "/etc/passwd".to_string()
+        }
+    );
 }
 
 #[test]
 fn rejects_parent_dir_escapes() {
     let err = parse_relative_claim_paths("../outside.rs").expect_err("escape is rejected");
-    assert_eq!(err, ClaimPathError::Escaping { raw: "../outside.rs".to_string() });
+    assert_eq!(
+        err,
+        ClaimPathError::Escaping {
+            raw: "../outside.rs".to_string()
+        }
+    );
 }
 
 #[test]
@@ -98,11 +111,23 @@ fn read_only_never_writes_even_when_other_flags_are_set() {
 #[test]
 fn file_writes_installs_and_destructive_all_count_as_writing() {
     for effects in [
-        ToolSideEffects { writes_files: true, ..Default::default() },
-        ToolSideEffects { installs_dependencies: true, ..Default::default() },
-        ToolSideEffects { destructive: true, ..Default::default() },
+        ToolSideEffects {
+            writes_files: true,
+            ..Default::default()
+        },
+        ToolSideEffects {
+            installs_dependencies: true,
+            ..Default::default()
+        },
+        ToolSideEffects {
+            destructive: true,
+            ..Default::default()
+        },
     ] {
-        assert!(writes_shared_workspace(&effects), "{effects:?} should count as writing");
+        assert!(
+            writes_shared_workspace(&effects),
+            "{effects:?} should count as writing"
+        );
     }
 }
 
@@ -152,7 +177,8 @@ fn an_isolated_worker_that_writes_still_runs_in_parallel() {
 
 #[test]
 fn a_shared_writer_with_a_claim_is_serialized() {
-    let plan = plan_shared_workspace_dispatch(&[WorkspaceClaim::writing("w1", vec![p("src/a.rs")])]);
+    let plan =
+        plan_shared_workspace_dispatch(&[WorkspaceClaim::writing("w1", vec![p("src/a.rs")])]);
     assert_eq!(plan.modes, vec![Some(DispatchMode::Serial)]);
     assert!(plan.conflicts.is_empty());
     assert!(plan.has_serial_work());
@@ -165,7 +191,12 @@ fn a_shared_writer_without_a_claim_is_rejected_as_unbounded() {
     assert_eq!(plan.modes, vec![None]);
     assert_eq!(
         plan.conflicts,
-        vec![(0, ClaimConflict::UnboundedWrite { worker_id: "w1".to_string() })]
+        vec![(
+            0,
+            ClaimConflict::UnboundedWrite {
+                worker_id: "w1".to_string()
+            }
+        )]
     );
 }
 
@@ -267,7 +298,10 @@ fn mixed_batches_keep_every_index_aligned_with_the_input() {
     assert_eq!(plan.parallel_indices(), vec![0, 1]);
     assert_eq!(plan.serial_indices(), vec![2]);
     assert_eq!(
-        plan.conflicts.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+        plan.conflicts
+            .iter()
+            .map(|(index, _)| *index)
+            .collect::<Vec<_>>(),
         vec![3, 4]
     );
 }
@@ -281,7 +315,9 @@ fn an_empty_batch_plans_nothing() {
 
 #[test]
 fn claim_conflict_reports_the_worker_it_rejected() {
-    let unbounded = ClaimConflict::UnboundedWrite { worker_id: "w1".to_string() };
+    let unbounded = ClaimConflict::UnboundedWrite {
+        worker_id: "w1".to_string(),
+    };
     assert_eq!(unbounded.worker_id(), "w1");
     let overlap = ClaimConflict::Overlap {
         worker_id: "w2".to_string(),

--- a/src/graph/parallel/claims/types.rs
+++ b/src/graph/parallel/claims/types.rs
@@ -1,0 +1,158 @@
+//! Type definitions for shared-workspace claim arbitration.
+
+use std::path::PathBuf;
+
+/// One worker's declared relationship to a fan-out's shared workspace.
+///
+/// A worker is safe to run concurrently with its siblings when it either has a
+/// workspace of its own ([`isolated`](Self::isolated)) or never mutates the one
+/// it shares ([`writes`](Self::writes) is `false`). Anything else needs an
+/// explicit, disjoint set of owned [`paths`](Self::paths) before it can be
+/// scheduled at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceClaim {
+    /// Caller-chosen identifier, echoed back in conflicts so the caller can
+    /// phrase its own diagnostics.
+    pub worker_id: String,
+    /// The worker runs in its own isolated root and can never collide.
+    pub isolated: bool,
+    /// The worker can mutate files in whatever root it runs in.
+    pub writes: bool,
+    /// Relative paths this worker declares exclusive ownership of. Empty means
+    /// "unbounded" — a writing, non-isolated worker with no claim yields
+    /// [`ClaimConflict::UnboundedWrite`].
+    pub paths: Vec<PathBuf>,
+}
+
+impl WorkspaceClaim {
+    /// A worker with its own workspace root. Never conflicts, always parallel.
+    pub fn isolated(worker_id: impl Into<String>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            isolated: true,
+            writes: false,
+            paths: Vec::new(),
+        }
+    }
+
+    /// A worker sharing the workspace but never mutating it.
+    pub fn read_only(worker_id: impl Into<String>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            isolated: false,
+            writes: false,
+            paths: Vec::new(),
+        }
+    }
+
+    /// A worker sharing the workspace and mutating the given owned paths.
+    ///
+    /// An empty `paths` is accepted here and reported as
+    /// [`ClaimConflict::UnboundedWrite`] at planning time, so callers can build
+    /// claims uniformly and let the planner do the rejecting.
+    pub fn writing(worker_id: impl Into<String>, paths: Vec<PathBuf>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            isolated: false,
+            writes: true,
+            paths,
+        }
+    }
+}
+
+/// Why a claim string could not be parsed into safe relative paths.
+///
+/// Carries the offending input rather than a rendered sentence: the phrasing a
+/// host shows its users is the host's, not this crate's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimPathError {
+    /// The path was absolute; claims are always relative to the shared root.
+    Absolute {
+        /// The offending entry, as written.
+        raw: String,
+    },
+    /// The path escaped the shared root via `..` or a platform path prefix.
+    Escaping {
+        /// The offending entry, as written.
+        raw: String,
+    },
+}
+
+/// Why a worker cannot be scheduled against the shared workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimConflict {
+    /// The worker mutates a shared workspace without declaring what it owns.
+    UnboundedWrite {
+        /// The worker that could not be scheduled.
+        worker_id: String,
+    },
+    /// The worker's claim overlaps one already granted to an earlier worker.
+    Overlap {
+        /// The worker that could not be scheduled.
+        worker_id: String,
+        /// The earlier worker holding the conflicting claim.
+        other_worker_id: String,
+        /// The path both workers claim.
+        path: PathBuf,
+    },
+}
+
+impl ClaimConflict {
+    /// The worker this conflict rejected.
+    pub fn worker_id(&self) -> &str {
+        match self {
+            Self::UnboundedWrite { worker_id } => worker_id,
+            Self::Overlap { worker_id, .. } => worker_id,
+        }
+    }
+}
+
+/// How a worker must be dispatched relative to its siblings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchMode {
+    /// Safe to run concurrently with every other worker.
+    Parallel,
+    /// Mutates the shared workspace; must not overlap another writer in time.
+    Serial,
+}
+
+/// Which workers may run concurrently, in input order.
+///
+/// [`modes`](Self::modes) is index-aligned with the planner's input. Rejected
+/// workers appear in [`conflicts`](Self::conflicts) keyed by that same index and
+/// are **not** represented in `modes`, so the two are read together.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DispatchPlan {
+    /// Per-worker dispatch mode, indexed by input position. `None` marks a
+    /// worker that was rejected and must not run.
+    pub modes: Vec<Option<DispatchMode>>,
+    /// Rejections, paired with the input index of the worker they rejected.
+    pub conflicts: Vec<(usize, ClaimConflict)>,
+}
+
+impl DispatchPlan {
+    /// `true` when at least one schedulable worker must run serially.
+    pub fn has_serial_work(&self) -> bool {
+        self.modes
+            .iter()
+            .any(|mode| matches!(mode, Some(DispatchMode::Serial)))
+    }
+
+    /// Input indices of the workers that may run concurrently.
+    pub fn parallel_indices(&self) -> Vec<usize> {
+        self.indices_matching(DispatchMode::Parallel)
+    }
+
+    /// Input indices of the workers that must run one at a time, in input order.
+    pub fn serial_indices(&self) -> Vec<usize> {
+        self.indices_matching(DispatchMode::Serial)
+    }
+
+    fn indices_matching(&self, wanted: DispatchMode) -> Vec<usize> {
+        self.modes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, mode)| (*mode == Some(wanted)).then_some(index))
+            .collect()
+    }
+}

--- a/src/graph/parallel/mod.rs
+++ b/src/graph/parallel/mod.rs
@@ -14,6 +14,7 @@
 //! yields items as they finish, and each future carries its input index so the
 //! completed results are re-sorted into input-order slots before being returned.
 
+mod claims;
 mod types;
 
 pub use types::{FailurePolicy, ItemOutcome, ParallelOptions, ParallelOutcome};

--- a/src/graph/parallel/mod.rs
+++ b/src/graph/parallel/mod.rs
@@ -17,6 +17,11 @@
 mod claims;
 mod types;
 
+pub use claims::{
+    parse_relative_claim_paths, paths_overlap, plan_shared_workspace_dispatch,
+    writes_shared_workspace, ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan,
+    WorkspaceClaim,
+};
 pub use types::{FailurePolicy, ItemOutcome, ParallelOptions, ParallelOutcome};
 
 use futures::stream::StreamExt;

--- a/src/graph/parallel/mod.rs
+++ b/src/graph/parallel/mod.rs
@@ -18,9 +18,9 @@ mod claims;
 mod types;
 
 pub use claims::{
+    ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan, WorkspaceClaim,
     parse_relative_claim_paths, paths_overlap, plan_shared_workspace_dispatch,
-    writes_shared_workspace, ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan,
-    WorkspaceClaim,
+    writes_shared_workspace,
 };
 pub use types::{FailurePolicy, ItemOutcome, ParallelOptions, ParallelOutcome};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,13 @@ pub use graph::parallel::{
     FailurePolicy, ItemOutcome, ParallelOptions, ParallelOutcome, map_reduce,
 };
 
+// --- Graph: shared-workspace claim arbitration ---
+pub use graph::parallel::{
+    ClaimConflict, ClaimPathError, DispatchMode, DispatchPlan, WorkspaceClaim,
+    parse_relative_claim_paths, paths_overlap, plan_shared_workspace_dispatch,
+    writes_shared_workspace,
+};
+
 // --- Graph: export / visualization ---
 // Topology types are surfaced at the crate root; the `to_json`/`to_mermaid`
 // free functions stay behind `graph::export::` to avoid generic-name clashes.


### PR DESCRIPTION
## What

Three generic surfaces that hosts fanning out agent work were each reimplementing.

### `graph::parallel::claims` — shared-workspace write safety

`map_reduce` answers "run these N items with bounded concurrency". It cannot
answer whether running them concurrently is *safe*. When fanned-out workers
share one filesystem root, two of them mutating the same file corrupts it
silently — there is no error, just a plausible-looking result built on a torn
tree.

`plan_shared_workspace_dispatch` takes a set of `WorkspaceClaim`s and returns
which workers may run concurrently, which must be serialized, and which cannot
be scheduled at all. Supporting pieces: `parse_relative_claim_paths` (rejects
absolute paths and `..` escapes), `paths_overlap`, `writes_shared_workspace`.

Two decisions worth knowing:

- **Claims are granted in input order, first-writer-wins.** That makes the plan
  a pure function of the request rather than of which worker finished first, so
  the same request always produces the same rejection.
- **Conflicts are data, not sentences.** `ClaimConflict` carries the worker ids
  and the contended path. Whether an unbounded write is a hard rejection or a
  warning, and what the user reads, are host decisions.

`paths_overlap` is component-wise: `src/a` and `src/ab` are distinct, which a
textual prefix check gets wrong. Pinned by test.

### `graph::orchestration::store_registry` — one store per scope

Opening a second `JsonlTaskStore` over the same append log gives two writers
with independently replayed state, so caching is part of the contract rather
than an optimization. `TaskStoreRegistry` is keyed on whatever the host uses to
tell scopes apart, with a host-supplied opener.

`open_jsonl_task_store_or_memory` degrades to an in-memory store when the
directory or the log cannot be opened. Losing durability across a restart is a
far smaller harm than refusing to orchestrate at all — a host on a read-only
volume should still be able to spawn work.

Accessors return `TaskStoreRegistryError` rather than unwrapping, matching the
lock-poison convention `DetachedTaskRegistry` already uses: a panic in an
unrelated task must not turn every later lookup into a second panic.

### `graph::orchestration::reconcile` — settling orphans

A detached task runs on an executor owned by the process that spawned it. When
that process dies, the executor dies with it but a durable record does not, so
without reconciliation it reads as perpetually live.

`reconcile_orphaned_tasks` owns the state machine — a cancel-requested orphan
honours that intent and settles as cancelled, everything else live settles as
failed — and takes the **reason as a closure**, so product phrasing stays with
the host. Per-task transition failures are captured in the report rather than
aborting the sweep: a record racing to terminal between the listing and the
transition is expected, not exceptional.

## Testing

- 44 new unit tests across the three modules, covering both directions of every
  branch (path validation, overlap, ordering, each live status, the fallback
  ladder, lock-error display).
- `cargo fmt --check`, `cargo clippy --all-targets [--all-features] -D warnings`
  clean.
- `cargo test --all-features`: 101 test binaries, 0 failures.
- `cargo llvm-cov --all-features --workspace --fail-under-lines 90`: **92.16%**.

Additive only — no existing file's behaviour changes.

## Note on commits

The granular commit history is from this repo's auto-commit checkpointing hook,
not hand-authored steps; read the diff as one change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reconciliation for orphaned tasks, including cancellation, failure handling, status reporting, and error tracking.
  * Added durable task-store management with per-scope reuse and in-memory fallback when persistent storage is unavailable.
  * Added shared-workspace claim arbitration for parallel work, including path validation, overlap detection, conflict reporting, and deterministic dispatch planning.

* **Tests**
  * Added comprehensive coverage for task reconciliation, storage fallback, workspace claims, conflict handling, and dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->