### PR TITLE
Add Basic auth for OpenAI-compatible providers

### DIFF
--- a/src/harness/providers/openai/test.rs
+++ b/src/harness/providers/openai/test.rs
@@ -2008,6 +2008,23 @@ fn auth_headers_bearer_is_the_default() {
 }
 
 #[test]
+fn auth_headers_basic_prefixes_the_credential() {
+    let headers = auth_headers(&AuthStyle::Basic, "base64-credential");
+    assert_eq!(
+        headers,
+        vec![(
+            "Authorization".to_string(),
+            "Basic base64-credential".to_string()
+        )]
+    );
+}
+
+#[test]
+fn auth_headers_basic_omits_an_empty_credential() {
+    assert!(auth_headers(&AuthStyle::Basic, "").is_empty());
+}
+
+#[test]
 fn auth_headers_x_api_key_sends_bare_key_without_authorization() {
     let headers = auth_headers(&AuthStyle::XApiKey, "secret");
     assert_eq!(

--- a/src/harness/providers/openai/transport.rs
+++ b/src/harness/providers/openai/transport.rs
@@ -16,10 +16,10 @@ use crate::harness::model::StreamAccumulator;
 /// How the provider expects the API credential to be sent on each request.
 ///
 /// OpenAI-compatible endpoints diverge on auth: hosted OpenAI and most gateways
-/// use `Bearer`, some providers use a bare `x-api-key`, Anthropic's compat
-/// endpoint pairs `x-api-key` with an `anthropic-version` header, and a few need
-/// an arbitrary custom header carrying the raw credential. Defaults to
-/// [`AuthStyle::Bearer`].
+/// use `Bearer`, Inworld uses HTTP Basic credentials, some providers use a bare
+/// `x-api-key`, Anthropic's compat endpoint pairs `x-api-key` with an
+/// `anthropic-version` header, and a few need an arbitrary custom header
+/// carrying the raw credential. Defaults to [`AuthStyle::Bearer`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum AuthStyle {
     /// No authentication header (e.g. a local Ollama server).
@@ -27,6 +27,8 @@ pub enum AuthStyle {
     /// `Authorization: Bearer <key>` — hosted OpenAI and most gateways.
     #[default]
     Bearer,
+    /// `Authorization: Basic <credential>` — used by Inworld and compatible APIs.
+    Basic,
     /// `x-api-key: <key>` — used by some OpenAI-compatible providers.
     XApiKey,
     /// `x-api-key: <key>` + `anthropic-version: 2023-06-01` (Anthropic compat).
@@ -199,6 +201,8 @@ pub(super) fn auth_headers(auth: &AuthStyle, api_key: &str) -> Vec<(String, Stri
     match auth {
         AuthStyle::None => Vec::new(),
         AuthStyle::Bearer => vec![("Authorization".to_string(), format!("Bearer {api_key}"))],
+        AuthStyle::Basic if api_key.is_empty() => Vec::new(),
+        AuthStyle::Basic => vec![("Authorization".to_string(), format!("Basic {api_key}"))],
         AuthStyle::XApiKey => vec![("x-api-key".to_string(), api_key.to_string())],
         AuthStyle::Anthropic => vec![
             ("x-api-key".to_string(), api_key.to_string()),


### PR DESCRIPTION
## Summary

Add an explicit HTTP Basic authentication style for OpenAI-compatible providers, enabling hosts to integrate providers such as Inworld without disguising credentials as Bearer tokens. Empty Basic credentials emit no Authorization header.

## API Or Behavior Changes

Adds the public AuthStyle::Basic variant. Requests using it send Authorization: Basic <credential>. Existing auth styles are unchanged.

## Tests

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [ ] cargo clippy --all-targets --all-features -- -D warnings
- [ ] cargo build --all-targets
- [ ] cargo build --all-targets --all-features
- [x] cargo test
- [ ] cargo test --all-features

Added focused auth-header tests for populated and empty Basic credentials. The full default-feature suite passed: 1,784 unit tests, integration tests, and 49 doc tests.

## Documentation

Updated AuthStyle rustdoc and the transport-level authentication overview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP Basic authentication for compatible API connections.
  - Empty credentials no longer produce an authorization header.

- **Bug Fixes**
  - Corrected authentication header formatting to use the `Basic` scheme when configured.

- **Tests**
  - Added coverage for valid and empty Basic authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->