### PR TITLE
fix(openai): keep transport failures structured instead of flattening them

### DIFF
--- a/src/harness/providers/openai/README.md
+++ b/src/harness/providers/openai/README.md
@@ -224,10 +224,12 @@ into a structured `ProviderError` (HTTP status, provider error code, and a
 everything else — including 401/400 — is not) and surfaced as
 `TinyAgentsError::Provider`, so `harness::retry::is_retryable` can classify
 retryability instead of retrying every provider failure indiscriminately.
-Transport-level failures (connection errors, body-read failures) have no such
-structure to preserve and surface as a plain `TinyAgentsError::Model` string
-via `provider_failure_message`. Malformed JSON bodies surface as
-`TinyAgentsError::Serialization`.
+Transport-level failures (connection errors, body-read failures) carry no HTTP
+status, but they do carry a provider, a model, and a computed `retryable`, so
+they are raised as `TinyAgentsError::Provider` with `status: None` rather than
+flattened — a host that classifies on the variant would otherwise see a
+connection reset as an unstructured error. `Display` is identical either way.
+Malformed JSON bodies surface as `TinyAgentsError::Serialization`.
 
 ## Operational constraints
 

--- a/src/harness/providers/openai/README.md
+++ b/src/harness/providers/openai/README.md
@@ -224,12 +224,15 @@ into a structured `ProviderError` (HTTP status, provider error code, and a
 everything else — including 401/400 — is not) and surfaced as
 `TinyAgentsError::Provider`, so `harness::retry::is_retryable` can classify
 retryability instead of retrying every provider failure indiscriminately.
-A **send** failure — the request never reached a server, so there is no status
-— still carries a provider, a model, and a computed `retryable`, so
-`send_checked` raises it as `TinyAgentsError::Provider` with `status: None`
+A **send** failure — no final HTTP status was available, so there is nothing to
+report as one — still carries a provider, a model, and a computed `retryable`,
+so `send_checked` raises it as `TinyAgentsError::Provider` with `status: None`
 rather than flattening it; a host that classifies on the variant would
 otherwise see a connection reset as an unstructured error. `Display` is
-identical either way.
+identical either way. Note that "no final status" is not the same as "never
+reached a server": the client keeps reqwest's default redirect policy, so a
+redirect loop or an exceeded redirect limit lands here too, after servers have
+answered with 3xx.
 
 **Body-read** failures after a 2xx (`list_models`, `invoke_responses`) remain
 plain `TinyAgentsError::Model` strings. Malformed JSON bodies surface as

--- a/src/harness/providers/openai/README.md
+++ b/src/harness/providers/openai/README.md
@@ -224,12 +224,16 @@ into a structured `ProviderError` (HTTP status, provider error code, and a
 everything else — including 401/400 — is not) and surfaced as
 `TinyAgentsError::Provider`, so `harness::retry::is_retryable` can classify
 retryability instead of retrying every provider failure indiscriminately.
-Transport-level failures (connection errors, body-read failures) carry no HTTP
-status, but they do carry a provider, a model, and a computed `retryable`, so
-they are raised as `TinyAgentsError::Provider` with `status: None` rather than
-flattened — a host that classifies on the variant would otherwise see a
-connection reset as an unstructured error. `Display` is identical either way.
-Malformed JSON bodies surface as `TinyAgentsError::Serialization`.
+A **send** failure — the request never reached a server, so there is no status
+— still carries a provider, a model, and a computed `retryable`, so
+`send_checked` raises it as `TinyAgentsError::Provider` with `status: None`
+rather than flattening it; a host that classifies on the variant would
+otherwise see a connection reset as an unstructured error. `Display` is
+identical either way.
+
+**Body-read** failures after a 2xx (`list_models`, `invoke_responses`) remain
+plain `TinyAgentsError::Model` strings. Malformed JSON bodies surface as
+`TinyAgentsError::Serialization`.
 
 ## Operational constraints
 

--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -2915,3 +2915,63 @@ fn stream_cleanup_scrubs_leaked_markup_from_live_deltas() {
     assert_eq!(completed.tool_calls().len(), 1);
     assert_eq!(completed.tool_calls()[0].name, "lookup");
 }
+
+// ── transport-level failures keep their structure ───────────────────────────
+
+/// A transport failure must reach the caller as `TinyAgentsError::Provider`.
+///
+/// It carries no HTTP status — nothing answered — but it does carry the
+/// provider, the model, and a computed `retryable`, and a host that classifies
+/// on the variant needs all three. Flattening it into
+/// `TinyAgentsError::Model(String)` sends a connection reset down the generic
+/// arm of a host's logger, where it is recorded with no status, no provider and
+/// no retryability, and the operator reading it cannot tell a dead endpoint
+/// from a rejected request.
+#[tokio::test]
+async fn a_transport_failure_is_reported_as_a_structured_provider_error() {
+    // Bind, read the port, then drop the listener: the port is now almost
+    // certainly closed, so the connect fails without waiting on a timeout.
+    let port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+        listener.local_addr().expect("read the bound port").port()
+    };
+
+    let model = OpenAiModel::compatible_provider(
+        "OpenHuman",
+        "test-key",
+        format!("http://127.0.0.1:{port}/openai/v1"),
+        "chat-v1",
+    );
+
+    let error = ChatModel::<()>::invoke(&model, &(), ModelRequest::new(vec![Message::user("hi")]))
+        .await
+        .expect_err("a closed port cannot answer");
+
+    let TinyAgentsError::Provider(provider_error) = &error else {
+        panic!("expected a structured Provider error, got: {error:?}");
+    };
+    assert_eq!(provider_error.provider, "OpenHuman");
+    assert_eq!(provider_error.model.as_deref(), Some("chat-v1"));
+    assert!(
+        provider_error.status.is_none(),
+        "nothing answered, so there is no status to report"
+    );
+    assert!(
+        provider_error.retryable,
+        "a transport failure is worth retrying; the flag is what says so"
+    );
+
+    // The rendered text is the no-regression half: `Display for ProviderError`
+    // reproduces what `provider_failure_message` used to build by hand, and both
+    // error variants render as `model error: {0}`, so nothing a user or a log
+    // reader sees changes.
+    let rendered = error.to_string();
+    assert!(
+        rendered.starts_with("model error: OpenHuman returned: "),
+        "the user-facing wording must not change, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("/openai/v1/chat/completions"),
+        "the failing URL is what makes this diagnosable, got: {rendered}"
+    );
+}

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -1993,9 +1993,19 @@ impl OpenAiModel {
         url: &str,
     ) -> Result<reqwest::Response> {
         let response = builder.send().await.map_err(|e| {
-            let error =
-                self.provider_error(format!("{what} to {url} failed: {e}"), None, None, None);
-            TinyAgentsError::Model(self.provider_failure_message(&error))
+            // Structured, not flattened. A transport failure has no HTTP status,
+            // but it does have a provider, a model, and a computed `retryable` —
+            // and a host that matches on `TinyAgentsError::Provider` to log
+            // those fields would otherwise fall through to its generic arm and
+            // record a connection reset as "(non-provider error)" with nothing
+            // to act on. `Display` renders identically either way, so only the
+            // machine-readable half changes.
+            TinyAgentsError::from_provider_error(self.provider_error(
+                format!("{what} to {url} failed: {e}"),
+                None,
+                None,
+                None,
+            ))
         })?;
 
         let status = response.status();
@@ -2131,23 +2141,6 @@ impl OpenAiModel {
             retry_after_ms: None,
             raw,
         }
-    }
-
-    fn provider_failure_message(&self, error: &ProviderError) -> String {
-        format!(
-            "{} returned{}{}: {}",
-            error.provider,
-            error
-                .status
-                .map(|status| format!(" HTTP {status}"))
-                .unwrap_or_default(),
-            error
-                .code
-                .as_deref()
-                .map(|code| format!(" ({code})"))
-                .unwrap_or_default(),
-            error.message
-        )
     }
 
     /// Decodes a non-2xx body into a structured [`ProviderError`].


### PR DESCRIPTION
## Summary

`send_checked` built a fully-populated `ProviderError` for a transport failure — provider, model, and a computed `retryable` — and then threw the struct away, returning a flattened `TinyAgentsError::Model(String)`. The non-2xx branch twelve lines below keeps its structure.

Hosts classify on the variant, so this had a visible cost. Every transport failure reached the OpenHuman backend model's logger through its *generic* arm and was recorded as `managed invoke failed (non-provider error): ...` — no status, no provider, no retryability. A connection reset and a rejected request were indistinguishable in the log. That is the diagnostic gap reported in `tinyhumansai/openhuman#5604`; the reporter was reading a bug, not a property of the network.

The crate's own contract already says this branch is wrong: `TinyAgentsError::Provider` is documented as what adapters raise "whenever they have a `ProviderError` in hand", and `send_checked` constructs one on the line above.

## API Or Behavior Changes

**Nothing user-facing changes, deliberately.** Both variants carry `#[error("model error: {0}")]`, and `Display for ProviderError` reproduces `provider_failure_message` field for field and in the same order — so the rendered string is byte-identical before and after. The test asserts this, which is what pins the claim.

**Retry behaviour is unchanged.** `provider_error` already computes `retryable` with the same `classify_provider_failure` that `is_retryable` applies to the `Model` string today. The flag becomes a *stored fact* instead of being re-derived from English prose at each call site.

**What does change**, and is the point: the error variant. `TinyAgentsError::Provider` is now reachable with `status: None` for the first time on this path. I checked every consumer and all tolerate it — `maybe_publish_session_expired` gates on `matches!(pe.status, Some(401 | 403))`, and `from_provider_error` gates on `code`, which is `None` here — but **anything added later that assumes `Provider` implies a status will now see `None`.** Worth knowing before writing such a match.

`provider_failure_message` loses its only caller and is deleted; the crate denies warnings, so leaving it would fail on `dead_code`.

## Tests

One new test, `a_transport_failure_is_reported_as_a_structured_provider_error`, in the openai provider suite. It binds an ephemeral port, reads it, drops the listener, and points a `compatible_provider("OpenHuman", …)` model at the now-closed port — so the connect fails without waiting on a timeout. It asserts the variant, `provider`, `model`, `status.is_none()`, `retryable`, **and** that the rendered text is unchanged.

**Revert check — done.** Restoring the pre-fix flattening (keeping the test) fails it, and the observed failure reproduces the exact string from the issue report:

```
thread '...::a_transport_failure_is_reported_as_a_structured_provider_error' panicked at
src/harness/providers/openai/test.rs:2951:9:
expected a structured Provider error, got: Model("OpenHuman returned: request to
http://127.0.0.1:51835/openai/v1/chat/completions failed: error sending request for url
(http://127.0.0.1:51835/openai/v1/chat/completions)")

test result: FAILED. 0 passed; 1 failed
```

That `Model(...)` payload is verbatim what the reporter saw in the log. With the fix it is a `Provider` error carrying the same text plus the fields.

Commands run locally, all exit 0:

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test` — 1778 lib tests, 0 failed
- [x] `cargo test --all-features` — same, plus the integration and doc suites

The `harness::retry` suite (36 tests) passes unchanged, which is the one that would notice if retryability had shifted.

## Documentation

`src/harness/providers/openai/README.md` documented the flattening as intentional ("have no such structure to preserve and surface as a plain `TinyAgentsError::Model` string via `provider_failure_message`"). Corrected in the same commit — leaving it would have left the repo arguing for the behaviour this removes.

## Related issue

`tinyhumansai/openhuman#5604`. Cross-repo, so no closing keyword: that issue must be closed by hand, and only after its **infrastructure half** is settled, which this does not touch. This is a diagnostic fix — it does not make a failing request succeed and says nothing about whether staging was actually down. Two of the three fix directions in that issue need no work: retry for transport failures already exists (`RetryPolicy { max_attempts: 3, … }` applied at the harness model call, and a bare transport error already classifies as retryable), and the "staging API goes offline" theory is argued against by the error class itself — a Cloudflare-fronted origin restart would have produced a `52x` *status*, which this path reports through the non-2xx branch.

A submodule bump in openhuman follows once this merges; it cannot be raised before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI transport failures now return structured provider errors with provider, model, retryability, and unavailable HTTP status details.
  * Response-body read failures remain model errors, while malformed JSON continues to be reported as a serialization error.
  * User-facing error messages remain unchanged.

* **Tests**
  * Added coverage verifying structured error details for transport failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->