### PR TITLE
harness/store: decode the JSONL tail window losslessly

### DIFF
--- a/src/harness/store/mod.rs
+++ b/src/harness/store/mod.rs
@@ -350,10 +350,19 @@ impl JsonlAppendStore {
             file.seek(SeekFrom::Start(start)).map_err(|e| {
                 TinyAgentsError::Validation(format!("append store seek error: {e}"))
             })?;
-            let mut buf = String::new();
-            file.read_to_string(&mut buf).map_err(|e| {
+            let mut raw = Vec::new();
+            file.read_to_end(&mut raw).map_err(|e| {
                 TinyAgentsError::Validation(format!("append store read error: {e}"))
             })?;
+            // The window starts at an arbitrary byte offset, so it can begin in
+            // the middle of a multi-byte character. `read_to_string` rejects
+            // that outright ("stream did not contain valid UTF-8"), which fails
+            // the whole append and drops the journal record silently — and
+            // permanently, because the file then stops growing, so every later
+            // append reads the same broken window. Lossy decoding is safe here:
+            // the damaged bytes are by definition in the first line, which is
+            // discarded below anyway (`complete_from`).
+            let buf = String::from_utf8_lossy(&raw);
             // Only lines that are certainly complete: when the window did not
             // reach the start of the file, its first line may be cut in half.
             let complete_from = usize::from(start > 0);

--- a/src/harness/store/test.rs
+++ b/src/harness/store/test.rs
@@ -425,3 +425,47 @@ async fn jsonl_rejects_unsafe_stream_names() {
     // Allowed characters round-trip.
     assert_eq!(store.append("runs-1.events_v2", json!(1)).await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn jsonl_append_survives_a_tail_window_that_starts_mid_character() {
+    // `next_offset` seeks to `len - 4096` and reads from there. That offset is
+    // an arbitrary byte, so on a file full of non-ASCII text (é, €, —) the
+    // window can begin halfway through a multi-byte character. Decoding it as
+    // UTF-8 then fails, which failed the whole append and dropped the record —
+    // permanently, because the file never grows again and every later append
+    // reads the same broken window.
+    let dir = TempDir::new("jsonl-utf8-window");
+    let path = dir.0.join("evts.jsonl");
+
+    // Pad the first record until byte `len - 4096` is a UTF-8 continuation byte
+    // (`10xxxxxx`), i.e. until the window provably starts inside a character.
+    let second = serde_json::to_string(&StoreRecord {
+        offset: 1,
+        value: json!({"n": 1}),
+        created_at_ms: 0,
+    })
+    .unwrap();
+    let mut pad = 0usize;
+    let first = loop {
+        let first = serde_json::to_string(&StoreRecord {
+            offset: 0,
+            value: json!({"tekst": format!("{}{}", "x".repeat(pad), "—".repeat(2000))}),
+            created_at_ms: 0,
+        })
+        .unwrap();
+        let len = first.len() + 1 + second.len() + 1;
+        if first.as_bytes()[len - 4096] & 0b1100_0000 == 0b1000_0000 {
+            break first;
+        }
+        pad += 1;
+    };
+    std::fs::write(&path, format!("{first}\n{second}\n")).unwrap();
+
+    let store = JsonlAppendStore::new(&dir.0);
+    assert_eq!(
+        store.append("evts", json!({"n": 2})).await.unwrap(),
+        2,
+        "an append must not be lost because the tail window starts mid-character"
+    );
+    assert_eq!(store.len("evts").await.unwrap(), 3);
+}


### PR DESCRIPTION
`JsonlAppendStore::append` fails permanently on any stream whose file happens to
have a UTF-8 continuation byte at offset `len - 4096`:

```
append store read error: stream did not contain valid UTF-8
```

The append fails, so the record is lost. Nothing else reports it — the file that
would carry the trace is the one that was not written. And it does not recover:
the failed append left the file unchanged, so `len` is the same next time, so
`len - 4096` points at the same broken byte. **One unlucky em-dash freezes the
stream forever.**


`JsonlAppendStore::next_offset` (`src/harness/store/mod.rs:328`) avoids reading
the whole file by seeking to a fixed-size tail window:

```rust
let start = len.saturating_sub(window);   // window = 4096
file.seek(SeekFrom::Start(start))?;
let mut buf = String::new();
file.read_to_string(&mut buf)?;           // ← here
```

`start` is an arbitrary byte offset — nobody placed it on a character boundary.
`read_to_string` requires the entire read to be valid UTF-8, so if `start` lands
inside a multi-byte character the read fails, and with it the whole append.

With ASCII this never happens: every character is one byte, so every offset is a
character boundary. It shows up as soon as the content is not English. An em-dash
(`—`) and a euro sign (`€`) are three bytes each; the more non-ASCII in the file,
the higher the chance that byte `len - 4096` falls inside a character. Note that
only a *continuation* byte (`10xxxxxx`, 128–191) is fatal — a leading byte is a
valid character boundary and decodes fine, which is part of why this looks
intermittent.

It is effectively a die rolled on every append: `len` changes with every written
line, so the window slides and points at a different byte each time. One bad roll
is enough, because after that the file stops growing.


Observed in production on a session journal of 8003 bytes. `8003 - 4096 = 3907`,
and bytes 3905–3907 are `e2 80 94` — U+2014, an em-dash. The read therefore
starts on the *third* byte of that character. The file has been stuck at 8003
bytes since the first failure. Of the 17 journal files in that directory exactly
one was frozen; the other sixteen happen to have an ordinary byte at
`len - 4096`.


Read bytes, then decode: `read_to_end` into a `Vec<u8>`, then
`String::from_utf8_lossy`.

Lossy decoding is not a concession here, for a reason already present in the
function: when the window does not start at the beginning of the file
(`start > 0`), `next_offset` discards the first line anyway, because it may be
cut in half (`complete_from`). The damaged bytes are by definition at the start
of the window, i.e. in exactly the line that is discarded. No replacement
character can ever reach a line that is used. And when `start == 0` the window
begins at the start of the file — always a character boundary — so
`from_utf8_lossy` replaces nothing.

Thirteen lines, nine of them comment. No new dependency. No behaviour change for
files that work today.

**A file that is already frozen starts growing again.** No migration or repair
step is needed: once `next_offset` stops tripping, the next append on such a
stream succeeds and the file grows past its stuck length.


`jsonl_append_survives_a_tail_window_that_starts_mid_character` in
`src/harness/store/test.rs`. It does not guess: it pads the first record one byte
at a time until byte `len - 4096` is provably a UTF-8 continuation byte
(`b & 0b1100_0000 == 0b1000_0000`), and only then writes the file. So it fails
always rather than occasionally.

Checked in both directions:

* on unpatched `5e026cd` it fails with exactly the production message —
  `Validation("append store read error: stream did not contain valid UTF-8")`;
* with the patch it passes, and all 34 tests in `harness::store` stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSONL journal appends that could fail when the read window began in the middle of a multi-byte UTF-8 character.
  * Append operations now continue normally while safely discarding incomplete or damaged leading bytes.

* **Tests**
  * Added coverage to verify records remain intact and offsets advance correctly in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->