### PR TITLE
feat: extract delegation graph, DAG validation, and tool selection from the OpenHuman host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,17 +28,27 @@ cargo test --features sqlite
 cargo test --features repl
 ```
 
-### Wiki Submodule
+### Submodules
 
-The published GitHub wiki lives in `wiki/`, checked out as a git submodule
-pointing at the `tinyhumansai/tinyagents.wiki` repository. It is not part of
-the crate build and is not covered by this project's Markdown line-length or
-review rules. Clone with submodules to pull it down:
+This repository has two git submodules, and they are not interchangeable:
+
+- **`vendor/tinytools`** — the vendored tool vocabulary crate `Cargo.toml`
+  resolves `tinytools` from (`vendor/tinytools/crates/tinytools`). This one is
+  **required**: without it, cargo cannot even read the manifest, and every
+  build fails at "Updating crates.io index" with "failed to read
+  vendor/tinytools/crates/tinytools/Cargo.toml".
+- **`wiki`** — the published GitHub wiki, pointing at the
+  `tinyhumansai/tinyagents.wiki` repository. It is not part of the crate build
+  and is not covered by this project's Markdown line-length or review rules.
+
+Clone with submodules to pull down both:
 
 ```sh
 git clone --recurse-submodules https://github.com/tinyhumansai/tinyagents.git
 # or, in an existing checkout:
-git submodule update --init wiki
+git submodule update --init --recursive
+# or, to fetch only the required build dependency:
+git submodule update --init vendor/tinytools
 ```
 
 Do not edit `wiki/` content as part of an unrelated code or docs change; wiki

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 #
 # Path-only for now, which is what stops this crate being published. Publishing
 # `tinytools` is the prerequisite; see that repository's AGENTS.md.
-tinytools = { path = "vendor/tinytools/crates/tinytools" }
+tinytools = { path = "vendor/tinytools/crates/tinytools", version = "0.1.0" }
 # Cheap, reference-counted byte buffers. Used only on the *internal* SSE
 # byte-stream seam (`harness::providers::openai::sse::SseState`) so each
 # network chunk from `reqwest::Response::bytes_stream` is forwarded without a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,21 @@ async-trait = "0.1"
 # without this crate naming `ToolExecutionContext` inside `tinytools` (the
 # edge points one way: `tinytools` must never depend on this crate).
 #
-# Path-only for now, which is what stops this crate being published. Publishing
-# `tinytools` is the prerequisite; see that repository's AGENTS.md.
-tinytools = { path = "vendor/tinytools/crates/tinytools" }
+# Vendored as a git submodule at `vendor/tinytools`, pinned to a commit on
+# that repository's `main` branch (verify with `git -C vendor/tinytools log
+# -1`); update the submodule pointer deliberately, the same as any other
+# dependency bump, not incidentally.
+#
+# `version` is required alongside `path` for `cargo package`/`cargo publish`
+# to accept this manifest at all (a path-only dependency fails packaging with
+# "all dependencies must have a version requirement specified"). It does not
+# by itself make this crate publishable: `cargo publish` additionally
+# resolves every dependency against the registry, so publishing still fails
+# until `tinytools` itself is published on crates.io at a compatible version.
+# That is the real prerequisite; see that repository's AGENTS.md. Keep this
+# version requirement in sync with `vendor/tinytools/crates/tinytools`'s own
+# `Cargo.toml` version.
+tinytools = { path = "vendor/tinytools/crates/tinytools", version = "0.1.0" }
 # Cheap, reference-counted byte buffers. Used only on the *internal* SSE
 # byte-stream seam (`harness::providers::openai::sse::SseState`) so each
 # network chunk from `reqwest::Response::bytes_stream` is forwarded without a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 #
 # Path-only for now, which is what stops this crate being published. Publishing
 # `tinytools` is the prerequisite; see that repository's AGENTS.md.
-tinytools = { path = "vendor/tinytools/crates/tinytools", version = "0.1.0" }
+tinytools = { path = "vendor/tinytools/crates/tinytools" }
 # Cheap, reference-counted byte buffers. Used only on the *internal* SSE
 # byte-stream seam (`harness::providers::openai::sse::SseState`) so each
 # network chunk from `reqwest::Response::bytes_stream` is forwarded without a

--- a/docs/modules/harness/workspace.md
+++ b/docs/modules/harness/workspace.md
@@ -139,7 +139,7 @@ assert!(err.to_string().contains("outside the allowed workspace"));
 | --- | --- |
 | `WorkspacePrepared { policy_id, root }` | `prepare_workspace` succeeds |
 | `WorkspaceCleanup { policy_id, error }` | `cleanup_workspace` runs (`error` set on failure) |
-| `WorkspaceViolation { path }` | `enforce` blocks an out-of-root path |
+| `WorkspaceViolation { path }` | `enforce_workspace_path` blocks an out-of-root path |
 
 The descriptor is fully `Serialize`/`Deserialize` for registry introspection and
 audit journaling.

--- a/src/graph/checkpoint/file.rs
+++ b/src/graph/checkpoint/file.rs
@@ -31,7 +31,7 @@ struct CheckpointIdHeader {
 
 use super::{
     Checkpoint, CheckpointConfig, CheckpointMetadata, CheckpointTuple, Checkpointer, PendingWrite,
-    merge_writes,
+    decode_json_err, merge_writes,
 };
 use crate::harness::ids::CheckpointId;
 use crate::{Result, TinyAgentsError};

--- a/src/graph/checkpoint/file.rs
+++ b/src/graph/checkpoint/file.rs
@@ -289,7 +289,7 @@ where
                     line.len()
                 );
             }
-            Err(e) => return Err(io_err("decode record", e)),
+            Err(e) => return Err(decode_json_err("file checkpointer", "record", e)),
         }
     }
     Ok(out)
@@ -428,7 +428,7 @@ where
                 Some(id) => {
                     // Decode only the id header to test the match, not `State`.
                     let header: CheckpointIdHeader =
-                        serde_json::from_str(&line).map_err(|e| io_err("decode header", e))?;
+                        serde_json::from_str(&line).map_err(|e| decode_json_err("file checkpointer", "header", e))?;
                     if header.checkpoint_id == id {
                         target = Some(line);
                     }
@@ -438,7 +438,7 @@ where
         }
         match target {
             Some(line) => Ok(Some(
-                serde_json::from_str(&line).map_err(|e| io_err("decode record", e))?,
+                serde_json::from_str(&line).map_err(|e| decode_json_err("file checkpointer", "record", e))?,
             )),
             None => Ok(None),
         }

--- a/src/graph/checkpoint/file.rs
+++ b/src/graph/checkpoint/file.rs
@@ -427,8 +427,8 @@ where
             match checkpoint_id {
                 Some(id) => {
                     // Decode only the id header to test the match, not `State`.
-                    let header: CheckpointIdHeader =
-                        serde_json::from_str(&line).map_err(|e| decode_json_err("file checkpointer", "header", e))?;
+                    let header: CheckpointIdHeader = serde_json::from_str(&line)
+                        .map_err(|e| decode_json_err("file checkpointer", "header", e))?;
                     if header.checkpoint_id == id {
                         target = Some(line);
                     }
@@ -437,9 +437,11 @@ where
             }
         }
         match target {
-            Some(line) => Ok(Some(
-                serde_json::from_str(&line).map_err(|e| decode_json_err("file checkpointer", "record", e))?,
-            )),
+            Some(line) => {
+                Ok(Some(serde_json::from_str(&line).map_err(|e| {
+                    decode_json_err("file checkpointer", "record", e)
+                })?))
+            }
             None => Ok(None),
         }
     }

--- a/src/graph/checkpoint/mod.rs
+++ b/src/graph/checkpoint/mod.rs
@@ -51,14 +51,19 @@ use crate::{Result, TinyAgentsError};
 /// record indistinguishably from an outdated one — silently discarding
 /// evidence of real storage corruption instead of surfacing it. This tag is
 /// the stable discriminator that lets the caller tell the two apart.
-pub(super) fn decode_json_err(context: &str, err: serde_json::Error) -> TinyAgentsError {
+///
+/// `backend` is the existing `"sqlite checkpointer" / "file checkpointer"`
+/// prefix; `what` names the field being decoded (e.g. `"record"`,
+/// `"next_nodes"`) with no leading `"decode "` — this function supplies that
+/// wording once, alongside the tag.
+pub(super) fn decode_json_err(backend: &str, what: &str, err: serde_json::Error) -> TinyAgentsError {
     let tag = match err.classify() {
         serde_json::error::Category::Data => "schema",
         serde_json::error::Category::Syntax
         | serde_json::error::Category::Eof
         | serde_json::error::Category::Io => "corrupt",
     };
-    TinyAgentsError::Checkpoint(format!("decode [{tag}] {context}: {err}"))
+    TinyAgentsError::Checkpoint(format!("{backend}: decode [{tag}] {what}: {err}"))
 }
 
 /// Persists and retrieves graph checkpoints keyed by thread.

--- a/src/graph/checkpoint/mod.rs
+++ b/src/graph/checkpoint/mod.rs
@@ -35,6 +35,32 @@ use async_trait::async_trait;
 use crate::harness::ids::CheckpointId;
 use crate::{Result, TinyAgentsError};
 
+/// Builds a `TinyAgentsError::Checkpoint` for a failed `serde_json` decode,
+/// tagging the message with whether the failure looks like a genuine
+/// shape/schema mismatch or ambiguous/likely corruption.
+///
+/// `serde_json::Error::classify()` distinguishes `Category::Data` (the JSON
+/// parsed fine but didn't match the target type — a missing field, a renamed
+/// variant, a type change: exactly what a legacy or newer schema produces)
+/// from `Category::Syntax` / `Category::Eof` / `Category::Io` (the bytes
+/// themselves are malformed or truncated — a write torn by a crash, disk
+/// corruption, or a partial copy). Both backends previously tagged every
+/// failure here identically as `"decode …"`, and a caller (see
+/// `graph::delegation::run::is_incompatible_checkpoint_error`) that expired
+/// any checkpoint whose error mentioned "decode" would delete a corrupted
+/// record indistinguishably from an outdated one — silently discarding
+/// evidence of real storage corruption instead of surfacing it. This tag is
+/// the stable discriminator that lets the caller tell the two apart.
+pub(super) fn decode_json_err(context: &str, err: serde_json::Error) -> TinyAgentsError {
+    let tag = match err.classify() {
+        serde_json::error::Category::Data => "schema",
+        serde_json::error::Category::Syntax
+        | serde_json::error::Category::Eof
+        | serde_json::error::Category::Io => "corrupt",
+    };
+    TinyAgentsError::Checkpoint(format!("decode [{tag}] {context}: {err}"))
+}
+
 /// Persists and retrieves graph checkpoints keyed by thread.
 #[async_trait]
 pub trait Checkpointer<State>: Send + Sync

--- a/src/graph/checkpoint/mod.rs
+++ b/src/graph/checkpoint/mod.rs
@@ -56,7 +56,11 @@ use crate::{Result, TinyAgentsError};
 /// prefix; `what` names the field being decoded (e.g. `"record"`,
 /// `"next_nodes"`) with no leading `"decode "` — this function supplies that
 /// wording once, alongside the tag.
-pub(super) fn decode_json_err(backend: &str, what: &str, err: serde_json::Error) -> TinyAgentsError {
+pub(super) fn decode_json_err(
+    backend: &str,
+    what: &str,
+    err: serde_json::Error,
+) -> TinyAgentsError {
     let tag = match err.classify() {
         serde_json::error::Category::Data => "schema",
         serde_json::error::Category::Syntax

--- a/src/graph/checkpoint/sqlite.rs
+++ b/src/graph/checkpoint/sqlite.rs
@@ -34,7 +34,7 @@ use serde::de::DeserializeOwned;
 
 use super::{
     Checkpoint, CheckpointConfig, CheckpointMetadata, CheckpointSource, CheckpointTuple,
-    Checkpointer, PendingWrite, merge_writes,
+    Checkpointer, PendingWrite, decode_json_err, merge_writes,
 };
 use crate::harness::ids::{CheckpointId, NodeId};
 use crate::{Result, TinyAgentsError};

--- a/src/graph/checkpoint/sqlite.rs
+++ b/src/graph/checkpoint/sqlite.rs
@@ -193,9 +193,10 @@ struct MetaRow {
 /// without touching the full serialized record.
 fn row_metadata(row: MetaRow) -> Result<CheckpointMetadata> {
     let namespace: Vec<String> =
-        serde_json::from_str(&row.namespace_json).map_err(|e| sqlite_err("decode namespace", e))?;
+        serde_json::from_str(&row.namespace_json)
+            .map_err(|e| decode_json_err("sqlite checkpointer", "namespace", e))?;
     let next_nodes: Vec<NodeId> = serde_json::from_str(&row.next_nodes_json)
-        .map_err(|e| sqlite_err("decode next_nodes", e))?;
+        .map_err(|e| decode_json_err("sqlite checkpointer", "next_nodes", e))?;
     Ok(CheckpointMetadata {
         thread_id: row.thread_id,
         checkpoint_id: row.checkpoint_id,
@@ -292,7 +293,7 @@ where
         };
         match record {
             Some(json) => Ok(Some(
-                serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?,
+                serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
             )),
             None => Ok(None),
         }
@@ -334,7 +335,7 @@ where
         };
         match record {
             Some(json) => Ok(Some(
-                serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?,
+                serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
             )),
             None => Ok(None),
         }
@@ -368,7 +369,7 @@ where
             for row in rows {
                 let json = row.map_err(|e| sqlite_err("read record row", e))?;
                 records
-                    .push(serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?);
+                    .push(serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?);
             }
             let writes = read_writes_by_checkpoint(&conn, thread_id, &namespace_json)?;
             (records, writes)
@@ -473,7 +474,7 @@ where
         let mut out = Vec::new();
         for row in rows {
             let json = row.map_err(|e| sqlite_err("read record row", e))?;
-            out.push(serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?);
+            out.push(serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?);
         }
         Ok(out)
     }
@@ -649,7 +650,7 @@ fn map_write_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Result<PendingWrit
                 channel,
                 payload,
             }),
-            Err(e) => Err(sqlite_err("decode write payload", e)),
+            Err(e) => Err(decode_json_err("sqlite checkpointer", "write payload", e)),
         },
     )
 }
@@ -686,7 +687,7 @@ fn read_writes_by_checkpoint(
         let (checkpoint_id, node, task_id, idx, channel, payload_json) =
             row.map_err(|e| sqlite_err("read write row", e))?;
         let payload = serde_json::from_str(&payload_json)
-            .map_err(|e| sqlite_err("decode write payload", e))?;
+            .map_err(|e| decode_json_err("sqlite checkpointer", "write payload", e))?;
         let write = PendingWrite {
             node: NodeId::from(node),
             task_id,

--- a/src/graph/checkpoint/sqlite.rs
+++ b/src/graph/checkpoint/sqlite.rs
@@ -192,9 +192,8 @@ struct MetaRow {
 /// Reconstructs a [`CheckpointMetadata`] from the projected listing columns,
 /// without touching the full serialized record.
 fn row_metadata(row: MetaRow) -> Result<CheckpointMetadata> {
-    let namespace: Vec<String> =
-        serde_json::from_str(&row.namespace_json)
-            .map_err(|e| decode_json_err("sqlite checkpointer", "namespace", e))?;
+    let namespace: Vec<String> = serde_json::from_str(&row.namespace_json)
+        .map_err(|e| decode_json_err("sqlite checkpointer", "namespace", e))?;
     let next_nodes: Vec<NodeId> = serde_json::from_str(&row.next_nodes_json)
         .map_err(|e| decode_json_err("sqlite checkpointer", "next_nodes", e))?;
     Ok(CheckpointMetadata {
@@ -292,9 +291,11 @@ where
                 .map_err(|e| sqlite_err("query latest checkpoint", e))?,
         };
         match record {
-            Some(json) => Ok(Some(
-                serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
-            )),
+            Some(json) => {
+                Ok(Some(serde_json::from_str(&json).map_err(|e| {
+                    decode_json_err("sqlite checkpointer", "record", e)
+                })?))
+            }
             None => Ok(None),
         }
     }
@@ -334,9 +335,11 @@ where
                 .map_err(|e| sqlite_err("query latest scoped checkpoint", e))?,
         };
         match record {
-            Some(json) => Ok(Some(
-                serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
-            )),
+            Some(json) => {
+                Ok(Some(serde_json::from_str(&json).map_err(|e| {
+                    decode_json_err("sqlite checkpointer", "record", e)
+                })?))
+            }
             None => Ok(None),
         }
     }
@@ -368,8 +371,10 @@ where
             let mut records: Vec<Checkpoint<State>> = Vec::new();
             for row in rows {
                 let json = row.map_err(|e| sqlite_err("read record row", e))?;
-                records
-                    .push(serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?);
+                records.push(
+                    serde_json::from_str(&json)
+                        .map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
+                );
             }
             let writes = read_writes_by_checkpoint(&conn, thread_id, &namespace_json)?;
             (records, writes)
@@ -474,7 +479,10 @@ where
         let mut out = Vec::new();
         for row in rows {
             let json = row.map_err(|e| sqlite_err("read record row", e))?;
-            out.push(serde_json::from_str(&json).map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?);
+            out.push(
+                serde_json::from_str(&json)
+                    .map_err(|e| decode_json_err("sqlite checkpointer", "record", e))?,
+            );
         }
         Ok(out)
     }

--- a/src/graph/dag/mod.rs
+++ b/src/graph/dag/mod.rs
@@ -82,7 +82,7 @@ pub fn has_cycle(nodes: &[DagNode<'_>]) -> bool {
 
     let mut queue: VecDeque<&str> = indegree
         .iter()
-        .filter(|(_, &d)| d == 0)
+        .filter(|&(_, &d)| d == 0)
         .map(|(&n, _)| n)
         .collect();
     let mut visited = 0usize;

--- a/src/graph/dag/mod.rs
+++ b/src/graph/dag/mod.rs
@@ -70,7 +70,16 @@ pub fn has_cycle(nodes: &[DagNode<'_>]) -> bool {
     let mut indegree: HashMap<&str, usize> = ids.iter().map(|&id| (id, 0)).collect();
     let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
 
+    // A repeated id is reported separately as `DagIssue::DuplicateNode`; the
+    // cycle graph must still be built from exactly one declaration per id, or
+    // two conflicting declarations of the same id (e.g. `a[]` and `a[b]`) get
+    // merged into edges that no single declaration actually names, which can
+    // fabricate a cycle that would not exist under either declaration alone.
+    let mut processed: HashSet<&str> = HashSet::with_capacity(ids.len());
     for node in nodes {
+        if !processed.insert(node.id) {
+            continue;
+        }
         for &dep in &node.depends_on {
             if ids.contains(dep) {
                 // Edge dep -> node: `node` runs after `dep`.

--- a/src/graph/dag/mod.rs
+++ b/src/graph/dag/mod.rs
@@ -1,0 +1,141 @@
+//! Structural validation of a dependency DAG.
+//!
+//! Orchestration surfaces keep re-deriving the same graph question: given nodes
+//! that each name the nodes they must run after, are the ids unique, do all the
+//! edges land, and is the whole thing acyclic? Workflow phases, team task
+//! boards and plan steps all ask it of different node shapes, so this module
+//! takes a borrowed [`DagNode`] view rather than any one caller's struct.
+//!
+//! Two entry points:
+//!
+//! - [`has_cycle`] — the cycle question alone, for a caller that already
+//!   validated ids and edges its own way (a task board admitting one new node
+//!   at a time, say, where a dangling edge on an *existing* node is not the new
+//!   node's fault).
+//! - [`validate_dag`] — duplicates, dangling edges and cycles in one pass,
+//!   returning every issue rather than the first, so a definition can be shown
+//!   with all of its problems at once.
+//!
+//! # Semantics worth knowing
+//!
+//! - **Edges pointing at unknown ids are ignored by the cycle check.** They are
+//!   reported as [`DagIssue::UnknownDependency`] instead. A dangling edge
+//!   cannot close a loop, and letting it participate would turn one mistake
+//!   into two errors.
+//! - **Duplicate ids never trip a false cycle.** The graph is keyed by unique
+//!   id, and reachability is compared against the unique-node count rather than
+//!   the input length — otherwise a repeated id (already reported as
+//!   [`DagIssue::DuplicateNode`]) would look like an unreachable node and read
+//!   as a cycle.
+//! - **A self-edge is a cycle.** `a` depending on `a` yields
+//!   [`DagIssue::Cycle`]. Callers that surface self-dependency as its own
+//!   diagnostic should test for it before calling.
+//!
+//! The algorithm is Kahn's: count indegrees, drain the zero-indegree frontier,
+//! and compare the number of nodes drained against the number of nodes. Runs in
+//! O(V + E), allocates only the working maps, and touches no graph runtime
+//! state — this module is pure structure and is usable before anything is
+//! compiled or executed.
+//!
+//! ```
+//! use tinyagents::graph::dag::{DagIssue, DagNode, validate_dag};
+//!
+//! let nodes = vec![
+//!     DagNode::new("plan", []),
+//!     DagNode::new("build", ["plan"]),
+//!     DagNode::new("ship", ["build"]),
+//! ];
+//! assert!(validate_dag(&nodes).is_empty());
+//!
+//! let looped = vec![DagNode::new("a", ["b"]), DagNode::new("b", ["a"])];
+//! assert_eq!(validate_dag(&looped), vec![DagIssue::Cycle]);
+//! ```
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+mod types;
+
+#[cfg(test)]
+mod test;
+
+pub use types::{DagIssue, DagNode};
+
+/// Reports whether the dependency edges contain a cycle.
+///
+/// Edges naming an id that is not a declared node are ignored (see the module
+/// docs). Duplicate ids are collapsed to one node, so they cannot produce a
+/// false positive.
+pub fn has_cycle(nodes: &[DagNode<'_>]) -> bool {
+    let ids: HashSet<&str> = nodes.iter().map(|n| n.id).collect();
+    let mut indegree: HashMap<&str, usize> = ids.iter().map(|&id| (id, 0)).collect();
+    let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for node in nodes {
+        for &dep in &node.depends_on {
+            if ids.contains(dep) {
+                // Edge dep -> node: `node` runs after `dep`.
+                adjacency.entry(dep).or_default().push(node.id);
+                *indegree.entry(node.id).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut queue: VecDeque<&str> = indegree
+        .iter()
+        .filter(|(_, &d)| d == 0)
+        .map(|(&n, _)| n)
+        .collect();
+    let mut visited = 0usize;
+    while let Some(node) = queue.pop_front() {
+        visited += 1;
+        if let Some(children) = adjacency.get(node) {
+            for &child in children {
+                let entry = indegree.get_mut(child).expect("child in indegree");
+                *entry -= 1;
+                if *entry == 0 {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    // Compare against the unique-id count, not `nodes.len()`: the graph is keyed
+    // by unique id, so duplicates (reported separately) must not read as
+    // unreachable nodes.
+    visited != indegree.len()
+}
+
+/// Validates ids, edges and acyclicity in one pass, returning every issue found.
+///
+/// Issues are ordered: duplicate ids in input order, then dangling edges in
+/// input order, then a single [`DagIssue::Cycle`] if the resolvable edges close
+/// a loop. An empty result means the input is a well-formed DAG.
+pub fn validate_dag(nodes: &[DagNode<'_>]) -> Vec<DagIssue> {
+    let mut issues = Vec::new();
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for node in nodes {
+        if !seen.insert(node.id) {
+            issues.push(DagIssue::DuplicateNode {
+                id: node.id.to_string(),
+            });
+        }
+    }
+
+    for node in nodes {
+        for &dep in &node.depends_on {
+            if !seen.contains(dep) {
+                issues.push(DagIssue::UnknownDependency {
+                    node: node.id.to_string(),
+                    depends_on: dep.to_string(),
+                });
+            }
+        }
+    }
+
+    if has_cycle(nodes) {
+        issues.push(DagIssue::Cycle);
+    }
+
+    issues
+}

--- a/src/graph/dag/test.rs
+++ b/src/graph/dag/test.rs
@@ -1,0 +1,118 @@
+//! Unit tests for dependency-DAG validation: acyclic acceptance, cycle and
+//! self-edge detection, dangling edges, and the duplicate-id false-cycle guard.
+
+use super::*;
+
+#[test]
+fn linear_chain_is_acyclic() {
+    let nodes = vec![
+        DagNode::new("a", []),
+        DagNode::new("b", ["a"]),
+        DagNode::new("c", ["b"]),
+    ];
+    assert!(!has_cycle(&nodes));
+    assert!(validate_dag(&nodes).is_empty());
+}
+
+#[test]
+fn diamond_is_acyclic() {
+    let nodes = vec![
+        DagNode::new("root", []),
+        DagNode::new("left", ["root"]),
+        DagNode::new("right", ["root"]),
+        DagNode::new("join", ["left", "right"]),
+    ];
+    assert!(!has_cycle(&nodes));
+    assert!(validate_dag(&nodes).is_empty());
+}
+
+#[test]
+fn empty_graph_is_acyclic() {
+    assert!(!has_cycle(&[]));
+    assert!(validate_dag(&[]).is_empty());
+}
+
+#[test]
+fn two_node_cycle_is_detected() {
+    let nodes = vec![DagNode::new("a", ["b"]), DagNode::new("b", ["a"])];
+    assert!(has_cycle(&nodes));
+    assert_eq!(validate_dag(&nodes), vec![DagIssue::Cycle]);
+}
+
+#[test]
+fn longer_cycle_is_detected() {
+    let nodes = vec![
+        DagNode::new("a", ["c"]),
+        DagNode::new("b", ["a"]),
+        DagNode::new("c", ["b"]),
+    ];
+    assert!(has_cycle(&nodes));
+}
+
+#[test]
+fn self_edge_is_a_cycle() {
+    let nodes = vec![DagNode::new("a", ["a"])];
+    assert!(has_cycle(&nodes));
+    assert_eq!(validate_dag(&nodes), vec![DagIssue::Cycle]);
+}
+
+#[test]
+fn cycle_off_to_the_side_is_still_detected() {
+    let nodes = vec![
+        DagNode::new("start", []),
+        DagNode::new("x", ["y"]),
+        DagNode::new("y", ["x"]),
+    ];
+    assert!(has_cycle(&nodes));
+}
+
+#[test]
+fn dangling_edges_are_reported_and_ignored_by_the_cycle_check() {
+    let nodes = vec![DagNode::new("only", ["ghost"])];
+    assert!(!has_cycle(&nodes));
+    assert_eq!(
+        validate_dag(&nodes),
+        vec![DagIssue::UnknownDependency {
+            node: "only".to_string(),
+            depends_on: "ghost".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn duplicate_ids_are_reported_without_a_false_cycle() {
+    let nodes = vec![DagNode::new("a", []), DagNode::new("a", [])];
+    assert!(!has_cycle(&nodes));
+    assert_eq!(
+        validate_dag(&nodes),
+        vec![DagIssue::DuplicateNode {
+            id: "a".to_string()
+        }]
+    );
+}
+
+#[test]
+fn all_issue_kinds_are_reported_together() {
+    let nodes = vec![
+        DagNode::new("a", ["b"]),
+        DagNode::new("b", ["a"]),
+        DagNode::new("b", ["ghost"]),
+    ];
+    let issues = validate_dag(&nodes);
+    assert!(issues.contains(&DagIssue::DuplicateNode {
+        id: "b".to_string()
+    }));
+    assert!(issues.contains(&DagIssue::UnknownDependency {
+        node: "b".to_string(),
+        depends_on: "ghost".to_string(),
+    }));
+    assert!(issues.contains(&DagIssue::Cycle));
+}
+
+#[test]
+fn node_view_borrows_owned_dependency_ids() {
+    let deps = vec!["a".to_string(), "b".to_string()];
+    let node = DagNode::new("c", deps.iter().map(String::as_str));
+    assert_eq!(node.id, "c");
+    assert_eq!(node.depends_on, vec!["a", "b"]);
+}

--- a/src/graph/dag/test.rs
+++ b/src/graph/dag/test.rs
@@ -92,6 +92,28 @@ fn duplicate_ids_are_reported_without_a_false_cycle() {
 }
 
 #[test]
+fn conflicting_duplicate_declarations_do_not_fabricate_a_cycle() {
+    // `a` is declared twice with conflicting dependency lists ([] and [b]),
+    // and `b` depends on `a`. Merging both declarations of `a` would add an
+    // edge b -> a (from the second `a[b]`) alongside a -> b (from `b[a]`),
+    // fabricating a cycle that neither declaration of `a` alone produces:
+    // the first (`a[]`) yields a -> b only, and the second (`a[b]`) yields
+    // b -> a only. Only one declaration per id may contribute edges.
+    let nodes = vec![
+        DagNode::new("a", []),
+        DagNode::new("a", ["b"]),
+        DagNode::new("b", ["a"]),
+    ];
+    assert!(!has_cycle(&nodes));
+    assert_eq!(
+        validate_dag(&nodes),
+        vec![DagIssue::DuplicateNode {
+            id: "a".to_string()
+        }]
+    );
+}
+
+#[test]
 fn all_issue_kinds_are_reported_together() {
     let nodes = vec![
         DagNode::new("a", ["b"]),

--- a/src/graph/dag/test.rs
+++ b/src/graph/dag/test.rs
@@ -111,7 +111,7 @@ fn all_issue_kinds_are_reported_together() {
 
 #[test]
 fn node_view_borrows_owned_dependency_ids() {
-    let deps = vec!["a".to_string(), "b".to_string()];
+    let deps = ["a".to_string(), "b".to_string()];
     let node = DagNode::new("c", deps.iter().map(String::as_str));
     assert_eq!(node.id, "c");
     assert_eq!(node.depends_on, vec!["a", "b"]);

--- a/src/graph/dag/types.rs
+++ b/src/graph/dag/types.rs
@@ -1,0 +1,67 @@
+//! Types for structural validation of a dependency DAG.
+//!
+//! A [`DagNode`] is a borrowed view of one node — its id plus the ids it
+//! declares a dependency on — so a host can validate its own node shape without
+//! this crate learning anything about that shape.
+
+/// One node of a dependency graph: an id and the ids it depends on.
+///
+/// Borrowed on purpose: callers hold their own node structs (workflow phases,
+/// team tasks, plan steps) and project them into this view for the duration of
+/// a validation call. Edges are read as `depends_on -> id`, i.e. a node runs
+/// after everything it names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DagNode<'a> {
+    /// This node's id. Ids are compared as strings and are expected to be
+    /// unique; a repeat is reported as [`DagIssue::DuplicateNode`].
+    pub id: &'a str,
+    /// Ids this node depends on. An entry naming no declared node is reported
+    /// as [`DagIssue::UnknownDependency`] and is ignored by the cycle check.
+    pub depends_on: Vec<&'a str>,
+}
+
+impl<'a> DagNode<'a> {
+    /// Builds a node view from an id and any iterator of dependency ids.
+    ///
+    /// ```
+    /// use tinyagents::graph::dag::DagNode;
+    ///
+    /// let deps = vec!["a".to_string(), "b".to_string()];
+    /// let node = DagNode::new("c", deps.iter().map(String::as_str));
+    /// assert_eq!(node.depends_on, vec!["a", "b"]);
+    /// ```
+    pub fn new(id: &'a str, depends_on: impl IntoIterator<Item = &'a str>) -> Self {
+        Self {
+            id,
+            depends_on: depends_on.into_iter().collect(),
+        }
+    }
+}
+
+/// A structural problem found in a dependency graph.
+///
+/// Deliberately small: these are the graph-shaped facts only. Domain rules a
+/// host layers on top — "a phase must name at least one agent", "a task may not
+/// depend on itself by name" — stay with the host, which knows what to call
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DagIssue {
+    /// Two nodes share the same id.
+    DuplicateNode {
+        /// The repeated id.
+        id: String,
+    },
+    /// A node named a dependency that is not a declared node.
+    UnknownDependency {
+        /// The node declaring the edge.
+        node: String,
+        /// The id it named.
+        depends_on: String,
+    },
+    /// The dependency edges contain at least one cycle.
+    ///
+    /// A self-edge (`a` depends on `a`) is a cycle and is reported this way; a
+    /// host that wants to distinguish it should check for that case itself
+    /// before calling.
+    Cycle,
+}

--- a/src/graph/delegation/README.md
+++ b/src/graph/delegation/README.md
@@ -1,0 +1,102 @@
+# `graph::delegation`
+
+A multi-stage sub-agent delegation pipeline expressed as a durable state graph.
+
+```text
+  plan ─▶ execute ─▶ review ──approved / budget spent──▶ [approval] ─▶ finalize ─▶ END
+            ▲                   │
+            └──────revise───────┘
+```
+
+The `approval` node exists only when the run is human-gated
+(`DelegationConfig::require_review_approval`).
+
+## Why it is here
+
+Chaining sub-agents ad hoc gives you no revision budget, no resume after a
+crash, and no place to put a human in the loop. This module is that pipeline
+written once against the graph runtime, so the routing, the bounded revision
+loop, the checkpoint classification and the durable approval pause are one
+reviewed implementation rather than a per-host reinvention.
+
+## Public surface
+
+| Item | Role |
+| --- | --- |
+| `run_delegation` | Run to completion, return the terminal `DelegationState`. The convenience wrapper for the non-gated shape, where the graph never interrupts. |
+| `run_delegation_durable` | Run, reporting via `DelegationOutcome::pending` whether it finalized or parked on a human-approval interrupt. |
+| `run_or_resume_delegation` | Classify the thread's latest checkpoint, then resume / return / start fresh accordingly. |
+| `resume_delegation` | Deliver an approver's decision to a parked run. |
+| `deny_decision` | The canonical deny value, for resume-on-timeout. |
+| `delegation_graph_topology` | Structure-only export (nodes, edges, routing) for inspection. |
+
+## The stage worker is injected
+
+Every entry point takes a `run_stage` closure:
+
+```rust,ignore
+Fn(DelegationStage, DelegationState) -> impl Future<Output = Result<DelegationStageOutput, String>>
+```
+
+This module owns *when* a stage runs and *where its result routes*; it owns
+nothing about *how* a stage runs. A host passes a closure dispatching each
+`DelegationStage` to its own sub-agent runner; tests pass a deterministic mock,
+which is what makes the orchestration mechanics unit-testable without a model.
+
+The same reasoning applies to observability: `DelegationConfig::event_sink` is
+an optional host-supplied `GraphEventSink`. The module never reaches for a
+host-specific logger.
+
+## `DelegationState` is an on-disk format
+
+This is the constraint to read before editing anything in `types.rs`.
+
+A checkpoint written by one release is decoded by a later one. So the serde
+representation of `DelegationState` — field names, `#[serde(...)]` attributes,
+defaults, and the resulting JSON — is a compatibility contract with every
+installation that has a run in flight.
+
+`CURRENT_SCHEMA_VERSION` is what makes that contract enforceable rather than
+merely documented:
+
+- a fresh run stamps its state with the current version;
+- pre-versioned checkpoints decode to `0` via `#[serde(default)]`;
+- `run_or_resume_delegation` **expires** any checkpoint below the current
+  version instead of resuming or returning it.
+
+That last point closes a gap a decode failure alone cannot: a stale record whose
+fields still happen to decode (an empty `executions` list, say) is structurally
+readable but semantically wrong for the current graph, and would otherwise be
+resumed as if it were current.
+
+`test.rs` pins the exact serialized JSON of a fully-populated state, of the
+default state, and of a pre-versioned record. A field addition that drifts the
+shape fails those tests rather than reaching a user's disk unnoticed. Changing
+the shape deliberately means bumping `CURRENT_SCHEMA_VERSION` in the same
+change.
+
+## Bounds and failure handling
+
+- **Revision budget.** `max_revisions` caps reviewer-requested revisions; at the
+  cap the review is force-approved so a never-satisfied reviewer still
+  terminates.
+- **Recursion policy.** A `RecursionPolicy` bounds visits per node and total
+  steps as a backstop to the in-state counter — the loop terminates even if the
+  counter logic is wrong.
+- **Retry.** `max_attempts(1)` preserves single-attempt node semantics; the seam
+  is wired so raising it is a one-line change.
+- **Cancellation** is checked at each node boundary and routes to `finalize`,
+  so a cancelled run still produces a state rather than an error.
+- **Checkpoint read errors are split by kind.** A *decode* failure expires the
+  checkpoint and starts fresh; an *operational* failure (SQLite busy, I/O, a
+  poisoned lock) is propagated. Treating the second as the first would silently
+  discard valid durable work on a transient fault.
+
+## Durable pause vs. interactive pause
+
+The `approval` node is a **checkpointed graph interrupt**: the pause lives
+entirely in the checkpointer and survives a process restart, and only
+`resume_delegation` releases it. That is a durability mechanism for the pause —
+it grants no approval authority and bypasses no host security boundary. A host's
+own in-memory, TTL-bounded prompt for a live turn is a different mechanism and
+is unaffected by anything here.

--- a/src/graph/delegation/_graph_body.rs
+++ b/src/graph/delegation/_graph_body.rs
@@ -1,0 +1,282 @@
+/// Build (but do not run) the delegation `CompiledGraph`. Shared by
+/// [`run_delegation`] and [`delegation_graph_topology`] so the graph's structure
+/// has one definition.
+fn build_delegation_graph<F, Fut>(
+    max_revisions: usize,
+    cancel: CancellationToken,
+    require_review_approval: bool,
+    run_stage: F,
+) -> Result<CompiledGraph<DelegationState, DelegationUpdate>, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    let mut builder = GraphBuilder::<DelegationState, DelegationUpdate>::new().set_reducer(
+        ClosureStateReducer::new(|mut s: DelegationState, u: DelegationUpdate| {
+            match u {
+                DelegationUpdate::Plan(p) => s.plan = Some(p),
+                DelegationUpdate::Execution { prompt, result } => {
+                    let index = s.executions.len();
+                    s.executions.push(StepRecord {
+                        index,
+                        prompt,
+                        result,
+                    });
+                }
+                DelegationUpdate::Review { note, approved } => {
+                    s.reviews.push(note);
+                    s.approved = approved;
+                    if !approved {
+                        s.revisions += 1;
+                    }
+                }
+                DelegationUpdate::HumanDecision { approved } => {
+                    s.human_approved = Some(approved);
+                    s.denied = !approved;
+                    // A denial overrides the reviewer's in-graph approval: the
+                    // human gate is the final authority on whether the result
+                    // may finalize.
+                    if !approved {
+                        s.approved = false;
+                    }
+                }
+                DelegationUpdate::Final(f) => s.final_output = Some(f),
+                DelegationUpdate::Cancelled => s.cancelled = true,
+            }
+            Ok(s)
+        }),
+    );
+
+    // plan: produce the plan, then route to execute (or finalize if cancelled).
+    let run_plan = run_stage.clone();
+    let cancel_plan = cancel.clone();
+    builder = builder.add_node("plan", move |s: DelegationState, _c: NodeContext| {
+        let run_plan = run_plan.clone();
+        let cancel = cancel_plan.clone();
+        async move {
+            if cancel.is_cancelled() {
+                return Ok(NodeResult::Command(
+                    Command::default()
+                        .with_update(DelegationUpdate::Cancelled)
+                        .with_goto(["finalize"]),
+                ));
+            }
+            let out = run_plan(DelegationStage::Plan, s)
+                .await
+                .map_err(to_node_err)?;
+            Ok(NodeResult::Command(
+                Command::default()
+                    .with_update(DelegationUpdate::Plan(out.text))
+                    .with_goto(["execute"]),
+            ))
+        }
+    });
+
+    // execute: run the plan; route to review.
+    let run_exec = run_stage.clone();
+    let cancel_exec = cancel.clone();
+    builder = builder.add_node("execute", move |s: DelegationState, _c: NodeContext| {
+        let run_exec = run_exec.clone();
+        let cancel = cancel_exec.clone();
+        async move {
+            if cancel.is_cancelled() {
+                return Ok(NodeResult::Command(
+                    Command::default()
+                        .with_update(DelegationUpdate::Cancelled)
+                        .with_goto(["finalize"]),
+                ));
+            }
+            let out = run_exec(DelegationStage::Execute, s)
+                .await
+                .map_err(to_node_err)?;
+            Ok(NodeResult::Command(
+                Command::default()
+                    .with_update(DelegationUpdate::Execution {
+                        prompt: out.prompt.unwrap_or_default(),
+                        result: out.text,
+                    })
+                    .with_goto(["review"]),
+            ))
+        }
+    });
+
+    // review: approve (→ finalize) or request a revision (→ execute), bounded by
+    // `max_revisions` so a never-approving reviewer still terminates.
+    let run_review = run_stage.clone();
+    let cancel_review = cancel.clone();
+    builder = builder.add_node("review", move |s: DelegationState, _c: NodeContext| {
+        let run_review = run_review.clone();
+        let cancel = cancel_review.clone();
+        async move {
+            if cancel.is_cancelled() {
+                return Ok(NodeResult::Command(
+                    Command::default()
+                        .with_update(DelegationUpdate::Cancelled)
+                        .with_goto(["finalize"]),
+                ));
+            }
+            let revisions = s.revisions;
+            let out = run_review(DelegationStage::Review, s)
+                .await
+                .map_err(to_node_err)?;
+            // Approve when the reviewer is satisfied OR the revision budget is spent.
+            let approved = out.approved || revisions >= max_revisions;
+            // An approved result routes to the durable human-approval gate when
+            // the run is human-gated; otherwise it finalizes directly. A
+            // not-approved result always loops back to `execute` for a revision.
+            let next = if !approved {
+                "execute"
+            } else if require_review_approval {
+                "approval"
+            } else {
+                "finalize"
+            };
+            Ok(NodeResult::Command(
+                Command::default()
+                    .with_update(DelegationUpdate::Review {
+                        note: out.text,
+                        approved,
+                    })
+                    .with_goto([next]),
+            ))
+        }
+    });
+
+    // approval (only when human-gated): a durable human-in-the-loop pause.
+    //
+    // First entry (`ctx.resume` is `None`): emit `NodeResult::Interrupt`. The
+    // executor persists a boundary checkpoint (Sync durability) and returns
+    // control to the caller — the pause now survives a process restart. Nothing
+    // finalizes until a resume arrives.
+    //
+    // Re-entry (`ctx.resume` is `Some(decision)`): the approver's decision was
+    // delivered via `Command { resume: .. }`. Apply approve/deny and route to
+    // `finalize` (deny is honoured there as a blocked/denied result). This is a
+    // durability mechanism for the PAUSE only — it grants no new approval
+    // authority and never bypasses the security/approval boundary.
+    //
+    // Durable-vs-chat boundary: this pause is a *checkpointed graph interrupt*,
+    // distinct from the interactive chat-turn approval gate (10-min TTL steering
+    // pause via `ApprovalRequestCard`), which parks a live in-memory chat turn
+    // and is deliberately left untouched.
+    if require_review_approval {
+        builder = builder.add_node("approval", move |s: DelegationState, ctx: NodeContext| {
+            async move {
+                match ctx.resume {
+                    None => {
+                        let payload = json!({
+                            "kind": "delegation_review",
+                            "reviews": s.reviews,
+                            "executions": s.executions_texts(),
+                            "revisions": s.revisions,
+                        });
+                        tracing::info!(
+                            revisions = s.revisions,
+                            "[interrupt] delegation review reached durable human-approval gate; pausing"
+                        );
+                        Ok(NodeResult::Interrupt(Interrupt::with_id(
+                            "delegation-review-approval",
+                            "approval",
+                            payload,
+                        )))
+                    }
+                    Some(decision) => {
+                        let approved = decision_is_approve(&decision);
+                        tracing::info!(
+                            approved,
+                            "[interrupt] delegation review resumed with human decision"
+                        );
+                        Ok(NodeResult::Command(
+                            Command::default()
+                                .with_update(DelegationUpdate::HumanDecision { approved })
+                                .with_goto(["finalize"]),
+                        ))
+                    }
+                }
+            }
+        });
+    }
+
+    // finalize: synthesize the final output from the accumulated state, then end.
+    builder = builder.add_node(
+        "finalize",
+        move |s: DelegationState, _c: NodeContext| async move {
+            let summary = s
+                .executions
+                .last()
+                .map(|r| r.result.clone())
+                .unwrap_or_else(|| "<no execution>".to_string());
+            let final_text = if s.cancelled {
+                format!("cancelled after {} execution(s)", s.executions.len())
+            } else if s.denied {
+                format!(
+                    "denied by reviewer after {} execution(s)",
+                    s.executions.len()
+                )
+            } else {
+                summary
+            };
+            Ok(NodeResult::Command(
+                Command::default()
+                    .with_update(DelegationUpdate::Final(final_text))
+                    .with_goto([END]),
+            ))
+        },
+    );
+
+    builder = builder
+        .set_entry("plan")
+        .mark_command_routing("plan")
+        .mark_command_routing("execute")
+        .mark_command_routing("review")
+        .mark_command_routing("finalize");
+
+    if require_review_approval {
+        builder = builder
+            .mark_command_routing("approval")
+            .mark_interrupt("approval");
+    }
+
+    let graph = builder
+        .compile()
+        .map_err(|e| format!("delegation graph compile failed: {e}"))?
+        // Bound the execute⇄review loop as a backstop to the in-state counter:
+        // each of execute/review may be visited at most max_revisions + 1 times.
+        .with_recursion_policy(RecursionPolicy {
+            max_visits_per_node: Some(max_revisions + 2),
+            max_total_steps: (max_revisions + 1) * 4 + 8,
+            ..RecursionPolicy::default()
+        })
+        // Adapter-first landing of the crate-native per-node RetryPolicy
+        // (tinyagents 1.5.0 `CompiledGraph::with_node_retry`). Conservative:
+        // `max_attempts(1)` preserves today's single-attempt semantics exactly
+        // (no bespoke retry glue existed here) and backoff sleeping stays off
+        // (the default), so a transient node-handler failure surfaces as it does
+        // today. This wires the seam so raising the attempt cap / enabling
+        // backoff is a one-line, gated follow-up rather than a rewrite.
+        .with_node_retry(RetryPolicy::default().with_max_attempts(1));
+
+    Ok(graph)
+}
+
+/// Structure-only [`GraphTopology`] of the delegation graph for debug /
+/// inspection (issue #4249, Phase 4). Built with a no-op stub stage worker —
+/// the topology exposes only node names, edges, and routing, never closure
+/// bodies.
+pub fn delegation_graph_topology() -> Result<GraphTopology, String> {
+    let graph = build_delegation_graph(
+        DelegationConfig::default().max_revisions,
+        CancellationToken::new(),
+        // Topology export uses the non-gated shape (the four revision-loop
+        // nodes); the durable `approval` interrupt node is additive and only
+        // present when a run is human-gated.
+        false,
+        |_stage, _state| async { Ok(DelegationStageOutput::done("")) },
+    )?;
+    Ok(graph.topology())
+}
+
+/// Map an injected-stage error string into a graph node error.
+fn to_node_err(e: String) -> crate::TinyAgentsError {
+    crate::TinyAgentsError::Model(e)
+}

--- a/src/graph/delegation/_graph_body.rs
+++ b/src/graph/delegation/_graph_body.rs
@@ -1,7 +1,7 @@
 /// Build (but do not run) the delegation `CompiledGraph`. Shared by
 /// [`run_delegation`] and [`delegation_graph_topology`] so the graph's structure
 /// has one definition.
-fn build_delegation_graph<F, Fut>(
+pub(super) fn build_delegation_graph<F, Fut>(
     max_revisions: usize,
     cancel: CancellationToken,
     require_review_approval: bool,

--- a/src/graph/delegation/_run_body.rs
+++ b/src/graph/delegation/_run_body.rs
@@ -1,0 +1,351 @@
+/// Run the plan→execute⇄review→finalize delegation graph, invoking `run_stage`
+/// for each stage. Returns the final [`DelegationState`].
+///
+/// `run_stage` is the seam to the agent harness: production passes a closure that
+/// dispatches each [`DelegationStage`] to `run_subagent`; tests pass a mock.
+///
+/// This is the non-gated convenience wrapper: with the default config
+/// (`require_review_approval = false`) the graph never interrupts, so the
+/// returned state is always terminal.
+pub async fn run_delegation<F, Fut>(
+    config: DelegationConfig,
+    run_stage: F,
+) -> Result<DelegationState, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    Ok(run_delegation_durable(config, run_stage).await?.state)
+}
+
+/// Run the delegation graph and report whether it finalized or parked on a
+/// durable human-approval interrupt.
+///
+/// When [`DelegationConfig::require_review_approval`] is set and the reviewer
+/// approves, the `approval` node emits [`NodeResult::Interrupt`]; the executor
+/// persists a checkpoint (Sync durability — the crate default) and returns
+/// control here with the interrupt in [`DelegationOutcome::pending`]. Deliver the
+/// approver's decision later with [`resume_delegation`] — it may run after a
+/// process restart, since the pause lives entirely in the checkpointer.
+pub async fn run_delegation_durable<F, Fut>(
+    config: DelegationConfig,
+    run_stage: F,
+) -> Result<DelegationOutcome, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    let thread_id = config.thread_id.clone();
+    let mut graph = build_delegation_graph(
+        config.max_revisions,
+        config.cancel.clone(),
+        config.require_review_approval,
+        run_stage,
+    )?
+    .with_event_sink(Arc::new(super::observability::GraphTracingSink::new(
+        "delegation:graph",
+    )));
+
+    if let Some(cp) = config.checkpointer {
+        graph = graph.with_checkpointer(cp);
+    }
+
+    tracing::info!(
+        max_revisions = config.max_revisions,
+        durable = thread_id.is_some(),
+        human_gated = config.require_review_approval,
+        "[delegation] running sub-agent delegation graph"
+    );
+
+    let initial = DelegationState::new_run();
+    let execution = match thread_id.clone() {
+        Some(tid) => graph.run_with_thread(tid, initial).await,
+        None => graph.run(initial).await,
+    }
+    .map_err(|e| format!("delegation graph run failed: {e}"))?;
+
+    Ok(into_outcome(execution, thread_id))
+}
+
+/// Resume a delegation graph parked on a durable human-approval interrupt,
+/// delivering the approver's `decision` through `Command { resume: .. }`.
+///
+/// The graph is rebuilt (its node closures are not serializable — only the typed
+/// state is checkpointed) with the same checkpointer + `thread_id`, then
+/// re-entered at the interrupted node via [`CompiledGraph::resume`] (the
+/// `ResumeTarget::Latest` checkpoint). `decision` maps to approve/deny via
+/// [`decision_is_approve`], so passing the approval RPC's `ApprovalDecision`
+/// (serialized with its stable `as_str()` wire value — `approve_once` /
+/// `approve_always_for_tool` / `deny`) routes the existing decision contract
+/// into the resume **without changing that contract**.
+///
+/// TTL expiry → resume-with-deny: call this with [`deny_decision`] to preserve
+/// the existing timeout-deny behavior for a pause that was never answered.
+pub async fn resume_delegation<F, Fut>(
+    config: DelegationConfig,
+    decision: Value,
+    run_stage: F,
+) -> Result<DelegationOutcome, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    let approved = decision_is_approve(&decision);
+    tracing::info!(
+        approved,
+        "[interrupt] resuming durable delegation graph with approval decision"
+    );
+    let mut command = Command::default();
+    command.resume = Some(decision);
+    resume_graph(config, command, run_stage).await
+}
+
+/// Run the delegation graph, resuming from the last checkpoint boundary when the
+/// configured thread has a live, compatible, non-terminal checkpoint, else
+/// starting fresh (issue #3884 — node-level checkpoint & resume).
+///
+/// Classifies the thread's latest checkpoint and routes accordingly:
+/// - **resumable** (a crash/failure left a mid-run boundary) → re-run only the
+///   not-yet-completed nodes from that boundary via [`CompiledGraph::resume`]
+///   with an empty command — never restarting from `plan`, and never re-running
+///   an already-completed step (its [`StepRecord`] is restored from the state);
+/// - **terminal** (already finalized/cancelled) → return the stored final state
+///   without re-running (idempotent re-invocation of a stable thread);
+/// - **absent** (no checkpoint) → a fresh durable run;
+/// - **incompatible** (an undecodable record — e.g. a pre-#3884 `Vec<String>`
+///   `executions` shape) → log, best-effort prune, and start fresh. The decode
+///   error is swallowed into a fresh-run decision, never propagated, never a panic.
+///
+/// Callers that mint a unique `thread_id` per run (today's default) always take
+/// the fresh path unchanged; the resume paths activate only when a caller reuses
+/// a stable `thread_id`, so this is byte-compatible for existing callers while
+/// wiring the resume seam that #3881 (plan-edit resume) builds on.
+pub async fn run_or_resume_delegation<F, Fut>(
+    config: DelegationConfig,
+    run_stage: F,
+) -> Result<DelegationOutcome, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    // Without a checkpointer + thread there is nothing to resume from.
+    let (Some(cp), Some(tid)) = (config.checkpointer.clone(), config.thread_id.clone()) else {
+        return run_delegation_durable(config, run_stage).await;
+    };
+
+    match cp.get(tid.as_str(), None).await {
+        // A checkpoint written under an older state schema (e.g. a pre-#3884
+        // record whose `executions` happened to be empty and so still decoded
+        // into `Vec<StepRecord>`) is expired rather than resumed/returned — its
+        // semantics may not match the current graph. This is what makes
+        // `schema_version` an actual guard, not just documentation, and closes
+        // the empty-`executions` gap that a decode failure alone cannot catch.
+        Ok(Some(checkpoint)) if checkpoint.state.schema_version < CURRENT_SCHEMA_VERSION => {
+            tracing::warn!(
+                thread_id = %tid,
+                schema_version = checkpoint.state.schema_version,
+                current = CURRENT_SCHEMA_VERSION,
+                "[delegation] checkpoint predates the current state schema; pruning and starting fresh"
+            );
+            prune_thread(cp.as_ref(), &tid).await;
+            run_delegation_durable(config, run_stage).await
+        }
+        Ok(Some(checkpoint)) if checkpoint_is_resumable(&checkpoint) => {
+            tracing::info!(
+                thread_id = %tid,
+                "[delegation] resuming durable delegation from its last checkpoint boundary"
+            );
+            // A crash/failure resume carries no decision value — an empty command
+            // simply re-runs the pending node(s) (the crate's `retry` semantics).
+            resume_graph(config, Command::default(), run_stage).await
+        }
+        Ok(Some(checkpoint)) => {
+            // Terminal: return the finalized state without re-running. Defensive:
+            // if this checkpoint still carried an unconsumed interrupt, surface it
+            // instead of silently dropping it. The current routing never produces
+            // this (an interrupt boundary schedules its node and is classified
+            // resumable above), but a future schedule could, and a dropped pause
+            // would strand a run.
+            let pending = checkpoint.interrupts.first().map(|i| PendingApproval {
+                interrupt_id: i.id.clone(),
+                node: i.node.as_str().to_string(),
+                payload: i.payload.clone(),
+                thread_id: tid.clone(),
+            });
+            if pending.is_some() {
+                tracing::warn!(
+                    thread_id = %tid,
+                    "[delegation] terminal-classified checkpoint carried a pending interrupt; surfacing it"
+                );
+            } else {
+                tracing::info!(
+                    thread_id = %tid,
+                    "[delegation] thread already terminal; returning finalized state without re-running"
+                );
+            }
+            Ok(DelegationOutcome {
+                state: checkpoint.state,
+                pending,
+            })
+        }
+        Ok(None) => {
+            tracing::debug!(
+                thread_id = %tid,
+                "[delegation] no checkpoint for thread; starting a fresh durable run"
+            );
+            run_delegation_durable(config, run_stage).await
+        }
+        // Only a *decode / shape-incompatibility* read error expires the
+        // checkpoint. An operational error (SQLite busy / I/O / poisoned lock)
+        // must NOT silently restart a valid resumable run — it is propagated so
+        // durable work is retried by the caller, not dropped.
+        Err(e) if is_incompatible_checkpoint_error(&e) => {
+            tracing::warn!(
+                thread_id = %tid,
+                error = %e,
+                "[delegation] undecodable/incompatible checkpoint; pruning and starting fresh"
+            );
+            prune_thread(cp.as_ref(), &tid).await;
+            run_delegation_durable(config, run_stage).await
+        }
+        Err(e) => {
+            tracing::error!(
+                thread_id = %tid,
+                error = %e,
+                "[delegation] checkpoint read failed (operational); not restarting — propagating error"
+            );
+            Err(format!(
+                "delegation checkpoint read failed for thread {tid}: {e}"
+            ))
+        }
+    }
+}
+
+/// Best-effort prune of a dead/expired checkpoint thread so it is not re-probed
+/// forever. Failure to prune is non-fatal (logged at debug).
+async fn prune_thread(cp: &dyn Checkpointer<DelegationState>, thread_id: &str) {
+    if let Err(e) = cp.delete_thread(thread_id).await {
+        tracing::debug!(
+            thread_id = %thread_id,
+            error = %e,
+            "[delegation] could not prune checkpoint thread (non-fatal)"
+        );
+    }
+}
+
+/// Whether a `Checkpointer::get` error is a decode / shape-incompatibility (safe
+/// to expire the checkpoint) rather than an operational failure (SQLite busy /
+/// I/O / poisoned lock — must not silently restart durable work). The vendored
+/// `SqliteCheckpointer` reports both as `TinyAgentsError::Checkpoint(String)` but
+/// tags decode failures with a `"decode …"` context (`sqlite.rs`:
+/// `decode record` / `decode namespace` / `decode next_nodes`) — the only stable
+/// discriminator it exposes.
+fn is_incompatible_checkpoint_error(e: &crate::TinyAgentsError) -> bool {
+    matches!(e, crate::TinyAgentsError::Checkpoint(msg) if msg.contains("decode"))
+}
+
+/// Whether a loaded checkpoint still has work to resume: a non-finalized,
+/// non-cancelled run that still schedules a real (non-`END`) node.
+fn checkpoint_is_resumable(checkpoint: &Checkpoint<DelegationState>) -> bool {
+    if checkpoint.state.final_output.is_some() || checkpoint.state.cancelled {
+        return false;
+    }
+    checkpoint.next_nodes.iter().any(|n| n.as_str() != END)
+}
+
+/// Rebuild the delegation graph (its node closures are not serializable — only
+/// the typed state is checkpointed) with the same checkpointer + `thread_id`, and
+/// re-enter it at the latest checkpoint's pending node(s) via
+/// [`CompiledGraph::resume`]. `command` carries an approver's decision for the
+/// human-approval interrupt path, or is empty for a plain crash/failure resume.
+async fn resume_graph<F, Fut>(
+    config: DelegationConfig,
+    command: Command<DelegationUpdate>,
+    run_stage: F,
+) -> Result<DelegationOutcome, String>
+where
+    F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
+{
+    let thread_id = config
+        .thread_id
+        .clone()
+        .ok_or_else(|| "delegation resume requires a thread_id".to_string())?;
+    let cp = config
+        .checkpointer
+        .clone()
+        .ok_or_else(|| "delegation resume requires a checkpointer".to_string())?;
+
+    let graph = build_delegation_graph(
+        config.max_revisions,
+        config.cancel.clone(),
+        config.require_review_approval,
+        run_stage,
+    )?
+    .with_event_sink(Arc::new(super::observability::GraphTracingSink::new(
+        "delegation:graph",
+    )))
+    .with_checkpointer(cp);
+
+    let execution = graph
+        .resume(thread_id.clone(), command)
+        .await
+        .map_err(|e| format!("delegation graph resume failed: {e}"))?;
+
+    Ok(into_outcome(execution, Some(thread_id)))
+}
+
+/// The canonical deny decision used for TTL-expiry resume (resume-with-deny),
+/// serialized to the approval RPC's stable `deny` wire value.
+pub fn deny_decision() -> Value {
+    json!("deny")
+}
+
+/// Fold a finished/paused graph execution into a [`DelegationOutcome`],
+/// surfacing the first pending interrupt (if the run parked on one).
+fn into_outcome(
+    execution: crate::graph::GraphExecution<DelegationState>,
+    thread_id: Option<String>,
+) -> DelegationOutcome {
+    let pending = execution.interrupts.first().map(|i| {
+        tracing::info!(
+            interrupt_id = %i.id,
+            node = %i.node.as_str(),
+            "[interrupt] delegation run parked on durable human-approval interrupt"
+        );
+        PendingApproval {
+            interrupt_id: i.id.clone(),
+            node: i.node.as_str().to_string(),
+            payload: i.payload.clone(),
+            thread_id: thread_id.clone().unwrap_or_default(),
+        }
+    });
+    DelegationOutcome {
+        state: execution.state,
+        pending,
+    }
+}
+
+/// Map an approval decision value onto approve/deny. Accepts the approval RPC's
+/// stable string forms (`approve_once`, `approve_always_for_tool`, `deny`), a
+/// bare bool, or an object carrying `approved`/`decision` — so the existing
+/// decision contract routes into `Command::resume` unchanged.
+fn decision_is_approve(decision: &Value) -> bool {
+    match decision {
+        Value::Bool(b) => *b,
+        Value::String(s) => matches!(
+            s.as_str(),
+            "approve_once" | "approve_always_for_tool" | "approve" | "approved"
+        ),
+        Value::Object(m) => {
+            if let Some(b) = m.get("approved").and_then(Value::as_bool) {
+                return b;
+            }
+            m.get("decision")
+                .and_then(Value::as_str)
+                .map(|d| d.starts_with("approve"))
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}

--- a/src/graph/delegation/_run_body.rs
+++ b/src/graph/delegation/_run_body.rs
@@ -41,10 +41,10 @@ where
         config.cancel.clone(),
         config.require_review_approval,
         run_stage,
-    )?
-    .with_event_sink(Arc::new(super::observability::GraphTracingSink::new(
-        "delegation:graph",
-    )));
+    )?;
+    if let Some(sink) = config.event_sink.clone() {
+        graph = graph.with_event_sink(sink);
+    }
 
     if let Some(cp) = config.checkpointer {
         graph = graph.with_checkpointer(cp);
@@ -240,7 +240,7 @@ async fn prune_thread(cp: &dyn Checkpointer<DelegationState>, thread_id: &str) {
 /// tags decode failures with a `"decode …"` context (`sqlite.rs`:
 /// `decode record` / `decode namespace` / `decode next_nodes`) — the only stable
 /// discriminator it exposes.
-fn is_incompatible_checkpoint_error(e: &crate::TinyAgentsError) -> bool {
+pub(super) fn is_incompatible_checkpoint_error(e: &crate::TinyAgentsError) -> bool {
     matches!(e, crate::TinyAgentsError::Checkpoint(msg) if msg.contains("decode"))
 }
 
@@ -276,16 +276,16 @@ where
         .clone()
         .ok_or_else(|| "delegation resume requires a checkpointer".to_string())?;
 
-    let graph = build_delegation_graph(
+    let mut graph = build_delegation_graph(
         config.max_revisions,
         config.cancel.clone(),
         config.require_review_approval,
         run_stage,
     )?
-    .with_event_sink(Arc::new(super::observability::GraphTracingSink::new(
-        "delegation:graph",
-    )))
     .with_checkpointer(cp);
+    if let Some(sink) = config.event_sink.clone() {
+        graph = graph.with_event_sink(sink);
+    }
 
     let execution = graph
         .resume(thread_id.clone(), command)
@@ -330,7 +330,7 @@ fn into_outcome(
 /// stable string forms (`approve_once`, `approve_always_for_tool`, `deny`), a
 /// bare bool, or an object carrying `approved`/`decision` — so the existing
 /// decision contract routes into `Command::resume` unchanged.
-fn decision_is_approve(decision: &Value) -> bool {
+pub(super) fn decision_is_approve(decision: &Value) -> bool {
     match decision {
         Value::Bool(b) => *b,
         Value::String(s) => matches!(

--- a/src/graph/delegation/_types_body.rs
+++ b/src/graph/delegation/_types_body.rs
@@ -123,7 +123,7 @@ impl DelegationState {
 }
 
 /// Reducer updates emitted by the delegation nodes.
-enum DelegationUpdate {
+pub(crate) enum DelegationUpdate {
     Plan(String),
     Execution {
         prompt: String,

--- a/src/graph/delegation/_types_body.rs
+++ b/src/graph/delegation/_types_body.rs
@@ -1,0 +1,208 @@
+/// Which stage a delegation node is asking the injected worker to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegationStage {
+    /// Produce a plan for the task.
+    Plan,
+    /// Execute the current plan (re-run on revision).
+    Execute,
+    /// Review the latest execution; may approve or request a revision.
+    Review,
+}
+
+/// What an injected stage worker returns.
+#[derive(Debug, Clone)]
+pub struct DelegationStageOutput {
+    /// The stage's textual output (plan text, execution result, or review note).
+    pub text: String,
+    /// Only meaningful for [`DelegationStage::Review`]: `true` approves the
+    /// execution and ends the loop; `false` requests another revision.
+    pub approved: bool,
+    /// The exact prompt handed to this stage's worker, when it surfaces one.
+    /// Persisted into [`StepRecord::prompt`] for per-step provenance (read only
+    /// for the execute stage; ignored elsewhere). `None` when the worker does not
+    /// surface a prompt — e.g. the deterministic test mock.
+    pub prompt: Option<String>,
+}
+
+impl DelegationStageOutput {
+    /// A plain non-review stage output (the `approved` flag is unused and no
+    /// prompt is surfaced).
+    pub fn done(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            approved: true,
+            prompt: None,
+        }
+    }
+}
+
+/// Current on-disk schema version for a checkpointed [`DelegationState`]. Bumped
+/// only on a breaking state-shape change — introduced with the
+/// `executions: Vec<String>` → `Vec<StepRecord>` migration (issue #3884).
+/// Pre-versioned records deserialize to `0` via `#[serde(default)]`, so a resume
+/// can tell a stale checkpoint from a current one.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// One completed execute-stage pass, recorded durably so a resumed run knows
+/// exactly how far it got and can render/finalize per step rather than from a
+/// flat text log. Replaces the former `executions: Vec<String>` (issue #3884).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StepRecord {
+    /// 0-based execute pass: `0` is the first execution, `n` the n-th revision.
+    pub index: usize,
+    /// The exact prompt handed to the execute sub-agent for this pass — per-step
+    /// provenance and the seam a later plan-edit slice (#3881) diffs against.
+    /// Empty when the worker did not surface one.
+    #[serde(default)]
+    pub prompt: String,
+    /// The sub-agent's result text — the value the former `Vec<String>` entry held.
+    pub result: String,
+}
+
+/// Typed working state threaded through (and checkpointed across) the delegation
+/// graph. Serde-serializable so a [`Checkpointer`] can persist and restore it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DelegationState {
+    /// The plan produced by the `plan` stage.
+    pub plan: Option<String>,
+    /// One record per execution pass (the first plus each revision), typed so a
+    /// resumed run can render/finalize per step (widened from `Vec<String>`,
+    /// issue #3884).
+    pub executions: Vec<StepRecord>,
+    /// One entry per review pass.
+    pub reviews: Vec<String>,
+    /// Number of revisions the reviewer requested (loops back to `execute`).
+    pub revisions: usize,
+    /// Set once the reviewer approves or the revision cap is hit.
+    pub approved: bool,
+    /// The final synthesized output (set by `finalize`).
+    pub final_output: Option<String>,
+    /// Set when the run short-circuited because its token was cancelled.
+    pub cancelled: bool,
+    /// The durable human-approval decision, once a resume delivers one:
+    /// `Some(true)` = approved, `Some(false)` = denied, `None` = not gated /
+    /// still awaiting. Only meaningful when `require_review_approval` is set.
+    #[serde(default)]
+    pub human_approved: Option<bool>,
+    /// Set when the durable human-approval gate denied the delegated result
+    /// (deny semantics: block the action, finalize as denied).
+    #[serde(default)]
+    pub denied: bool,
+    /// On-disk schema version, stamped [`CURRENT_SCHEMA_VERSION`] on a fresh run
+    /// and defaulting to `0` for pre-versioned checkpoints.
+    /// [`run_or_resume_delegation`] expires any checkpoint whose version is below
+    /// `CURRENT_SCHEMA_VERSION` (and any that fails to deserialize) instead of
+    /// resuming or returning it — so a shape change that stays structurally
+    /// decodable is still not misread.
+    #[serde(default)]
+    pub schema_version: u32,
+}
+
+impl DelegationState {
+    /// A fresh run's initial state, stamped with the current schema version so
+    /// its checkpoints are self-identifying.
+    fn new_run() -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            ..Self::default()
+        }
+    }
+
+    /// The latest execution result text, if any — the projection the review
+    /// prompt and the finalize summary read.
+    pub fn last_result(&self) -> Option<&str> {
+        self.executions.last().map(|r| r.result.as_str())
+    }
+
+    /// The execution result texts in order — the flat projection used for the
+    /// durable approval-interrupt payload, kept `Vec<&str>` so that wire shape
+    /// is unchanged from the pre-#3884 `Vec<String>`.
+    pub fn executions_texts(&self) -> Vec<&str> {
+        self.executions.iter().map(|r| r.result.as_str()).collect()
+    }
+}
+
+/// Reducer updates emitted by the delegation nodes.
+enum DelegationUpdate {
+    Plan(String),
+    Execution {
+        prompt: String,
+        result: String,
+    },
+    Review {
+        note: String,
+        approved: bool,
+    },
+    /// A durable human-approval decision delivered by a resume command.
+    HumanDecision {
+        approved: bool,
+    },
+    Final(String),
+    Cancelled,
+}
+
+/// Configuration for a delegation run.
+pub struct DelegationConfig {
+    /// Upper bound on reviewer-requested revisions before forcing `finalize`.
+    pub max_revisions: usize,
+    /// Optional durable checkpointer (e.g. a `FileCheckpointer`). When set with a
+    /// `thread_id`, the run persists its state at every super-step boundary.
+    pub checkpointer: Option<Arc<dyn Checkpointer<DelegationState>>>,
+    /// Thread id for checkpoint keying; required for the checkpointer to persist.
+    pub thread_id: Option<String>,
+    /// Cooperative cancellation; checked at each node boundary.
+    pub cancel: CancellationToken,
+    /// When set, an approved review does not finalize directly: the run reaches
+    /// a durable **human-approval** interrupt (`NodeResult::Interrupt`) that is
+    /// persisted via the checkpointer (Sync durability) and survives a process
+    /// restart. The pause is only released by [`resume_delegation`] carrying the
+    /// approver's decision. Requires `checkpointer` + `thread_id` (interrupts
+    /// require durability).
+    ///
+    /// This is the **durable** approval boundary — distinct from the interactive
+    /// chat-turn approval gate (the 10-min TTL steering pause surfaced via
+    /// `ApprovalRequestCard`), which parks a live chat turn in memory and is left
+    /// exactly as-is. Durable graphs pause by checkpoint; chat turns pause by
+    /// steering. See the `approval` node below.
+    pub require_review_approval: bool,
+}
+
+impl Default for DelegationConfig {
+    fn default() -> Self {
+        Self {
+            max_revisions: 2,
+            checkpointer: None,
+            thread_id: None,
+            cancel: CancellationToken::new(),
+            require_review_approval: false,
+        }
+    }
+}
+
+/// A durable human-approval pause the delegation graph is parked on.
+///
+/// Produced when a run reaches the `approval` interrupt (see
+/// [`DelegationConfig::require_review_approval`]). The pause is already
+/// persisted as a checkpoint keyed by `thread_id`; the approver's decision is
+/// delivered later via [`resume_delegation`], which survives a process restart.
+#[derive(Debug, Clone)]
+pub struct PendingApproval {
+    /// Stable id of the emitted interrupt (matches a resume value to this pause).
+    pub interrupt_id: String,
+    /// The node that emitted the interrupt (always `"approval"` here).
+    pub node: String,
+    /// Approval-request payload presented to the approver (review notes, etc.).
+    pub payload: Value,
+    /// Thread id the paused graph is checkpointed under; the resume key.
+    pub thread_id: String,
+}
+
+/// Outcome of a durable delegation run or resume.
+#[derive(Debug, Clone)]
+pub struct DelegationOutcome {
+    /// The latest committed [`DelegationState`] at the run/resume boundary.
+    pub state: DelegationState,
+    /// `Some` when the run is parked on a durable human-approval interrupt;
+    /// `None` when the run reached a terminal (finalized) boundary.
+    pub pending: Option<PendingApproval>,
+}

--- a/src/graph/delegation/_types_body.rs
+++ b/src/graph/delegation/_types_body.rs
@@ -165,6 +165,13 @@ pub struct DelegationConfig {
     /// exactly as-is. Durable graphs pause by checkpoint; chat turns pause by
     /// steering. See the `approval` node below.
     pub require_review_approval: bool,
+    /// Optional observability sink for the graph's run/node/route events.
+    ///
+    /// Host-supplied and `None` by default: this crate emits its own `tracing`
+    /// diagnostics for the graph runtime, and a host that wants delegation runs
+    /// journalled into its own observability surface attaches a sink here
+    /// rather than the module reaching for a host-specific logger.
+    pub event_sink: Option<Arc<dyn GraphEventSink>>,
 }
 
 impl Default for DelegationConfig {
@@ -175,6 +182,7 @@ impl Default for DelegationConfig {
             thread_id: None,
             cancel: CancellationToken::new(),
             require_review_approval: false,
+            event_sink: None,
         }
     }
 }

--- a/src/graph/delegation/graph.rs
+++ b/src/graph/delegation/graph.rs
@@ -1,3 +1,24 @@
+//! Structure of the delegation graph: nodes, routing, the state reducer, and
+//! the recursion/retry policy that bounds the `execute` ⇄ `review` loop.
+
+use std::future::Future;
+
+use serde_json::json;
+
+use super::run::decision_is_approve;
+use super::types::{
+    DelegationConfig, DelegationStage, DelegationStageOutput, DelegationState, DelegationUpdate,
+    StepRecord,
+};
+use crate::CancellationToken;
+use crate::graph::export::GraphTopology;
+use crate::graph::recursion::RecursionPolicy;
+use crate::graph::{
+    ClosureStateReducer, Command, CompiledGraph, END, GraphBuilder, Interrupt, NodeContext,
+    NodeResult,
+};
+use crate::harness::retry::RetryPolicy;
+
 /// Build (but do not run) the delegation `CompiledGraph`. Shared by
 /// [`run_delegation`] and [`delegation_graph_topology`] so the graph's structure
 /// has one definition.

--- a/src/graph/delegation/graph.rs
+++ b/src/graph/delegation/graph.rs
@@ -230,8 +230,13 @@ where
             let final_text = if s.cancelled {
                 format!("cancelled after {} execution(s)", s.executions.len())
             } else if s.denied {
+                // `s.denied` is set only by `DelegationUpdate::HumanDecision`
+                // (the durable human-approval gate) — the in-graph reviewer
+                // never sets it: a not-approved review routes back to
+                // `execute` and only increments `revisions`. Attribute the
+                // denial to the actor that can actually produce it.
                 format!(
-                    "denied by reviewer after {} execution(s)",
+                    "denied by approver after {} execution(s)",
                     s.executions.len()
                 )
             } else {

--- a/src/graph/delegation/mod.rs
+++ b/src/graph/delegation/mod.rs
@@ -1,0 +1,73 @@
+//! Multi-stage sub-agent delegation as a durable, resumable state graph.
+//!
+//! Where a single harness call drives *one* agent turn, this module composes
+//! several sub-agent stages into a checkpointed state machine — the graph-native
+//! alternative to ad-hoc sub-agent chaining:
+//!
+//! ```text
+//!   plan ─▶ execute ─▶ review ──approved/maxed──▶ finalize ─▶ END
+//!             ▲                   │
+//!             └─────revise────────┘
+//! ```
+//!
+//! It exercises most of the graph layer:
+//! - **conditional routing** — `review` returns a [`Command`](crate::graph::Command)
+//!   routing to `execute` (revise) or `finalize` (done) based on the stage result;
+//! - **recursion bounds** — a [`RecursionPolicy`](crate::graph::RecursionPolicy)
+//!   caps the `execute` ⇄ `review` loop as a backstop to the in-state
+//!   `revisions` counter;
+//! - **durable checkpoint/resume** — an optional
+//!   [`Checkpointer`](crate::graph::Checkpointer) persists the typed
+//!   [`DelegationState`] at every super-step boundary, so a crashed or paused
+//!   run resumes from its last node;
+//! - **human-in-the-loop** — with [`DelegationConfig::require_review_approval`]
+//!   an approved review parks on a durable
+//!   [`Interrupt`](crate::graph::Interrupt) that survives a process restart and
+//!   is released by [`resume_delegation`];
+//! - **cooperative cancellation** — a
+//!   [`CancellationToken`](crate::CancellationToken) short-circuits the pipeline
+//!   to `finalize` at the next node boundary.
+//!
+//! # The per-stage worker is injected
+//!
+//! [`run_delegation`] and friends take a `run_stage` closure, so this module owns
+//! the orchestration mechanics and nothing about *how* a stage runs. A host
+//! passes a closure dispatching each [`DelegationStage`] to its own sub-agent
+//! runner; tests pass a deterministic mock.
+//!
+//! # [`DelegationState`] is an on-disk format
+//!
+//! Checkpointed state is read back by a later process — potentially a later
+//! release. [`CURRENT_SCHEMA_VERSION`] stamps fresh runs and
+//! [`run_or_resume_delegation`] expires any checkpoint below it rather than
+//! misreading a stale shape. Changing a field name, a `#[serde(...)]` attribute,
+//! or a default breaks resume for existing installations; `test.rs` pins the
+//! exact serialized JSON so such a change fails loudly. See `README.md`.
+//!
+//! # Entry points
+//!
+//! - [`run_delegation`] — run to completion, return the terminal state. The
+//!   convenience wrapper for the non-gated shape.
+//! - [`run_delegation_durable`] — run, reporting whether it finalized or parked
+//!   on a human-approval interrupt.
+//! - [`run_or_resume_delegation`] — resume a thread's last checkpoint boundary
+//!   when one is live and compatible, else start fresh.
+//! - [`resume_delegation`] — deliver an approver's decision to a parked run.
+//! - [`delegation_graph_topology`] — structure-only export for inspection.
+
+mod graph;
+mod run;
+mod types;
+
+pub use graph::delegation_graph_topology;
+pub use run::{
+    deny_decision, resume_delegation, run_delegation, run_delegation_durable,
+    run_or_resume_delegation,
+};
+pub use types::{
+    CURRENT_SCHEMA_VERSION, DelegationConfig, DelegationOutcome, DelegationStage,
+    DelegationStageOutput, DelegationState, PendingApproval, StepRecord,
+};
+
+#[cfg(test)]
+mod test;

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -58,7 +58,8 @@ where
     // "delegation resume requires a thread_id"/"a checkpointer" — the pause
     // can never be released and the delegated work is stranded. Reject the
     // misconfiguration up front instead.
-    if config.require_review_approval && (config.checkpointer.is_none() || config.thread_id.is_none())
+    if config.require_review_approval
+        && (config.checkpointer.is_none() || config.thread_id.is_none())
     {
         return Err(
             "delegation human-approval gate (require_review_approval) requires both a \

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -2,7 +2,6 @@
 //! checkpoint classification that decides between the two.
 
 use std::future::Future;
-use std::sync::Arc;
 
 use serde_json::{Value, json};
 

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -1,3 +1,19 @@
+//! Driving the delegation graph: fresh runs, durable resumes, and the
+//! checkpoint classification that decides between the two.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use super::graph::build_delegation_graph;
+use super::types::{
+    CURRENT_SCHEMA_VERSION, DelegationConfig, DelegationOutcome, DelegationStage,
+    DelegationStageOutput, DelegationState, DelegationUpdate, PendingApproval,
+};
+use crate::graph::checkpoint::{Checkpoint, Checkpointer};
+use crate::graph::{Command, END};
+
 /// Run the plan→execute⇄review→finalize delegation graph, invoking `run_stage`
 /// for each stage. Returns the final [`DelegationState`].
 ///

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -2,8 +2,10 @@
 //! checkpoint classification that decides between the two.
 
 use std::future::Future;
+use std::sync::{Arc, OnceLock};
 
 use serde_json::{Value, json};
+use tokio::sync::Mutex;
 
 use super::graph::build_delegation_graph;
 use super::types::{
@@ -11,7 +13,20 @@ use super::types::{
     DelegationStageOutput, DelegationState, DelegationUpdate, PendingApproval,
 };
 use crate::graph::checkpoint::{Checkpoint, Checkpointer};
+use crate::graph::thread_locks::ThreadLockMap;
 use crate::graph::{Command, END};
+
+/// Serializes [`run_or_resume_delegation`]'s classify-then-dispatch critical
+/// section per thread (see the lock acquisition there for why). Same pattern
+/// as `graph::goals::store::thread_lock` / `graph::todos::store::thread_lock`
+/// — a weak-value map so an idle thread's mutex is reclaimed instead of
+/// leaking for the life of the process.
+fn thread_lock(thread_id: &str) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<ThreadLockMap> = OnceLock::new();
+    LOCKS
+        .get_or_init(|| ThreadLockMap::new("delegation run/resume lock map"))
+        .lock_for(thread_id)
+}
 
 /// Run the plan→execute⇄review→finalize delegation graph, invoking `run_stage`
 /// for each stage. Returns the final [`DelegationState`].

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -250,15 +250,24 @@ async fn prune_thread(cp: &dyn Checkpointer<DelegationState>, thread_id: &str) {
     }
 }
 
-/// Whether a `Checkpointer::get` error is a decode / shape-incompatibility (safe
-/// to expire the checkpoint) rather than an operational failure (SQLite busy /
-/// I/O / poisoned lock — must not silently restart durable work). The vendored
-/// `SqliteCheckpointer` reports both as `TinyAgentsError::Checkpoint(String)` but
-/// tags decode failures with a `"decode …"` context (`sqlite.rs`:
-/// `decode record` / `decode namespace` / `decode next_nodes`) — the only stable
-/// discriminator it exposes.
+/// Whether a `Checkpointer::get` error is a *positively identified* schema
+/// mismatch (safe to expire the checkpoint) rather than an operational failure
+/// (SQLite busy / I/O / poisoned lock) or ambiguous/likely corruption — either
+/// of which must propagate rather than silently discard the record.
+///
+/// Both backends (`checkpoint::file`, `checkpoint::sqlite`) route every decode
+/// failure through `checkpoint::decode_json_err`, which classifies the
+/// underlying `serde_json::Error` and tags the message `"decode [schema] …"`
+/// when the JSON parsed but didn't match the target type (a missing field, a
+/// renamed variant — exactly what a legacy or newer schema produces), or
+/// `"decode [corrupt] …"` when the bytes themselves were malformed or
+/// truncated (a write torn by a crash, disk corruption). Only the former is
+/// pruned here: matching on a bare `"decode"` substring previously expired a
+/// corrupted record exactly as readily as an outdated one, deleting the only
+/// evidence of the corruption and restarting the delegation from `plan`,
+/// potentially repeating already-completed execute-stage side effects.
 pub(super) fn is_incompatible_checkpoint_error(e: &crate::TinyAgentsError) -> bool {
-    matches!(e, crate::TinyAgentsError::Checkpoint(msg) if msg.contains("decode"))
+    matches!(e, crate::TinyAgentsError::Checkpoint(msg) if msg.contains("decode [schema]"))
 }
 
 /// Whether a loaded checkpoint still has work to resume: a non-finalized,

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -384,19 +384,24 @@ fn into_outcome(
 /// bare bool, or an object carrying `approved`/`decision` — so the existing
 /// decision contract routes into `Command::resume` unchanged.
 pub(super) fn decision_is_approve(decision: &Value) -> bool {
+    /// Recognised string spellings for an approval decision. Also used for
+    /// the object-shaped `{"decision": ..}` form below: a prefix check there
+    /// (`starts_with("approve")`) previously treated any unvalidated string
+    /// beginning with "approve" (e.g. an attacker- or bug-supplied
+    /// `"approve_not_authorized"`) as approval, releasing the durable
+    /// human-approval gate for a decision value nothing actually approved.
+    const APPROVE_STRINGS: &[&str] = &["approve_once", "approve_always_for_tool", "approve", "approved"];
+
     match decision {
         Value::Bool(b) => *b,
-        Value::String(s) => matches!(
-            s.as_str(),
-            "approve_once" | "approve_always_for_tool" | "approve" | "approved"
-        ),
+        Value::String(s) => APPROVE_STRINGS.contains(&s.as_str()),
         Value::Object(m) => {
             if let Some(b) = m.get("approved").and_then(Value::as_bool) {
                 return b;
             }
             m.get("decision")
                 .and_then(Value::as_str)
-                .map(|d| d.starts_with("approve"))
+                .map(|d| APPROVE_STRINGS.contains(&d))
                 .unwrap_or(false)
         }
         _ => false,

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -187,6 +187,18 @@ where
         return run_delegation_durable(config, run_stage).await;
     };
 
+    // Serialize checkpoint classification + the selected run/resume operation
+    // per thread. Without this, two concurrent callers for the same stable
+    // `thread_id` can both read the same checkpoint (or both observe none)
+    // before either starts executing — neither this wrapper nor the
+    // `CompiledGraph` run/resume entry points hold a per-thread lock across
+    // that gap on their own. Both would then run the same pending stage,
+    // duplicating execute-stage external side effects and producing
+    // competing checkpoint histories. The lock is held for the whole
+    // classify-then-dispatch critical section below, released on return.
+    let lock = thread_lock(&tid);
+    let _guard = lock.lock().await;
+
     match cp.get(tid.as_str(), None).await {
         // A checkpoint written under a schema version other than the current
         // one is expired rather than resumed/returned — its semantics may not

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -50,6 +50,23 @@ where
     F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
 {
+    // `require_review_approval` documents that it needs a checkpointer +
+    // thread_id (interrupts require durability). Without this check either
+    // may be absent and the graph still parks on the approval interrupt: no
+    // checkpoint is written, `into_outcome` fills `PendingApproval::thread_id`
+    // with an empty string, and `resume_delegation` then fails with
+    // "delegation resume requires a thread_id"/"a checkpointer" — the pause
+    // can never be released and the delegated work is stranded. Reject the
+    // misconfiguration up front instead.
+    if config.require_review_approval && (config.checkpointer.is_none() || config.thread_id.is_none())
+    {
+        return Err(
+            "delegation human-approval gate (require_review_approval) requires both a \
+             checkpointer and a thread_id"
+                .to_string(),
+        );
+    }
+
     let thread_id = config.thread_id.clone();
     let mut graph = build_delegation_graph(
         config.max_revisions,

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -447,7 +447,12 @@ pub(super) fn decision_is_approve(decision: &Value) -> bool {
     /// beginning with "approve" (e.g. an attacker- or bug-supplied
     /// `"approve_not_authorized"`) as approval, releasing the durable
     /// human-approval gate for a decision value nothing actually approved.
-    const APPROVE_STRINGS: &[&str] = &["approve_once", "approve_always_for_tool", "approve", "approved"];
+    const APPROVE_STRINGS: &[&str] = &[
+        "approve_once",
+        "approve_always_for_tool",
+        "approve",
+        "approved",
+    ];
 
     match decision {
         Value::Bool(b) => *b,

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -297,10 +297,21 @@ pub(super) fn is_incompatible_checkpoint_error(e: &crate::TinyAgentsError) -> bo
     matches!(e, crate::TinyAgentsError::Checkpoint(msg) if msg.contains("decode [schema]"))
 }
 
-/// Whether a loaded checkpoint still has work to resume: a non-finalized,
-/// non-cancelled run that still schedules a real (non-`END`) node.
+/// Whether a loaded checkpoint still has work to resume: a non-finalized run
+/// that still schedules a real (non-`END`) node.
+///
+/// Cancellation alone does NOT mean finalized: every cancellation route goes
+/// through `goto finalize` (see `graph.rs`), so a checkpoint can be
+/// `cancelled == true` with `final_output == None` and `next_nodes ==
+/// ["finalize"]` if the process stopped after the cancellation update was
+/// checkpointed but before `finalize` ran. Treating `cancelled` as an
+/// independent terminal signal classified that live boundary as terminal, so
+/// `run_or_resume_delegation` returned the run unfinished and never produced
+/// the cancellation summary. `final_output` — the one field `finalize`
+/// itself sets — is the actual terminal signal; the schedule is what decides
+/// whether there is still work to resume.
 fn checkpoint_is_resumable(checkpoint: &Checkpoint<DelegationState>) -> bool {
-    if checkpoint.state.final_output.is_some() || checkpoint.state.cancelled {
+    if checkpoint.state.final_output.is_some() {
         return false;
     }
     checkpoint.next_nodes.iter().any(|n| n.as_str() != END)

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -168,18 +168,27 @@ where
     };
 
     match cp.get(tid.as_str(), None).await {
-        // A checkpoint written under an older state schema (e.g. a pre-#3884
-        // record whose `executions` happened to be empty and so still decoded
-        // into `Vec<StepRecord>`) is expired rather than resumed/returned — its
-        // semantics may not match the current graph. This is what makes
-        // `schema_version` an actual guard, not just documentation, and closes
-        // the empty-`executions` gap that a decode failure alone cannot catch.
-        Ok(Some(checkpoint)) if checkpoint.state.schema_version < CURRENT_SCHEMA_VERSION => {
+        // A checkpoint written under a schema version other than the current
+        // one is expired rather than resumed/returned — its semantics may not
+        // match this binary's graph. This is what makes `schema_version` an
+        // actual guard, not just documentation, and closes the empty-
+        // `executions` gap that a decode failure alone cannot catch (e.g. a
+        // pre-#3884 record whose `executions` happened to be empty and so
+        // still decoded into `Vec<StepRecord>`).
+        //
+        // A version *greater* than `CURRENT_SCHEMA_VERSION` is rejected here
+        // too, not only a lesser one: during a rollback or a mixed-version
+        // deployment, serde can decode a checkpoint written by a newer binary
+        // by silently ignoring its added fields, and this older binary would
+        // then resume or return that state under outdated semantics. The
+        // guard must treat any version it does not explicitly recognize as
+        // incompatible, not merely an older one.
+        Ok(Some(checkpoint)) if checkpoint.state.schema_version != CURRENT_SCHEMA_VERSION => {
             tracing::warn!(
                 thread_id = %tid,
                 schema_version = checkpoint.state.schema_version,
                 current = CURRENT_SCHEMA_VERSION,
-                "[delegation] checkpoint predates the current state schema; pruning and starting fresh"
+                "[delegation] checkpoint schema version does not match the current binary; pruning and starting fresh"
             );
             prune_thread(cp.as_ref(), &tid).await;
             run_delegation_durable(config, run_stage).await

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -110,8 +110,10 @@ where
         approved,
         "[interrupt] resuming durable delegation graph with approval decision"
     );
-    let mut command = Command::default();
-    command.resume = Some(decision);
+    let command = Command {
+        resume: Some(decision),
+        ..Command::default()
+    };
     resume_graph(config, command, run_stage).await
 }
 

--- a/src/graph/delegation/run.rs
+++ b/src/graph/delegation/run.rs
@@ -22,6 +22,16 @@ use crate::graph::{Command, END};
 /// This is the non-gated convenience wrapper: with the default config
 /// (`require_review_approval = false`) the graph never interrupts, so the
 /// returned state is always terminal.
+///
+/// Rejects `require_review_approval = true` rather than silently discarding
+/// [`DelegationOutcome::pending`]: with the gate on, a legitimately
+/// configured run can still return at the durable approval interrupt with
+/// `final_output` unset. Returning only `.state` here would hand the caller
+/// an unfinished state with no indication that approval is pending — the
+/// caller loses the one signal that would tell it to call
+/// [`resume_delegation`]. Use [`run_delegation_durable`] (or
+/// [`run_or_resume_delegation`]) when the gate is on, and read
+/// `DelegationOutcome::pending`.
 pub async fn run_delegation<F, Fut>(
     config: DelegationConfig,
     run_stage: F,
@@ -30,6 +40,15 @@ where
     F: Fn(DelegationStage, DelegationState) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<DelegationStageOutput, String>> + Send + 'static,
 {
+    if config.require_review_approval {
+        return Err(
+            "run_delegation does not support require_review_approval=true (it would \
+             silently discard a pending durable approval interrupt); call \
+             run_delegation_durable or run_or_resume_delegation instead and read \
+             DelegationOutcome::pending"
+                .to_string(),
+        );
+    }
     Ok(run_delegation_durable(config, run_stage).await?.state)
 }
 

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -705,7 +705,7 @@ async fn cancelled_checkpoint_still_scheduling_finalize_is_resumed_not_terminal(
             schema_version: CURRENT_SCHEMA_VERSION,
             ..Default::default()
         },
-        next_nodes: vec![crate::graph::NodeId::from("finalize")],
+        next_nodes: vec![crate::harness::ids::NodeId::from("finalize")],
         completed_tasks: vec![],
         pending_writes: vec![],
         interrupts: vec![],

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -557,17 +557,29 @@ async fn checkpoint_below_current_schema_version_expires_to_fresh_run() {
 }
 
 #[test]
-fn incompatible_checkpoint_error_matches_decode_not_operational() {
+fn incompatible_checkpoint_error_matches_schema_not_corrupt_or_operational() {
     use crate::TinyAgentsError;
-    // Decode / shape-incompatibility → safe to expire.
+    // Positively identified schema mismatch → safe to expire.
     assert!(is_incompatible_checkpoint_error(
         &TinyAgentsError::Checkpoint(
-            "sqlite checkpointer: decode record: invalid type: string".to_string()
+            "sqlite checkpointer: decode [schema] record: invalid type: string".to_string()
         )
     ));
-    assert!(is_incompatible_checkpoint_error(
-        &TinyAgentsError::Checkpoint("sqlite checkpointer: decode next_nodes: eof".to_string())
+    assert!(is_incompatible_checkpoint_error(&TinyAgentsError::Checkpoint(
+        "sqlite checkpointer: decode [schema] next_nodes: missing field `foo`".to_string()
+    )));
+    // Ambiguous/likely corruption must NOT be treated as a safe-to-expire
+    // schema mismatch — deleting it would discard the only evidence of the
+    // corruption and silently restart the delegation from `plan`, potentially
+    // repeating already-completed execute-stage side effects.
+    assert!(!is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "sqlite checkpointer: decode [corrupt] record: EOF while parsing a value".to_string()
+        )
     ));
+    assert!(!is_incompatible_checkpoint_error(&TinyAgentsError::Checkpoint(
+        "file checkpointer: decode [corrupt] record: expected `,` or `}`".to_string()
+    )));
     // Operational failures must NOT be treated as incompatible (they must
     // propagate, not silently restart durable work).
     assert!(!is_incompatible_checkpoint_error(
@@ -581,6 +593,41 @@ fn incompatible_checkpoint_error_matches_decode_not_operational() {
     assert!(!is_incompatible_checkpoint_error(&TinyAgentsError::Resume(
         "no checkpoint".to_string()
     )));
+}
+
+#[test]
+fn decode_json_err_classifies_data_errors_as_schema_and_others_as_corrupt() {
+    use crate::graph::checkpoint::decode_json_err;
+
+    // `Category::Data`: syntactically valid JSON that doesn't match the
+    // target type — the shape a legacy or newer schema produces.
+    let data_err = serde_json::from_str::<u32>("\"not a number\"").unwrap_err();
+    assert_eq!(data_err.classify(), serde_json::error::Category::Data);
+    let wrapped = decode_json_err("sqlite checkpointer", "record", data_err);
+    assert!(
+        format!("{wrapped}").contains("decode [schema] record"),
+        "data-category decode errors must be tagged [schema]: {wrapped}"
+    );
+
+    // `Category::Eof`: the bytes were truncated — real corruption, not a
+    // schema difference.
+    let eof_err = serde_json::from_str::<serde_json::Value>("{\"a\":").unwrap_err();
+    assert_eq!(eof_err.classify(), serde_json::error::Category::Eof);
+    let wrapped = decode_json_err("file checkpointer", "record", eof_err);
+    assert!(
+        format!("{wrapped}").contains("decode [corrupt] record"),
+        "eof-category decode errors must be tagged [corrupt]: {wrapped}"
+    );
+
+    // `Category::Syntax`: malformed bytes — also corruption, not a schema
+    // difference.
+    let syntax_err = serde_json::from_str::<serde_json::Value>("{not json}").unwrap_err();
+    assert_eq!(syntax_err.classify(), serde_json::error::Category::Syntax);
+    let wrapped = decode_json_err("sqlite checkpointer", "record", syntax_err);
+    assert!(
+        format!("{wrapped}").contains("decode [corrupt] record"),
+        "syntax-category decode errors must be tagged [corrupt]: {wrapped}"
+    );
 }
 
 #[tokio::test]

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use super::run::is_incompatible_checkpoint_error;
+use super::run::{decision_is_approve, is_incompatible_checkpoint_error};
 use super::*;
 use crate::CancellationToken;
 use crate::graph::Interrupt;
@@ -655,6 +655,30 @@ async fn checkpoint_above_current_schema_version_also_expires_to_fresh_run() {
         Some("PLAN"),
         "re-planned from scratch, not resumed with the future-schema plan"
     );
+}
+
+#[test]
+fn decision_is_approve_rejects_unrecognized_string_prefixes() {
+    // Object-shaped decisions must be checked against the SAME allowlist as
+    // string-shaped ones, not a `starts_with("approve")` prefix check: an
+    // unvalidated JSON value like `{"decision":"approve_not_authorized"}`
+    // must not release the durable human-approval gate just because it
+    // begins with "approve".
+    assert!(!decision_is_approve(&json!({"decision": "approve_not_authorized"})));
+    assert!(!decision_is_approve(&json!({"decision": "approved_by_nobody"})));
+    assert!(!decision_is_approve(&json!("approve_not_authorized")));
+
+    // The real allowlisted spellings still approve, in both shapes.
+    assert!(decision_is_approve(&json!("approve_once")));
+    assert!(decision_is_approve(&json!("approve_always_for_tool")));
+    assert!(decision_is_approve(&json!({"decision": "approve_once"})));
+    assert!(decision_is_approve(&json!({"approved": true})));
+    assert!(decision_is_approve(&json!(true)));
+
+    // Denials and unrecognized shapes stay denials.
+    assert!(!decision_is_approve(&json!("deny")));
+    assert!(!decision_is_approve(&json!(false)));
+    assert!(!decision_is_approve(&json!(null)));
 }
 
 #[test]

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -681,6 +681,60 @@ fn decision_is_approve_rejects_unrecognized_string_prefixes() {
     assert!(!decision_is_approve(&json!(null)));
 }
 
+#[tokio::test]
+async fn cancelled_checkpoint_still_scheduling_finalize_is_resumed_not_terminal() {
+    // Every cancellation route goes through `goto finalize` (see
+    // `graph.rs`), so a checkpoint can be `cancelled == true` with
+    // `final_output == None` and `next_nodes == ["finalize"]` if the process
+    // stopped after the cancellation update was checkpointed but before
+    // `finalize` ran. Treating `cancelled` as its own terminal signal
+    // classified that live boundary as terminal and returned it unfinished,
+    // never producing the cancellation summary.
+    let dir = tempfile::tempdir().unwrap();
+    let seed: crate::graph::checkpoint::FileCheckpointer<DelegationState> =
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path());
+    let checkpoint = Checkpoint {
+        thread_id: "cancelled-mid-flight".to_string(),
+        checkpoint_id: "cp-cancel".to_string(),
+        run_id: None,
+        parent_checkpoint_id: None,
+        namespace: vec![],
+        state: DelegationState {
+            plan: Some("PLAN".to_string()),
+            cancelled: true,
+            schema_version: CURRENT_SCHEMA_VERSION,
+            ..Default::default()
+        },
+        next_nodes: vec![crate::graph::NodeId::from("finalize")],
+        completed_tasks: vec![],
+        pending_writes: vec![],
+        interrupts: vec![],
+        pending_activations: None,
+        barrier_arrivals: vec![],
+        metadata: json!({}),
+    };
+    seed.put(checkpoint)
+        .await
+        .expect("seed cancelled-but-not-finalized checkpoint");
+
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<DelegationState>::new(dir.path()));
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("cancelled-mid-flight".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("resumes to finalize");
+    assert!(
+        outcome.state.final_output.is_some(),
+        "must resume through finalize and produce a cancellation summary, not \
+         return the unfinished checkpoint verbatim"
+    );
+    assert!(outcome.state.cancelled);
+}
+
 #[test]
 fn incompatible_checkpoint_error_matches_schema_not_corrupt_or_operational() {
     use crate::TinyAgentsError;

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -157,6 +157,33 @@ async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
 }
 
 #[tokio::test]
+async fn run_delegation_rejects_require_review_approval() {
+    // `run_delegation` documents itself as the non-gated convenience wrapper
+    // that always returns a terminal state. With the gate on, a legitimately
+    // configured durable run can still return at the approval interrupt with
+    // `final_output` unset; discarding `DelegationOutcome::pending` (as
+    // `.state` alone does) would silently hand back an unfinished state with
+    // no signal that approval is pending. Reject the misuse instead of
+    // discarding it.
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
+    let config = DelegationConfig {
+        require_review_approval: true,
+        checkpointer: Some(cp),
+        thread_id: Some("hg-wrong-wrapper".to_string()),
+        ..DelegationConfig::default()
+    };
+    let err = run_delegation(config, flow_runner(0))
+        .await
+        .expect_err("must reject require_review_approval=true");
+    assert!(
+        err.contains("require_review_approval"),
+        "error should name the misuse: {err}"
+    );
+}
+
+#[tokio::test]
 async fn human_gated_without_checkpointer_or_thread_id_is_rejected() {
     // `require_review_approval` documents that it needs both a checkpointer
     // and a thread_id (interrupts require durability). Without this guard the

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -600,6 +600,63 @@ async fn checkpoint_below_current_schema_version_expires_to_fresh_run() {
     );
 }
 
+#[tokio::test]
+async fn checkpoint_above_current_schema_version_also_expires_to_fresh_run() {
+    // A checkpoint stamped with a schema version NEWER than this binary
+    // understands (e.g. written by a newer binary during a rollback, or in a
+    // mixed-version deployment) must be expired exactly like an older one, not
+    // resumed. Serde can decode a newer record just fine by ignoring fields it
+    // doesn't recognize, so an inequality check — not merely `<` — is what
+    // catches this: resuming it under this binary's older semantics would be
+    // silently wrong rather than loudly incompatible.
+    let dir = tempfile::tempdir().unwrap();
+    let seed: crate::graph::checkpoint::FileCheckpointer<DelegationState> =
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path());
+    let checkpoint = Checkpoint {
+        thread_id: "future-schema".to_string(),
+        checkpoint_id: "cp-future".to_string(),
+        run_id: None,
+        parent_checkpoint_id: None,
+        namespace: vec![],
+        state: DelegationState {
+            plan: Some("from-the-future".to_string()),
+            schema_version: CURRENT_SCHEMA_VERSION + 1,
+            ..Default::default()
+        },
+        next_nodes: vec![],
+        completed_tasks: vec![],
+        pending_writes: vec![],
+        interrupts: vec![],
+        pending_activations: None,
+        barrier_arrivals: vec![],
+        metadata: json!({}),
+    };
+    seed.put(checkpoint)
+        .await
+        .expect("seed future-schema checkpoint");
+
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<DelegationState>::new(dir.path()));
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("future-schema".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("expires + fresh");
+    assert!(outcome.state.final_output.is_some(), "fresh run completed");
+    assert_eq!(
+        outcome.state.schema_version, CURRENT_SCHEMA_VERSION,
+        "fresh run stamped the current version, not the future one"
+    );
+    assert_eq!(
+        outcome.state.plan.as_deref(),
+        Some("PLAN"),
+        "re-planned from scratch, not resumed with the future-schema plan"
+    );
+}
+
 #[test]
 fn incompatible_checkpoint_error_matches_schema_not_corrupt_or_operational() {
     use crate::TinyAgentsError;

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -1,0 +1,637 @@
+//! Unit tests for the delegation graph: the revision loop and its budget,
+//! cancellation, durable checkpoint/resume classification, the human-approval
+//! interrupt, and the on-disk shape of [`DelegationState`].
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+/// A reviewer that rejects the first `reject_first` executions, then approves,
+/// driving the execute⇄review revision loop.
+fn flow_runner(
+    reject_first: usize,
+) -> impl Fn(
+    DelegationStage,
+    DelegationState,
+) -> std::pin::Pin<
+    Box<dyn Future<Output = Result<DelegationStageOutput, String>> + Send>,
+> + Clone
+       + Send
+       + Sync
+       + 'static {
+    let reviews = Arc::new(AtomicUsize::new(0));
+    move |stage, _state| {
+        let reviews = reviews.clone();
+        Box::pin(async move {
+            match stage {
+                DelegationStage::Plan => Ok(DelegationStageOutput::done("PLAN")),
+                DelegationStage::Execute => Ok(DelegationStageOutput::done("EXEC")),
+                DelegationStage::Review => {
+                    let n = reviews.fetch_add(1, Ordering::SeqCst);
+                    Ok(DelegationStageOutput {
+                        text: format!("review-{n}"),
+                        approved: n >= reject_first,
+                        prompt: None,
+                    })
+                }
+            }
+        })
+    }
+}
+
+#[tokio::test]
+async fn approves_first_pass_no_revision() {
+    let state = run_delegation(DelegationConfig::default(), flow_runner(0))
+        .await
+        .expect("runs");
+    assert_eq!(state.plan.as_deref(), Some("PLAN"));
+    assert_eq!(state.executions.len(), 1, "one execution, no revision");
+    assert_eq!(state.executions[0].index, 0);
+    assert_eq!(state.executions[0].result, "EXEC");
+    assert_eq!(state.reviews.len(), 1);
+    assert_eq!(state.revisions, 0);
+    assert!(state.approved);
+    assert_eq!(state.final_output.as_deref(), Some("EXEC"));
+}
+
+#[tokio::test]
+async fn revises_then_approves() {
+    // Reject the first review → one revision (a second execute+review).
+    let state = run_delegation(DelegationConfig::default(), flow_runner(1))
+        .await
+        .expect("runs");
+    assert_eq!(state.executions.len(), 2, "initial + one revised execution");
+    assert_eq!(state.reviews.len(), 2);
+    assert_eq!(state.revisions, 1);
+    assert!(state.approved);
+}
+
+#[tokio::test]
+async fn revision_budget_caps_a_never_approving_reviewer() {
+    // Reviewer never approves on its own; the max_revisions cap forces finalize.
+    let config = DelegationConfig {
+        max_revisions: 2,
+        ..DelegationConfig::default()
+    };
+    let state = run_delegation(config, flow_runner(999))
+        .await
+        .expect("runs");
+    // revisions counted: 1st review (rev 1), 2nd review (rev 2), 3rd review
+    // hits revisions>=2 → forced approve. So 3 executions, 3 reviews.
+    assert_eq!(state.revisions, 2, "stops at the revision budget");
+    assert!(state.approved, "forced-approved at the cap");
+    assert_eq!(state.executions.len(), 3);
+}
+
+#[tokio::test]
+async fn cancellation_short_circuits_to_finalize() {
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let ran = Arc::new(Mutex::new(Vec::<DelegationStage>::new()));
+    let ran2 = ran.clone();
+    let runner = move |stage: DelegationStage, _s: DelegationState| {
+        let ran = ran2.clone();
+        Box::pin(async move {
+            ran.lock().unwrap().push(stage);
+            Ok::<_, String>(DelegationStageOutput::done("X"))
+        }) as std::pin::Pin<Box<dyn Future<Output = _> + Send>>
+    };
+    let config = DelegationConfig {
+        cancel,
+        ..DelegationConfig::default()
+    };
+    let state = run_delegation(config, runner).await.expect("runs");
+    assert!(state.cancelled, "state flagged cancelled");
+    assert!(state.final_output.is_some());
+    assert!(
+        ran.lock().unwrap().is_empty(),
+        "no stage worker ran once cancelled at the plan boundary"
+    );
+}
+
+#[tokio::test]
+async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    let make_config = || DelegationConfig {
+        require_review_approval: true,
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("hg-approve".to_string()),
+        ..DelegationConfig::default()
+    };
+
+    // First pass: reviewer approves on the first review, so the run reaches
+    // the durable human-approval gate and parks on an interrupt.
+    let outcome = run_delegation_durable(make_config(), flow_runner(0))
+        .await
+        .expect("runs");
+    let pending = outcome.pending.expect("parked on the approval interrupt");
+    assert_eq!(pending.node, "approval");
+    assert_eq!(pending.thread_id, "hg-approve");
+    assert!(
+        outcome.state.final_output.is_none(),
+        "must not finalize while paused for human approval"
+    );
+
+    // Simulated process restart: `resume_delegation` rebuilds a fresh graph
+    // from the same checkpointer + thread and re-enters via Command::resume.
+    let resumed = resume_delegation(make_config(), json!("approve_once"), flow_runner(0))
+        .await
+        .expect("resumes");
+    assert!(resumed.pending.is_none(), "resume clears the pause");
+    assert_eq!(resumed.state.human_approved, Some(true));
+    assert!(!resumed.state.denied);
+    assert!(
+        resumed.state.final_output.is_some(),
+        "resumes from checkpoint to finalize"
+    );
+}
+
+#[tokio::test]
+async fn ttl_expiry_resume_with_deny_blocks_the_result() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    let make_config = || DelegationConfig {
+        require_review_approval: true,
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("hg-deny".to_string()),
+        ..DelegationConfig::default()
+    };
+
+    let outcome = run_delegation_durable(make_config(), flow_runner(0))
+        .await
+        .expect("runs");
+    assert!(outcome.pending.is_some(), "parks awaiting approval");
+
+    // TTL expiry → resume-with-deny preserves the timeout-deny behavior.
+    let resumed = resume_delegation(make_config(), deny_decision(), flow_runner(0))
+        .await
+        .expect("resumes");
+    assert_eq!(resumed.state.human_approved, Some(false));
+    assert!(resumed.state.denied, "deny is honoured as a blocked result");
+    assert!(
+        !resumed.state.approved,
+        "human deny overrides the reviewer's in-graph approval"
+    );
+    assert!(resumed
+        .state
+        .final_output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("denied"));
+}
+
+#[tokio::test]
+async fn durable_checkpointer_persists_thread_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    let config = DelegationConfig {
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("run-1".to_string()),
+        ..DelegationConfig::default()
+    };
+    let state = run_delegation(config, flow_runner(1)).await.expect("runs");
+    assert!(state.approved);
+    // The checkpointer recorded the run under its thread id.
+    let threads = cp.list_threads().await.expect("list threads");
+    assert!(
+        threads.iter().any(|t| t == "run-1"),
+        "thread persisted, saw {threads:?}"
+    );
+    let checkpoints = cp.list("run-1").await.expect("list checkpoints");
+    assert!(
+        !checkpoints.is_empty(),
+        "at least one super-step boundary checkpoint persisted"
+    );
+}
+
+/// The boxed-future type every inline test runner returns.
+type BoxedStageFut =
+    std::pin::Pin<Box<dyn Future<Output = Result<DelegationStageOutput, String>> + Send>>;
+
+#[tokio::test]
+async fn execution_records_capture_index_and_prompt() {
+    // A worker that surfaces an execute prompt; assert the per-step record
+    // carries index + prompt + result (issue #3884).
+    let runner = move |stage: DelegationStage, _s: DelegationState| {
+        Box::pin(async move {
+            match stage {
+                DelegationStage::Plan => Ok(DelegationStageOutput::done("PLAN")),
+                DelegationStage::Execute => Ok(DelegationStageOutput {
+                    text: "EXEC".to_string(),
+                    approved: true,
+                    prompt: Some("EXEC-PROMPT".to_string()),
+                }),
+                DelegationStage::Review => Ok(DelegationStageOutput {
+                    text: "APPROVE".to_string(),
+                    approved: true,
+                    prompt: None,
+                }),
+            }
+        }) as BoxedStageFut
+    };
+    let state = run_delegation(DelegationConfig::default(), runner)
+        .await
+        .expect("runs");
+    assert_eq!(state.executions.len(), 1);
+    assert_eq!(state.executions[0].index, 0);
+    assert_eq!(state.executions[0].result, "EXEC");
+    assert_eq!(state.executions[0].prompt, "EXEC-PROMPT");
+}
+
+#[test]
+fn legacy_string_executions_do_not_deserialize_into_step_records() {
+    // A pre-#3884 checkpoint stored `executions` as a flat string array. It
+    // must fail to load into the new `Vec<StepRecord>` — which is exactly
+    // what makes `run_or_resume_delegation` expire the stale checkpoint
+    // instead of misreading it.
+    let legacy = r#"{"plan":"P","executions":["raw a","raw b"],"reviews":[],"revisions":0,"approved":true,"final_output":null,"cancelled":false}"#;
+    assert!(serde_json::from_str::<DelegationState>(legacy).is_err());
+}
+
+#[test]
+fn schema_version_defaults_to_zero_and_step_records_round_trip() {
+    // A pre-versioned record (no `schema_version`) loads as version 0.
+    let unversioned = r#"{"plan":null,"executions":[],"reviews":[],"revisions":0,"approved":false,"final_output":null,"cancelled":false}"#;
+    let s: DelegationState = serde_json::from_str(unversioned).expect("loads");
+    assert_eq!(s.schema_version, 0);
+
+    // A fresh run stamps the current version and round-trips step records.
+    let mut fresh = DelegationState::new_run();
+    assert_eq!(fresh.schema_version, CURRENT_SCHEMA_VERSION);
+    fresh.executions.push(StepRecord {
+        index: 0,
+        prompt: "P".to_string(),
+        result: "R".to_string(),
+    });
+    let json = serde_json::to_string(&fresh).expect("serializes");
+    let back: DelegationState = serde_json::from_str(&json).expect("round-trips");
+    assert_eq!(back.schema_version, CURRENT_SCHEMA_VERSION);
+    assert_eq!(back.executions[0].result, "R");
+    assert_eq!(back.executions[0].prompt, "P");
+}
+
+#[tokio::test]
+async fn run_or_resume_starts_fresh_without_a_checkpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("fresh-1".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("runs fresh");
+    assert!(outcome.state.final_output.is_some());
+    assert_eq!(outcome.state.executions.len(), 1);
+    assert_eq!(outcome.state.schema_version, CURRENT_SCHEMA_VERSION);
+}
+
+#[tokio::test]
+async fn run_or_resume_continues_from_last_boundary_after_a_crash() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    // Count stage invocations across BOTH the crashed run and the resume, to
+    // prove plan/execute are NOT re-run on resume.
+    let plan_runs = Arc::new(AtomicUsize::new(0));
+    let exec_runs = Arc::new(AtomicUsize::new(0));
+    let review_runs = Arc::new(AtomicUsize::new(0));
+    let make_runner = |crash_first_review: bool| {
+        let plan_runs = plan_runs.clone();
+        let exec_runs = exec_runs.clone();
+        let review_runs = review_runs.clone();
+        move |stage: DelegationStage, _s: DelegationState| {
+            let plan_runs = plan_runs.clone();
+            let exec_runs = exec_runs.clone();
+            let review_runs = review_runs.clone();
+            Box::pin(async move {
+                match stage {
+                    DelegationStage::Plan => {
+                        plan_runs.fetch_add(1, Ordering::SeqCst);
+                        Ok(DelegationStageOutput::done("PLAN"))
+                    }
+                    DelegationStage::Execute => {
+                        exec_runs.fetch_add(1, Ordering::SeqCst);
+                        Ok(DelegationStageOutput {
+                            text: "EXEC".to_string(),
+                            approved: true,
+                            prompt: Some("EXEC-PROMPT".to_string()),
+                        })
+                    }
+                    DelegationStage::Review => {
+                        let n = review_runs.fetch_add(1, Ordering::SeqCst);
+                        if crash_first_review && n == 0 {
+                            Err("simulated crash during review".to_string())
+                        } else {
+                            Ok(DelegationStageOutput {
+                                text: "APPROVE".to_string(),
+                                approved: true,
+                                prompt: None,
+                            })
+                        }
+                    }
+                }
+            }) as BoxedStageFut
+        }
+    };
+    let make_config = || DelegationConfig {
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("resume-1".to_string()),
+        ..DelegationConfig::default()
+    };
+
+    // Run 1: crashes during the first review. plan + execute completed and
+    // were checkpointed at their super-step boundaries; the run returns Err.
+    let crashed = run_or_resume_delegation(make_config(), make_runner(true)).await;
+    assert!(crashed.is_err(), "first run crashes at review");
+    assert_eq!(plan_runs.load(Ordering::SeqCst), 1);
+    assert_eq!(exec_runs.load(Ordering::SeqCst), 1);
+
+    // Run 2 (resume): a resumable checkpoint exists → re-enter at the pending
+    // node (review), NOT plan; plan/execute must not run again.
+    let resumed = run_or_resume_delegation(make_config(), make_runner(false))
+        .await
+        .expect("resumes");
+    assert!(
+        resumed.state.final_output.is_some(),
+        "resumed run finalizes"
+    );
+    assert_eq!(
+        plan_runs.load(Ordering::SeqCst),
+        1,
+        "plan not re-run on resume"
+    );
+    assert_eq!(
+        exec_runs.load(Ordering::SeqCst),
+        1,
+        "execute not re-run on resume"
+    );
+    assert_eq!(
+        resumed.state.executions.len(),
+        1,
+        "the pre-crash execution survived; no duplicate"
+    );
+    assert_eq!(resumed.state.executions[0].result, "EXEC");
+}
+
+#[tokio::test]
+async fn run_or_resume_is_idempotent_on_a_finalized_thread() {
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
+    );
+    let stage_runs = Arc::new(AtomicUsize::new(0));
+    let make_runner = || {
+        let stage_runs = stage_runs.clone();
+        move |stage: DelegationStage, _s: DelegationState| {
+            let stage_runs = stage_runs.clone();
+            Box::pin(async move {
+                stage_runs.fetch_add(1, Ordering::SeqCst);
+                match stage {
+                    DelegationStage::Review => Ok(DelegationStageOutput {
+                        text: "APPROVE".to_string(),
+                        approved: true,
+                        prompt: None,
+                    }),
+                    _ => Ok(DelegationStageOutput::done("X")),
+                }
+            }) as BoxedStageFut
+        }
+    };
+    let make_config = || DelegationConfig {
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("done-1".to_string()),
+        ..DelegationConfig::default()
+    };
+
+    let first = run_or_resume_delegation(make_config(), make_runner())
+        .await
+        .expect("runs");
+    assert!(first.state.final_output.is_some());
+    let after_first = stage_runs.load(Ordering::SeqCst);
+    assert!(after_first > 0, "the first run invoked stage workers");
+
+    // Re-invoke the SAME thread: a terminal checkpoint → return the finalized
+    // state without re-running any stage worker.
+    let second = run_or_resume_delegation(make_config(), make_runner())
+        .await
+        .expect("idempotent");
+    assert!(second.state.final_output.is_some());
+    assert_eq!(
+        stage_runs.load(Ordering::SeqCst),
+        after_first,
+        "no stage worker re-ran on a finalized thread"
+    );
+}
+
+#[tokio::test]
+async fn incompatible_checkpoint_expires_to_a_fresh_run() {
+    // A pre-#3884 checkpoint (executions as `Vec<String>`) left in the store
+    // must not crash a resume: `run_or_resume_delegation` expires it and runs
+    // fresh, never panicking or surfacing the decode error.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct LegacyState {
+        plan: Option<String>,
+        executions: Vec<String>,
+        reviews: Vec<String>,
+        revisions: usize,
+        approved: bool,
+        final_output: Option<String>,
+        cancelled: bool,
+    }
+    let dir = tempfile::tempdir().unwrap();
+    // Seed the store as the OLD state type under the thread.
+    let legacy_cp: crate::graph::checkpoint::FileCheckpointer<LegacyState> =
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path());
+    let legacy = Checkpoint {
+        thread_id: "legacy-1".to_string(),
+        checkpoint_id: "cp-legacy".to_string(),
+        run_id: None,
+        parent_checkpoint_id: None,
+        namespace: vec![],
+        state: LegacyState {
+            plan: Some("old".to_string()),
+            executions: vec!["a".to_string(), "b".to_string()],
+            reviews: vec![],
+            revisions: 0,
+            approved: true,
+            final_output: None,
+            cancelled: false,
+        },
+        next_nodes: vec![],
+        completed_tasks: vec![],
+        pending_writes: vec![],
+        interrupts: vec![],
+        pending_activations: None,
+        barrier_arrivals: vec![],
+        metadata: json!({}),
+    };
+    legacy_cp.put(legacy).await.expect("seed legacy checkpoint");
+
+    // Reopen the SAME store as the current state type and resume: the
+    // undecodable record is expired and a fresh run completes.
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
+            DelegationState,
+        >::new(dir.path()));
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("legacy-1".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("expires stale checkpoint and runs fresh");
+    assert!(outcome.state.final_output.is_some(), "fresh run completed");
+    assert_eq!(outcome.state.executions.len(), 1);
+    assert_eq!(outcome.state.executions[0].result, "EXEC");
+}
+
+#[tokio::test]
+async fn checkpoint_below_current_schema_version_expires_to_fresh_run() {
+    // A decodable but OLD-schema checkpoint (schema_version defaults to 0 —
+    // e.g. a pre-#3884 record whose executions happened to be empty) must be
+    // expired, not resumed: `schema_version` is a real guard, not just a doc.
+    let dir = tempfile::tempdir().unwrap();
+    let seed: crate::graph::checkpoint::FileCheckpointer<DelegationState> =
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path());
+    let checkpoint = Checkpoint {
+        thread_id: "old-schema".to_string(),
+        checkpoint_id: "cp-old".to_string(),
+        run_id: None,
+        parent_checkpoint_id: None,
+        namespace: vec![],
+        state: DelegationState {
+            plan: Some("stale".to_string()),
+            ..Default::default()
+        },
+        next_nodes: vec![],
+        completed_tasks: vec![],
+        pending_writes: vec![],
+        interrupts: vec![],
+        pending_activations: None,
+        barrier_arrivals: vec![],
+        metadata: json!({}),
+    };
+    assert_eq!(
+        checkpoint.state.schema_version, 0,
+        "an un-stamped record is version 0"
+    );
+    seed.put(checkpoint)
+        .await
+        .expect("seed old-schema checkpoint");
+
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
+            DelegationState,
+        >::new(dir.path()));
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("old-schema".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("expires + fresh");
+    assert!(outcome.state.final_output.is_some(), "fresh run completed");
+    assert_eq!(
+        outcome.state.schema_version, CURRENT_SCHEMA_VERSION,
+        "fresh run stamped the current version"
+    );
+    assert_eq!(
+        outcome.state.plan.as_deref(),
+        Some("PLAN"),
+        "re-planned from scratch, not resumed with the stale plan"
+    );
+}
+
+#[test]
+fn incompatible_checkpoint_error_matches_decode_not_operational() {
+    use crate::TinyAgentsError;
+    // Decode / shape-incompatibility → safe to expire.
+    assert!(is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "sqlite checkpointer: decode record: invalid type: string".to_string()
+        )
+    ));
+    assert!(is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint("sqlite checkpointer: decode next_nodes: eof".to_string())
+    ));
+    // Operational failures must NOT be treated as incompatible (they must
+    // propagate, not silently restart durable work).
+    assert!(!is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "sqlite checkpointer: query latest checkpoint: database is locked".to_string()
+        )
+    ));
+    assert!(!is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "sqlite checkpointer: connection lock poisoned".to_string()
+        )
+    ));
+    assert!(!is_incompatible_checkpoint_error(&TinyAgentsError::Resume(
+        "no checkpoint".to_string()
+    )));
+}
+
+#[tokio::test]
+async fn terminal_checkpoint_with_a_pending_interrupt_surfaces_it() {
+    // A terminal-classified checkpoint that still carries an interrupt must
+    // surface it, not silently drop `pending`. (The live routing never
+    // produces this shape; the terminal branch is defensive.)
+    let dir = tempfile::tempdir().unwrap();
+    let seed: crate::graph::checkpoint::FileCheckpointer<DelegationState> =
+        crate::graph::checkpoint::FileCheckpointer::new(dir.path());
+    let mut state = DelegationState::new_run();
+    state.final_output = Some("done".to_string());
+    let checkpoint = Checkpoint {
+        thread_id: "terminal-interrupt".to_string(),
+        checkpoint_id: "cp-ti".to_string(),
+        run_id: None,
+        parent_checkpoint_id: None,
+        namespace: vec![],
+        state,
+        next_nodes: vec![],
+        completed_tasks: vec![],
+        pending_writes: vec![],
+        interrupts: vec![Interrupt::with_id(
+            "intr-1",
+            "approval",
+            json!({ "kind": "delegation_review" }),
+        )],
+        pending_activations: None,
+        barrier_arrivals: vec![],
+        metadata: json!({}),
+    };
+    seed.put(checkpoint).await.expect("seed terminal+interrupt");
+
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
+            DelegationState,
+        >::new(dir.path()));
+    let config = DelegationConfig {
+        checkpointer: Some(cp),
+        thread_id: Some("terminal-interrupt".to_string()),
+        ..DelegationConfig::default()
+    };
+    let outcome = run_or_resume_delegation(config, flow_runner(0))
+        .await
+        .expect("terminal");
+    let pending = outcome
+        .pending
+        .expect("the carried interrupt is surfaced, not dropped");
+    assert_eq!(pending.node, "approval");
+    assert_eq!(pending.interrupt_id, "intr-1");
+    assert_eq!(outcome.state.final_output.as_deref(), Some("done"));
+}

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -13,7 +13,7 @@ use super::run::is_incompatible_checkpoint_error;
 use super::*;
 use crate::CancellationToken;
 use crate::graph::checkpoint::{Checkpoint, Checkpointer};
-use crate::graph::{Interrupt, NodeContext};
+use crate::graph::Interrupt;
 
 /// A reviewer that rejects the first `reject_first` executions, then approves,
 /// driving the execute⇄review revision loop.
@@ -643,4 +643,93 @@ async fn terminal_checkpoint_with_a_pending_interrupt_surfaces_it() {
     assert_eq!(pending.node, "approval");
     assert_eq!(pending.interrupt_id, "intr-1");
     assert_eq!(outcome.state.final_output.as_deref(), Some("done"));
+}
+
+/// Pins the exact serialized shape of a fully-populated [`DelegationState`].
+///
+/// `DelegationState` is an **on-disk checkpoint format**: installations carry
+/// persisted state written by an earlier release, and a resume decodes it with
+/// whatever the current binary declares. A renamed field, a changed
+/// `#[serde(...)]` attribute, a new field without `#[serde(default)]`, or a
+/// reordering that changes the emitted JSON silently breaks resume for those
+/// installations — the checkpoint decodes into something subtly different, or
+/// fails to decode at all and is expired, discarding in-flight work.
+///
+/// The literal below is the byte-for-byte output of the implementation this
+/// module was moved from, captured before the move. It is not merely a snapshot
+/// of current behaviour: it is the compatibility contract. A change here must be
+/// deliberate and paired with a [`CURRENT_SCHEMA_VERSION`] bump so
+/// `run_or_resume_delegation` expires older checkpoints rather than misreading
+/// them.
+#[test]
+fn serialized_state_shape_is_pinned() {
+    let state = DelegationState {
+        plan: Some("PLAN".into()),
+        executions: vec![
+            StepRecord {
+                index: 0,
+                prompt: "P0".into(),
+                result: "R0".into(),
+            },
+            StepRecord {
+                index: 1,
+                prompt: "P1".into(),
+                result: "R1".into(),
+            },
+        ],
+        reviews: vec!["review-0".into(), "review-1".into()],
+        revisions: 1,
+        approved: true,
+        final_output: Some("FINAL".into()),
+        cancelled: false,
+        human_approved: Some(true),
+        denied: false,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+
+    let json = serde_json::to_string(&state).expect("serializes");
+    assert_eq!(
+        json,
+        r#"{"plan":"PLAN","executions":[{"index":0,"prompt":"P0","result":"R0"},{"index":1,"prompt":"P1","result":"R1"}],"reviews":["review-0","review-1"],"revisions":1,"approved":true,"final_output":"FINAL","cancelled":false,"human_approved":true,"denied":false,"schema_version":1}"#,
+        "DelegationState's on-disk shape changed; see this test's doc comment"
+    );
+
+    // And it decodes back to an equal value, so the pin covers both directions.
+    let back: DelegationState = serde_json::from_str(&json).expect("round-trips");
+    assert_eq!(back.plan, state.plan);
+    assert_eq!(back.executions, state.executions);
+    assert_eq!(back.reviews, state.reviews);
+    assert_eq!(back.revisions, state.revisions);
+    assert_eq!(back.approved, state.approved);
+    assert_eq!(back.final_output, state.final_output);
+    assert_eq!(back.cancelled, state.cancelled);
+    assert_eq!(back.human_approved, state.human_approved);
+    assert_eq!(back.denied, state.denied);
+    assert_eq!(back.schema_version, state.schema_version);
+}
+
+/// A pre-versioned checkpoint — one written before `schema_version`,
+/// `human_approved` and `denied` existed — must still decode, taking the
+/// documented defaults. This is the half of the contract that lets
+/// `run_or_resume_delegation` *classify* a stale checkpoint (version `0`) rather
+/// than failing to read it at all.
+#[test]
+fn pre_versioned_state_decodes_with_documented_defaults() {
+    let legacy = r#"{"plan":"PLAN","executions":[],"reviews":[],"revisions":0,"approved":false,"final_output":null,"cancelled":false}"#;
+    let state: DelegationState = serde_json::from_str(legacy).expect("decodes");
+    assert_eq!(state.schema_version, 0, "defaults below CURRENT, so it expires");
+    assert_eq!(state.human_approved, None);
+    assert!(!state.denied);
+    assert!(state.schema_version < CURRENT_SCHEMA_VERSION);
+}
+
+/// The default state (a fresh, unstarted run) also has a pinned shape — it is
+/// what the very first checkpoint of a run serializes from.
+#[test]
+fn default_state_shape_is_pinned() {
+    let json = serde_json::to_string(&DelegationState::default()).expect("serializes");
+    assert_eq!(
+        json,
+        r#"{"plan":null,"executions":[],"reviews":[],"revisions":0,"approved":false,"final_output":null,"cancelled":false,"human_approved":null,"denied":false,"schema_version":0}"#
+    );
 }

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -666,9 +666,11 @@ fn incompatible_checkpoint_error_matches_schema_not_corrupt_or_operational() {
             "sqlite checkpointer: decode [schema] record: invalid type: string".to_string()
         )
     ));
-    assert!(is_incompatible_checkpoint_error(&TinyAgentsError::Checkpoint(
-        "sqlite checkpointer: decode [schema] next_nodes: missing field `foo`".to_string()
-    )));
+    assert!(is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "sqlite checkpointer: decode [schema] next_nodes: missing field `foo`".to_string()
+        )
+    ));
     // Ambiguous/likely corruption must NOT be treated as a safe-to-expire
     // schema mismatch — deleting it would discard the only evidence of the
     // corruption and silently restart the delegation from `plan`, potentially
@@ -678,9 +680,11 @@ fn incompatible_checkpoint_error_matches_schema_not_corrupt_or_operational() {
             "sqlite checkpointer: decode [corrupt] record: EOF while parsing a value".to_string()
         )
     ));
-    assert!(!is_incompatible_checkpoint_error(&TinyAgentsError::Checkpoint(
-        "file checkpointer: decode [corrupt] record: expected `,` or `}`".to_string()
-    )));
+    assert!(!is_incompatible_checkpoint_error(
+        &TinyAgentsError::Checkpoint(
+            "file checkpointer: decode [corrupt] record: expected `,` or `}`".to_string()
+        )
+    ));
     // Operational failures must NOT be treated as incompatible (they must
     // propagate, not silently restart durable work).
     assert!(!is_incompatible_checkpoint_error(

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -12,7 +12,8 @@ use serde_json::json;
 use super::run::is_incompatible_checkpoint_error;
 use super::*;
 use crate::CancellationToken;
-use crate::graph::checkpoint::Checkpointer;
+use crate::graph::checkpoint::{Checkpoint, Checkpointer};
+use crate::graph::{Interrupt, NodeContext};
 
 /// A reviewer that rejects the first `reject_first` executions, then approves,
 /// driving the execute⇄review revision loop.

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -157,6 +157,50 @@ async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
 }
 
 #[tokio::test]
+async fn human_gated_without_checkpointer_or_thread_id_is_rejected() {
+    // `require_review_approval` documents that it needs both a checkpointer
+    // and a thread_id (interrupts require durability). Without this guard the
+    // run would still park on the approval interrupt with nothing persisted,
+    // filling `PendingApproval::thread_id` with an empty string and stranding
+    // the pause forever (`resume_delegation` has no checkpoint/thread to
+    // resume from). Both misconfigurations must be rejected up front.
+    let neither = DelegationConfig {
+        require_review_approval: true,
+        ..DelegationConfig::default()
+    };
+    let err = run_delegation_durable(neither, flow_runner(0))
+        .await
+        .expect_err("must reject: no checkpointer, no thread_id");
+    assert!(
+        err.contains("require_review_approval"),
+        "error should name the misconfigured field: {err}"
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
+    let checkpointer_only = DelegationConfig {
+        require_review_approval: true,
+        checkpointer: Some(cp),
+        thread_id: None,
+        ..DelegationConfig::default()
+    };
+    run_delegation_durable(checkpointer_only, flow_runner(0))
+        .await
+        .expect_err("must reject: checkpointer without a thread_id");
+
+    let thread_only = DelegationConfig {
+        require_review_approval: true,
+        checkpointer: None,
+        thread_id: Some("hg-no-cp".to_string()),
+        ..DelegationConfig::default()
+    };
+    run_delegation_durable(thread_only, flow_runner(0))
+        .await
+        .expect_err("must reject: thread_id without a checkpointer");
+}
+
+#[tokio::test]
 async fn ttl_expiry_resume_with_deny_blocks_the_result() {
     let dir = tempfile::tempdir().unwrap();
     let cp: Arc<dyn Checkpointer<DelegationState>> =

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -749,8 +749,12 @@ fn decision_is_approve_rejects_unrecognized_string_prefixes() {
     // unvalidated JSON value like `{"decision":"approve_not_authorized"}`
     // must not release the durable human-approval gate just because it
     // begins with "approve".
-    assert!(!decision_is_approve(&json!({"decision": "approve_not_authorized"})));
-    assert!(!decision_is_approve(&json!({"decision": "approved_by_nobody"})));
+    assert!(!decision_is_approve(
+        &json!({"decision": "approve_not_authorized"})
+    ));
+    assert!(!decision_is_approve(
+        &json!({"decision": "approved_by_nobody"})
+    ));
     assert!(!decision_is_approve(&json!("approve_not_authorized")));
 
     // The real allowlisted spellings still approve, in both shapes.

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -12,8 +12,8 @@ use serde_json::json;
 use super::run::is_incompatible_checkpoint_error;
 use super::*;
 use crate::CancellationToken;
-use crate::graph::checkpoint::{Checkpoint, Checkpointer};
 use crate::graph::Interrupt;
+use crate::graph::checkpoint::{Checkpoint, Checkpointer};
 
 /// A reviewer that rejects the first `reject_first` executions, then approves,
 /// driving the execute⇄review revision loop.
@@ -22,12 +22,11 @@ fn flow_runner(
 ) -> impl Fn(
     DelegationStage,
     DelegationState,
-) -> std::pin::Pin<
-    Box<dyn Future<Output = Result<DelegationStageOutput, String>> + Send>,
-> + Clone
-       + Send
-       + Sync
-       + 'static {
+) -> std::pin::Pin<Box<dyn Future<Output = Result<DelegationStageOutput, String>> + Send>>
++ Clone
++ Send
++ Sync
++ 'static {
     let reviews = Arc::new(AtomicUsize::new(0));
     move |stage, _state| {
         let reviews = reviews.clone();
@@ -121,9 +120,8 @@ async fn cancellation_short_circuits_to_finalize() {
 #[tokio::test]
 async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     let make_config = || DelegationConfig {
         require_review_approval: true,
         checkpointer: Some(cp.clone()),
@@ -161,9 +159,8 @@ async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
 #[tokio::test]
 async fn ttl_expiry_resume_with_deny_blocks_the_result() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     let make_config = || DelegationConfig {
         require_review_approval: true,
         checkpointer: Some(cp.clone()),
@@ -186,20 +183,21 @@ async fn ttl_expiry_resume_with_deny_blocks_the_result() {
         !resumed.state.approved,
         "human deny overrides the reviewer's in-graph approval"
     );
-    assert!(resumed
-        .state
-        .final_output
-        .as_deref()
-        .unwrap_or_default()
-        .contains("denied"));
+    assert!(
+        resumed
+            .state
+            .final_output
+            .as_deref()
+            .unwrap_or_default()
+            .contains("denied")
+    );
 }
 
 #[tokio::test]
 async fn durable_checkpointer_persists_thread_state() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     let config = DelegationConfig {
         checkpointer: Some(cp.clone()),
         thread_id: Some("run-1".to_string()),
@@ -289,9 +287,8 @@ fn schema_version_defaults_to_zero_and_step_records_round_trip() {
 #[tokio::test]
 async fn run_or_resume_starts_fresh_without_a_checkpoint() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     let config = DelegationConfig {
         checkpointer: Some(cp),
         thread_id: Some("fresh-1".to_string()),
@@ -308,9 +305,8 @@ async fn run_or_resume_starts_fresh_without_a_checkpoint() {
 #[tokio::test]
 async fn run_or_resume_continues_from_last_boundary_after_a_crash() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     // Count stage invocations across BOTH the crashed run and the resume, to
     // prove plan/execute are NOT re-run on resume.
     let plan_runs = Arc::new(AtomicUsize::new(0));
@@ -397,9 +393,8 @@ async fn run_or_resume_continues_from_last_boundary_after_a_crash() {
 #[tokio::test]
 async fn run_or_resume_is_idempotent_on_a_finalized_thread() {
     let dir = tempfile::tempdir().unwrap();
-    let cp: Arc<dyn Checkpointer<DelegationState>> = Arc::new(
-        crate::graph::checkpoint::FileCheckpointer::new(dir.path()),
-    );
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
     let stage_runs = Arc::new(AtomicUsize::new(0));
     let make_runner = || {
         let stage_runs = stage_runs.clone();
@@ -491,9 +486,7 @@ async fn incompatible_checkpoint_expires_to_a_fresh_run() {
     // Reopen the SAME store as the current state type and resume: the
     // undecodable record is expired and a fresh run completes.
     let cp: Arc<dyn Checkpointer<DelegationState>> =
-        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
-            DelegationState,
-        >::new(dir.path()));
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<DelegationState>::new(dir.path()));
     let config = DelegationConfig {
         checkpointer: Some(cp),
         thread_id: Some("legacy-1".to_string()),
@@ -542,9 +535,7 @@ async fn checkpoint_below_current_schema_version_expires_to_fresh_run() {
         .expect("seed old-schema checkpoint");
 
     let cp: Arc<dyn Checkpointer<DelegationState>> =
-        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
-            DelegationState,
-        >::new(dir.path()));
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<DelegationState>::new(dir.path()));
     let config = DelegationConfig {
         checkpointer: Some(cp),
         thread_id: Some("old-schema".to_string()),
@@ -585,9 +576,7 @@ fn incompatible_checkpoint_error_matches_decode_not_operational() {
         )
     ));
     assert!(!is_incompatible_checkpoint_error(
-        &TinyAgentsError::Checkpoint(
-            "sqlite checkpointer: connection lock poisoned".to_string()
-        )
+        &TinyAgentsError::Checkpoint("sqlite checkpointer: connection lock poisoned".to_string())
     ));
     assert!(!is_incompatible_checkpoint_error(&TinyAgentsError::Resume(
         "no checkpoint".to_string()
@@ -626,9 +615,7 @@ async fn terminal_checkpoint_with_a_pending_interrupt_surfaces_it() {
     seed.put(checkpoint).await.expect("seed terminal+interrupt");
 
     let cp: Arc<dyn Checkpointer<DelegationState>> =
-        Arc::new(crate::graph::checkpoint::FileCheckpointer::<
-            DelegationState,
-        >::new(dir.path()));
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::<DelegationState>::new(dir.path()));
     let config = DelegationConfig {
         checkpointer: Some(cp),
         thread_id: Some("terminal-interrupt".to_string()),
@@ -717,7 +704,10 @@ fn serialized_state_shape_is_pinned() {
 fn pre_versioned_state_decodes_with_documented_defaults() {
     let legacy = r#"{"plan":"PLAN","executions":[],"reviews":[],"revisions":0,"approved":false,"final_output":null,"cancelled":false}"#;
     let state: DelegationState = serde_json::from_str(legacy).expect("decodes");
-    assert_eq!(state.schema_version, 0, "defaults below CURRENT, so it expires");
+    assert_eq!(
+        state.schema_version, 0,
+        "defaults below CURRENT, so it expires"
+    );
     assert_eq!(state.human_approved, None);
     assert!(!state.denied);
     assert!(state.schema_version < CURRENT_SCHEMA_VERSION);

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -2,9 +2,17 @@
 //! cancellation, durable checkpoint/resume classification, the human-approval
 //! interrupt, and the on-disk shape of [`DelegationState`].
 
-use super::*;
+use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::run::is_incompatible_checkpoint_error;
+use super::*;
+use crate::CancellationToken;
+use crate::graph::checkpoint::Checkpointer;
 
 /// A reviewer that rejects the first `reject_first` executions, then approves,
 /// driving the execute⇄review revision loop.

--- a/src/graph/delegation/test.rs
+++ b/src/graph/delegation/test.rs
@@ -157,6 +157,64 @@ async fn human_gated_run_parks_on_interrupt_then_resume_approves() {
 }
 
 #[tokio::test]
+async fn concurrent_calls_for_the_same_thread_never_overlap() {
+    // Two concurrent `run_or_resume_delegation` calls for the SAME stable
+    // thread_id must not both read the checkpoint and dispatch independently:
+    // without a per-thread lock held across classification and the selected
+    // run/resume operation, both can observe the same starting point and run
+    // the same pending stage concurrently, duplicating execute-stage
+    // external side effects and producing competing checkpoint histories.
+    let concurrent = Arc::new(AtomicUsize::new(0));
+    let max_concurrent = Arc::new(AtomicUsize::new(0));
+
+    let make_runner = || {
+        let concurrent = concurrent.clone();
+        let max_concurrent = max_concurrent.clone();
+        move |stage: DelegationStage, _s: DelegationState| {
+            let concurrent = concurrent.clone();
+            let max_concurrent = max_concurrent.clone();
+            Box::pin(async move {
+                let now = concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+                max_concurrent.fetch_max(now, Ordering::SeqCst);
+                // Widen the race window: without the per-thread lock, the
+                // second call's stages would start executing while the
+                // first call is still mid-flight.
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                concurrent.fetch_sub(1, Ordering::SeqCst);
+                let text = match stage {
+                    DelegationStage::Review => "approve".to_string(),
+                    _ => "ok".to_string(),
+                };
+                Ok::<_, String>(DelegationStageOutput::done(text))
+            }) as std::pin::Pin<Box<dyn Future<Output = _> + Send>>
+        }
+    };
+
+    let dir = tempfile::tempdir().unwrap();
+    let cp: Arc<dyn Checkpointer<DelegationState>> =
+        Arc::new(crate::graph::checkpoint::FileCheckpointer::new(dir.path()));
+    let make_config = || DelegationConfig {
+        checkpointer: Some(cp.clone()),
+        thread_id: Some("racing-thread".to_string()),
+        ..DelegationConfig::default()
+    };
+
+    let (r1, r2) = tokio::join!(
+        run_or_resume_delegation(make_config(), make_runner()),
+        run_or_resume_delegation(make_config(), make_runner()),
+    );
+    r1.expect("first call runs");
+    r2.expect("second call runs");
+
+    assert_eq!(
+        max_concurrent.load(Ordering::SeqCst),
+        1,
+        "the per-thread lock must serialize the two calls' stage execution; \
+         observed overlapping stage invocations"
+    );
+}
+
+#[tokio::test]
 async fn run_delegation_rejects_require_review_approval() {
     // `run_delegation` documents itself as the non-gated convenience wrapper
     // that always returns a terminal state. With the gate on, a legitimately

--- a/src/graph/delegation/types.rs
+++ b/src/graph/delegation/types.rs
@@ -117,7 +117,7 @@ pub struct DelegationState {
 impl DelegationState {
     /// A fresh run's initial state, stamped with the current schema version so
     /// its checkpoints are self-identifying.
-    fn new_run() -> Self {
+    pub(super) fn new_run() -> Self {
         Self {
             schema_version: CURRENT_SCHEMA_VERSION,
             ..Self::default()

--- a/src/graph/delegation/types.rs
+++ b/src/graph/delegation/types.rs
@@ -1,3 +1,19 @@
+//! Types threaded through the delegation graph.
+//!
+//! [`DelegationState`] is the durable one: it is what a [`Checkpointer`]
+//! persists, so its serde representation is an on-disk format. See the
+//! `schema_version` field and the module README before changing any field name,
+//! `#[serde(...)]` attribute, or default.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::CancellationToken;
+use crate::graph::checkpoint::Checkpointer;
+use crate::graph::stream::GraphEventSink;
+
 /// Which stage a delegation node is asking the injected worker to run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DelegationStage {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -13,7 +13,8 @@
 //! interrupts ([`command`]), a builder/compile contract ([`builder`]), a
 //! superstep executor ([`compiled`]), checkpointing ([`checkpoint`]),
 //! streaming/events ([`stream`]), run-status snapshots ([`status`]), graph
-//! export/visualization ([`export`]), subgraph embedding ([`subgraph`]), and
+//! export/visualization ([`export`]), dependency-DAG validation ([`dag`]),
+//! subgraph embedding ([`subgraph`]), and
 //! per-thread productivity primitives — a durable goal ([`goals`]) and a kanban
 //! task board ([`todos`], with its claim/heartbeat run log and dispatch policy)
 //! — exposed as harness tools.
@@ -26,6 +27,7 @@ pub mod channel;
 pub mod checkpoint;
 pub mod command;
 pub mod compiled;
+pub mod dag;
 pub mod delegation;
 pub mod export;
 pub mod goals;
@@ -60,6 +62,7 @@ pub use checkpoint::{
 };
 pub use command::{Command, Interrupt, NodeResult, RouteTarget, Send};
 pub use compiled::{CompiledGraph, GraphExecution, GraphInput, ResumeTarget, StateSnapshot};
+pub use dag::{DagIssue, DagNode, has_cycle, validate_dag};
 pub use delegation::{
     CURRENT_SCHEMA_VERSION as DELEGATION_SCHEMA_VERSION, DelegationConfig, DelegationOutcome,
     DelegationStage, DelegationStageOutput, DelegationState, PendingApproval, StepRecord,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -62,7 +62,7 @@ pub use checkpoint::{
 };
 pub use command::{Command, Interrupt, NodeResult, RouteTarget, Send};
 pub use compiled::{CompiledGraph, GraphExecution, GraphInput, ResumeTarget, StateSnapshot};
-pub use dag::{DagIssue, DagNode, has_cycle, validate_dag};
+pub use dag::{DagIssue, DagNode};
 pub use delegation::{
     CURRENT_SCHEMA_VERSION as DELEGATION_SCHEMA_VERSION, DelegationConfig, DelegationOutcome,
     DelegationStage, DelegationStageOutput, DelegationState, PendingApproval, StepRecord,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -26,6 +26,7 @@ pub mod channel;
 pub mod checkpoint;
 pub mod command;
 pub mod compiled;
+pub mod delegation;
 pub mod export;
 pub mod goals;
 pub mod observability;
@@ -59,6 +60,12 @@ pub use checkpoint::{
 };
 pub use command::{Command, Interrupt, NodeResult, RouteTarget, Send};
 pub use compiled::{CompiledGraph, GraphExecution, GraphInput, ResumeTarget, StateSnapshot};
+pub use delegation::{
+    CURRENT_SCHEMA_VERSION as DELEGATION_SCHEMA_VERSION, DelegationConfig, DelegationOutcome,
+    DelegationStage, DelegationStageOutput, DelegationState, PendingApproval, StepRecord,
+    delegation_graph_topology, deny_decision, resume_delegation, run_delegation,
+    run_delegation_durable, run_or_resume_delegation,
+};
 pub use export::{
     ChannelInfo, ConditionalEdgeInfo, EdgeInfo, GraphPolicySummary, GraphTopology, NodeInfo,
     NodePolicySummary, RouteInfo, ValidationReport, WaitingEdgeInfo, blueprint_to_json,

--- a/src/harness/tool/mod.rs
+++ b/src/harness/tool/mod.rs
@@ -15,6 +15,7 @@ pub mod injected;
 mod prompt;
 mod schema;
 mod schema_prepare;
+pub mod select;
 mod timeout;
 mod types;
 
@@ -33,6 +34,7 @@ pub use injected::{project_injected_arguments, strip_injected_arguments};
 pub use prompt::*;
 pub use schema::*;
 pub use schema_prepare::*;
+pub use select::*;
 pub use timeout::*;
 pub use tinytools::{
     ContextDetailOptions, context_detail_from_args, context_detail_from_args_with,

--- a/src/harness/tool/select/mod.rs
+++ b/src/harness/tool/select/mod.rs
@@ -176,22 +176,56 @@ fn detect_verbs(prompt: &str) -> HashSet<ToolVerb> {
     found
 }
 
-/// Classify a tool name (e.g. `"GITHUB_CREATE_A_PULL_REQUEST"`) by verb.
-/// Returns `None` when no verb prefix is recognised — such tools are kept as
-/// neutral by the gate.
+/// Whether `word` (already uppercased) is one of the recognised verb
+/// prefixes, tolerating a trailing plural `S` (`"CREATES"` -> `"CREATE"`).
+fn word_is_verb_prefix(word_upper: &str) -> bool {
+    let trimmed = word_upper.strip_suffix('S').unwrap_or(word_upper);
+    ALL_VERBS.iter().any(|&v| {
+        tool_verb_prefixes(v)
+            .iter()
+            .any(|&prefix| word_upper == prefix || trimmed == prefix)
+    })
+}
+
+/// Classify a tool name (e.g. `"GITHUB_CREATE_A_PULL_REQUEST"` or the
+/// canonical lowercase `"github_create_a_pull_request"`) by verb. Returns
+/// `None` when no verb prefix is recognised — such tools are kept as neutral
+/// by the gate.
+///
+/// `ToolSchema::name` is canonical `snake_case`, so segments are uppercased
+/// before comparison against the (uppercase) verb prefix tables — comparing
+/// raw case previously left every canonical lowercase name unclassified,
+/// silently disabling the verb gate for them.
+///
+/// The first segment is only stripped as an assumed vendor prefix when it is
+/// NOT itself a recognised verb. An unprefixed action slug (e.g.
+/// `"create_a_pull_request"`, no vendor segment) has its verb in that first
+/// position; unconditionally stripping it discarded the only verb present.
 fn tool_verb(name: &str) -> Option<ToolVerb> {
-    // Strip the vendor prefix (everything up to and including the first `_`).
-    let stripped = match name.split_once('_') {
-        Some((_, rest)) => rest,
-        None => name,
+    let first_segment = name.split('_').next().unwrap_or(name);
+    let first_is_verb = word_is_verb_prefix(&first_segment.to_ascii_uppercase());
+
+    // Strip an assumed vendor prefix (everything up to and including the
+    // first `_`) unless the first segment is itself the verb.
+    let stripped = if first_is_verb {
+        name
+    } else {
+        match name.split_once('_') {
+            Some((_, rest)) => rest,
+            None => name,
+        }
     };
+
     // Check the first two words.
     for word in stripped.split('_').take(2) {
-        let trimmed = word.strip_suffix('S').unwrap_or(word);
-        for &v in &ALL_VERBS {
-            for &prefix in tool_verb_prefixes(v) {
-                if word == prefix || trimmed == prefix {
-                    return Some(v);
+        let word_upper = word.to_ascii_uppercase();
+        if word_is_verb_prefix(&word_upper) {
+            let trimmed = word_upper.strip_suffix('S').unwrap_or(&word_upper);
+            for &v in &ALL_VERBS {
+                for &prefix in tool_verb_prefixes(v) {
+                    if word_upper == prefix || trimmed == prefix {
+                        return Some(v);
+                    }
                 }
             }
         }

--- a/src/harness/tool/select/mod.rs
+++ b/src/harness/tool/select/mod.rs
@@ -1,0 +1,299 @@
+//! Prompt-driven tool selection: rank a large tool catalogue against a task
+//! prompt and keep only the handful of tools that plausibly matter.
+//!
+//! A sub-agent bound to a large third-party catalogue is the motivating case.
+//! GitHub's action catalogue alone runs to ~500 entries; advertising every one
+//! of them balloons the prompt, dilutes the model's attention, and costs real
+//! money on every turn. The parent-refined task prompt is usually specific
+//! enough that a handful of actions are relevant, so a cheap local ranker can
+//! do the narrowing before the model ever sees the list.
+//!
+//! The ranker is a five-stage pipeline — no model load, pure CPU, stdlib only:
+//!
+//! 1. **Verb detection** — map the prompt to CRUD-ish intents
+//!    (`create`/`send`/`read`/`list`/`update`/`delete`/`merge`).
+//! 2. **Verb gate** — drop tools whose first-word verb conflicts with the
+//!    detected intent. Tools with a neutral prefix (e.g. `GITHUB_FIND_*`) are
+//!    kept as ambiguous.
+//! 3. **Query token expansion** — strip stopwords and expand common
+//!    abbreviations (`pr` → `pull request`, `dm` → `direct message`) so the
+//!    ranker can match casual phrasing against formal tool names.
+//! 4. **Weighted token overlap** — 3× weight on hits in the tool name, 1× on
+//!    hits in the description. Cheap, effective, explainable.
+//! 5. **Verb-alignment boost** — a small additive bonus when the tool's
+//!    first-word verb matches the detected intent, a penalty when it clearly
+//!    conflicts.
+//!
+//! The scoring is deliberately explainable rather than clever: it is a
+//! relevance ranker whose output decides what a model is allowed to see, so a
+//! reviewer must be able to read why a tool made the cut.
+//!
+//! Entry point: [`rank_tools_by_prompt`]. Callers should treat a thin result
+//! as no result — see [`MIN_CONFIDENT_HITS`].
+//!
+//! ```
+//! use tinyagents::harness::tool::{SelectableTool, rank_tools_by_prompt};
+//!
+//! let tools = [
+//!     SelectableTool::new("GITHUB_CREATE_A_PULL_REQUEST", "Creates a pull request."),
+//!     SelectableTool::new("GITHUB_DELETE_A_REPOSITORY", "Deletes a repository."),
+//! ];
+//! let hits = rank_tools_by_prompt("create a PR from my branch", &tools, 5);
+//! assert_eq!(hits, vec![0]);
+//! ```
+
+mod types;
+
+use std::collections::HashSet;
+
+pub use types::{SelectableTool, ToolVerb};
+
+/// Minimum number of hits the ranker must produce to be trusted. Below this,
+/// the caller should fall back to the unfiltered catalogue — a too-narrow
+/// selection is worse than no selection at all, because it starves the agent
+/// of the one tool it needed.
+pub const MIN_CONFIDENT_HITS: usize = 3;
+
+/// Rank `tools` against `prompt` and return indices into `tools` for the top
+/// `max_results` matches, ordered best-first.
+///
+/// Returns an empty `Vec` when `prompt` is blank, `tools` is empty, or no
+/// token hits are found. Callers should check the result against
+/// [`MIN_CONFIDENT_HITS`] and fall back to the unfiltered catalogue when it
+/// comes up short.
+pub fn rank_tools_by_prompt(
+    prompt: &str,
+    tools: &[SelectableTool<'_>],
+    max_results: usize,
+) -> Vec<usize> {
+    if prompt.trim().is_empty() || tools.is_empty() {
+        return Vec::new();
+    }
+
+    let verbs = detect_verbs(prompt);
+    let qt = query_tokens(prompt);
+
+    // Stage 1-2: verb gate. Keep tools whose verb matches the query, or whose
+    // prefix is neutral (no recognised verb).
+    let gated: Vec<usize> = tools
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            if verbs.is_empty() {
+                return true;
+            }
+            match tool_verb(t.name) {
+                Some(v) => verbs.contains(&v),
+                None => true,
+            }
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    // Stage 3-5: weighted token overlap + verb-alignment bonus, then sort.
+    let mut scored: Vec<(i32, usize)> = gated
+        .iter()
+        .map(|&i| {
+            let t = &tools[i];
+            let score = weighted_overlap(&qt, t.name, t.description) + verb_bonus(t.name, &verbs);
+            (score, i)
+        })
+        .collect();
+
+    scored.sort_by_key(|item| std::cmp::Reverse(item.0));
+
+    // Only keep positively-scored results. Zero-overlap tools would add noise.
+    scored
+        .into_iter()
+        .filter(|(s, _)| *s > 0)
+        .take(max_results)
+        .map(|(_, i)| i)
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Verb detection
+// ─────────────────────────────────────────────────────────────────────────
+
+fn verb_aliases(v: ToolVerb) -> &'static [&'static str] {
+    match v {
+        ToolVerb::Create => &[
+            "create", "make", "new", "add", "start", "write", "post", "draft",
+        ],
+        ToolVerb::Send => &[
+            "send", "email", "message", "dm", "reply", "forward", "notify",
+        ],
+        ToolVerb::Read => &["read", "get", "fetch", "show", "view", "see", "retrieve"],
+        ToolVerb::List => &["list", "search", "find", "lookup", "browse"],
+        ToolVerb::Update => &[
+            "update", "edit", "modify", "change", "rename", "move", "set",
+        ],
+        ToolVerb::Delete => &["delete", "remove", "drop", "archive", "unsubscribe"],
+        ToolVerb::Merge => &["merge", "accept", "approve"],
+    }
+}
+
+const ALL_VERBS: [ToolVerb; 7] = [
+    ToolVerb::Create,
+    ToolVerb::Send,
+    ToolVerb::Read,
+    ToolVerb::List,
+    ToolVerb::Update,
+    ToolVerb::Delete,
+    ToolVerb::Merge,
+];
+
+/// Tool-name prefixes (uppercase, after the vendor prefix is stripped) that map
+/// to each verb. Checked against the first two words of the stripped tool name;
+/// a trailing `S` is tolerated (`DELETES` → `DELETE`).
+fn tool_verb_prefixes(v: ToolVerb) -> &'static [&'static str] {
+    match v {
+        ToolVerb::Create => &["CREATE", "ADD", "NEW", "POST", "DRAFT", "START", "INSERT"],
+        ToolVerb::Send => &["SEND", "REPLY", "FORWARD", "NOTIFY"],
+        ToolVerb::Read => &[
+            "GET", "FETCH", "SHOW", "READ", "RETRIEVE", "DESCRIBE", "CHECK",
+        ],
+        ToolVerb::List => &["LIST", "SEARCH", "FIND", "BROWSE", "COUNT", "QUERY"],
+        ToolVerb::Update => &[
+            "UPDATE", "EDIT", "MODIFY", "RENAME", "MOVE", "SET", "PATCH", "UPSERT",
+        ],
+        ToolVerb::Delete => &["DELETE", "REMOVE", "DROP", "ARCHIVE", "UNSUBSCRIBE"],
+        ToolVerb::Merge => &["MERGE", "APPROVE", "ACCEPT", "DISMISS"],
+    }
+}
+
+fn detect_verbs(prompt: &str) -> HashSet<ToolVerb> {
+    let lowered = prompt.to_ascii_lowercase();
+    let mut found = HashSet::new();
+    for &v in &ALL_VERBS {
+        for alias in verb_aliases(v) {
+            if contains_whole_word(&lowered, alias) {
+                found.insert(v);
+                break;
+            }
+        }
+    }
+    found
+}
+
+/// Classify a tool name (e.g. `"GITHUB_CREATE_A_PULL_REQUEST"`) by verb.
+/// Returns `None` when no verb prefix is recognised — such tools are kept as
+/// neutral by the gate.
+fn tool_verb(name: &str) -> Option<ToolVerb> {
+    // Strip the vendor prefix (everything up to and including the first `_`).
+    let stripped = match name.split_once('_') {
+        Some((_, rest)) => rest,
+        None => name,
+    };
+    // Check the first two words.
+    for word in stripped.split('_').take(2) {
+        let trimmed = word.strip_suffix('S').unwrap_or(word);
+        for &v in &ALL_VERBS {
+            for &prefix in tool_verb_prefixes(v) {
+                if word == prefix || trimmed == prefix {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Token handling
+// ─────────────────────────────────────────────────────────────────────────
+
+const STOPWORDS: &[&str] = &[
+    "the", "a", "an", "to", "from", "for", "of", "with", "my", "me", "i", "and", "or", "on", "in",
+    "at", "is", "are", "by", "this", "that", "it", "about", "all", "any", "some", "new", "old",
+];
+
+/// Abbreviation map applied to query tokens. If the query has `pr`, we add
+/// `pull` and `request`; the tool name side already spells the words out, so
+/// expanding the query alone bridges the two.
+const ABBREVS: &[(&str, &[&str])] = &[
+    ("pr", &["pull", "request"]),
+    ("prs", &["pull", "requests"]),
+    ("dm", &["direct", "message"]),
+    ("dms", &["direct", "messages"]),
+    ("repo", &["repository"]),
+    ("repos", &["repositories"]),
+    ("org", &["organization"]),
+    ("orgs", &["organizations"]),
+    ("msg", &["message"]),
+    ("ch", &["channel"]),
+];
+
+/// Tokenize a string into lowercase alphanumeric words.
+fn tokenize(s: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut current = String::new();
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            current.push(c.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            out.insert(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        out.insert(current);
+    }
+    out
+}
+
+fn query_tokens(query: &str) -> HashSet<String> {
+    let raw: HashSet<String> = tokenize(query)
+        .into_iter()
+        .filter(|t| t.len() > 1 && !STOPWORDS.contains(&t.as_str()))
+        .collect();
+    let mut expanded = raw.clone();
+    for t in &raw {
+        for (abbr, replacements) in ABBREVS {
+            if t == abbr {
+                for r in *replacements {
+                    expanded.insert((*r).to_string());
+                }
+            }
+        }
+    }
+    expanded
+}
+
+fn weighted_overlap(qt: &HashSet<String>, name: &str, desc: &str) -> i32 {
+    let name_tokens = tokenize(name);
+    let desc_tokens = tokenize(desc);
+    let name_hits = qt.intersection(&name_tokens).count() as i32;
+    let desc_hits = qt.intersection(&desc_tokens).count() as i32;
+    3 * name_hits + desc_hits
+}
+
+fn verb_bonus(name: &str, query_verbs: &HashSet<ToolVerb>) -> i32 {
+    if query_verbs.is_empty() {
+        return 0;
+    }
+    match tool_verb(name) {
+        Some(v) if query_verbs.contains(&v) => 3,
+        Some(_) => -2,
+        None => 0,
+    }
+}
+
+fn contains_whole_word(haystack: &str, needle: &str) -> bool {
+    // Cheap whole-word check without regex. Works on ASCII; task prompts from
+    // orchestrators are essentially ASCII anyway.
+    let mut start = 0;
+    while let Some(idx) = haystack[start..].find(needle) {
+        let abs = start + idx;
+        let before_ok = abs == 0 || !haystack.as_bytes()[abs - 1].is_ascii_alphanumeric();
+        let end = abs + needle.len();
+        let after_ok = end == haystack.len() || !haystack.as_bytes()[end].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod test;

--- a/src/harness/tool/select/mod.rs
+++ b/src/harness/tool/select/mod.rs
@@ -176,11 +176,11 @@ fn detect_verbs(prompt: &str) -> HashSet<ToolVerb> {
     found
 }
 
-/// Whether `word` (already uppercased) is one of the recognised verb
-/// prefixes, tolerating a trailing plural `S` (`"CREATES"` -> `"CREATE"`).
-fn word_is_verb_prefix(word_upper: &str) -> bool {
+/// Classifies `word` (already uppercased) as a recognised verb prefix,
+/// tolerating a trailing plural `S` (`"CREATES"` -> `"CREATE"`).
+fn word_as_verb_prefix(word_upper: &str) -> Option<ToolVerb> {
     let trimmed = word_upper.strip_suffix('S').unwrap_or(word_upper);
-    ALL_VERBS.iter().any(|&v| {
+    ALL_VERBS.into_iter().find(|&v| {
         tool_verb_prefixes(v)
             .iter()
             .any(|&prefix| word_upper == prefix || trimmed == prefix)
@@ -203,7 +203,7 @@ fn word_is_verb_prefix(word_upper: &str) -> bool {
 /// position; unconditionally stripping it discarded the only verb present.
 fn tool_verb(name: &str) -> Option<ToolVerb> {
     let first_segment = name.split('_').next().unwrap_or(name);
-    let first_is_verb = word_is_verb_prefix(&first_segment.to_ascii_uppercase());
+    let first_is_verb = word_as_verb_prefix(&first_segment.to_ascii_uppercase()).is_some();
 
     // Strip an assumed vendor prefix (everything up to and including the
     // first `_`) unless the first segment is itself the verb.
@@ -217,20 +217,10 @@ fn tool_verb(name: &str) -> Option<ToolVerb> {
     };
 
     // Check the first two words.
-    for word in stripped.split('_').take(2) {
-        let word_upper = word.to_ascii_uppercase();
-        if word_is_verb_prefix(&word_upper) {
-            let trimmed = word_upper.strip_suffix('S').unwrap_or(&word_upper);
-            for &v in &ALL_VERBS {
-                for &prefix in tool_verb_prefixes(v) {
-                    if word_upper == prefix || trimmed == prefix {
-                        return Some(v);
-                    }
-                }
-            }
-        }
-    }
-    None
+    stripped
+        .split('_')
+        .take(2)
+        .find_map(|word| word_as_verb_prefix(&word.to_ascii_uppercase()))
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -6,20 +6,34 @@ fn tool<'a>(name: &'a str, desc: &'a str) -> SelectableTool<'a> {
 
 fn github_sample() -> Vec<SelectableTool<'static>> {
     vec![
-        tool("GITHUB_CREATE_A_PULL_REQUEST",
-             "Creates a pull request in a GitHub repository, requiring existing base and head branches."),
-        tool("GITHUB_CREATE_A_REVIEW_FOR_A_PULL_REQUEST",
-             "Creates a pull request review, allowing approval, change requests, or comments."),
-        tool("GITHUB_CREATE_A_DEPLOYMENT_BRANCH_POLICY",
-             "Creates a deployment branch or tag policy for an existing environment in a repository."),
-        tool("GITHUB_DELETE_A_REVIEW_COMMENT_FOR_A_PULL_REQUEST",
-             "Deletes a review comment on a pull request."),
-        tool("GITHUB_FIND_PULL_REQUESTS",
-             "Primary tool to find and search pull requests."),
-        tool("GITHUB_GET_A_PULL_REQUEST",
-             "Retrieves a specific pull request by number."),
-        tool("GITHUB_LIST_ASSIGNEES",
-             "Lists users who can be assigned to issues in a repository."),
+        tool(
+            "GITHUB_CREATE_A_PULL_REQUEST",
+            "Creates a pull request in a GitHub repository, requiring existing base and head branches.",
+        ),
+        tool(
+            "GITHUB_CREATE_A_REVIEW_FOR_A_PULL_REQUEST",
+            "Creates a pull request review, allowing approval, change requests, or comments.",
+        ),
+        tool(
+            "GITHUB_CREATE_A_DEPLOYMENT_BRANCH_POLICY",
+            "Creates a deployment branch or tag policy for an existing environment in a repository.",
+        ),
+        tool(
+            "GITHUB_DELETE_A_REVIEW_COMMENT_FOR_A_PULL_REQUEST",
+            "Deletes a review comment on a pull request.",
+        ),
+        tool(
+            "GITHUB_FIND_PULL_REQUESTS",
+            "Primary tool to find and search pull requests.",
+        ),
+        tool(
+            "GITHUB_GET_A_PULL_REQUEST",
+            "Retrieves a specific pull request by number.",
+        ),
+        tool(
+            "GITHUB_LIST_ASSIGNEES",
+            "Lists users who can be assigned to issues in a repository.",
+        ),
     ]
 }
 

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -182,10 +182,3 @@ fn delete_query_excludes_create_tools() {
     }
     assert!(idx.len() >= 3);
 }
-
-#[test]
-fn selectable_tool_converts_from_a_name_description_pair() {
-    let t: SelectableTool<'_> = ("GMAIL_SEND_EMAIL", "Sends an email.").into();
-    assert_eq!(t.name, "GMAIL_SEND_EMAIL");
-    assert_eq!(t.description, "Sends an email.");
-}

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -189,14 +189,8 @@ fn tool_verb_classifies_an_unprefixed_action_slug() {
     // A name with no vendor prefix carries its verb in the first segment;
     // unconditionally stripping the first segment as an assumed vendor
     // prefix discarded the only verb present.
-    assert_eq!(
-        tool_verb("create_a_pull_request"),
-        Some(ToolVerb::Create)
-    );
-    assert_eq!(
-        tool_verb("CREATE_A_PULL_REQUEST"),
-        Some(ToolVerb::Create)
-    );
+    assert_eq!(tool_verb("create_a_pull_request"), Some(ToolVerb::Create));
+    assert_eq!(tool_verb("CREATE_A_PULL_REQUEST"), Some(ToolVerb::Create));
     assert_eq!(tool_verb("delete_message"), Some(ToolVerb::Delete));
 }
 

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -1,0 +1,177 @@
+use super::*;
+
+fn tool<'a>(name: &'a str, desc: &'a str) -> SelectableTool<'a> {
+    SelectableTool::new(name, desc)
+}
+
+fn github_sample() -> Vec<SelectableTool<'static>> {
+    vec![
+        tool("GITHUB_CREATE_A_PULL_REQUEST",
+             "Creates a pull request in a GitHub repository, requiring existing base and head branches."),
+        tool("GITHUB_CREATE_A_REVIEW_FOR_A_PULL_REQUEST",
+             "Creates a pull request review, allowing approval, change requests, or comments."),
+        tool("GITHUB_CREATE_A_DEPLOYMENT_BRANCH_POLICY",
+             "Creates a deployment branch or tag policy for an existing environment in a repository."),
+        tool("GITHUB_DELETE_A_REVIEW_COMMENT_FOR_A_PULL_REQUEST",
+             "Deletes a review comment on a pull request."),
+        tool("GITHUB_FIND_PULL_REQUESTS",
+             "Primary tool to find and search pull requests."),
+        tool("GITHUB_GET_A_PULL_REQUEST",
+             "Retrieves a specific pull request by number."),
+        tool("GITHUB_LIST_ASSIGNEES",
+             "Lists users who can be assigned to issues in a repository."),
+    ]
+}
+
+#[test]
+fn create_pr_ranks_create_a_pull_request_first() {
+    let tools = github_sample();
+    let idx = rank_tools_by_prompt("create a PR from my feature branch to main", &tools, 5);
+    assert!(!idx.is_empty());
+    // Top match must be a CREATE verb tool (not DELETE/GET).
+    let top_name = tools[idx[0]].name;
+    assert!(
+        top_name.contains("CREATE") && top_name.contains("PULL_REQUEST"),
+        "expected top match to be a CREATE + PULL_REQUEST tool, got {top_name}"
+    );
+    // The DELETE tool must not appear — verb gate should drop it.
+    for &i in &idx {
+        assert!(
+            !tools[i].name.starts_with("GITHUB_DELETE"),
+            "DELETE tool leaked past verb gate: {}",
+            tools[i].name
+        );
+    }
+}
+
+#[test]
+fn list_prs_ranks_find_pull_requests_first() {
+    let tools = github_sample();
+    let idx = rank_tools_by_prompt("list open PRs assigned to me", &tools, 5);
+    assert!(!idx.is_empty());
+    let top_name = tools[idx[0]].name;
+    assert!(
+        top_name == "GITHUB_FIND_PULL_REQUESTS" || top_name == "GITHUB_LIST_ASSIGNEES",
+        "expected FIND_PULL_REQUESTS or LIST_ASSIGNEES on top, got {top_name}"
+    );
+}
+
+/// Exact-ordering snapshot, captured from the pre-extraction implementation in
+/// the OpenHuman host crate before this module was moved up. This is a
+/// relevance ranker whose output decides which tools a model is shown, so a
+/// scoring change is a silent behaviour change; pin the whole ordering, not
+/// just the winner.
+#[test]
+fn ranking_order_matches_the_pre_extraction_snapshot() {
+    let tools = github_sample();
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "create a PR from my feature branch to main",
+            &[
+                "GITHUB_CREATE_A_PULL_REQUEST",
+                "GITHUB_CREATE_A_REVIEW_FOR_A_PULL_REQUEST",
+                "GITHUB_CREATE_A_DEPLOYMENT_BRANCH_POLICY",
+            ],
+        ),
+        (
+            "list open PRs assigned to me",
+            &["GITHUB_FIND_PULL_REQUESTS", "GITHUB_LIST_ASSIGNEES"],
+        ),
+        (
+            "delete a review comment",
+            &["GITHUB_DELETE_A_REVIEW_COMMENT_FOR_A_PULL_REQUEST"],
+        ),
+        // No MERGE-prefixed tool in the sample, and the gate drops every
+        // non-merge verb, so this query is empty by construction.
+        ("merge pull request 42", &[]),
+    ];
+    for (prompt, expected) in cases {
+        let got: Vec<&str> = rank_tools_by_prompt(prompt, &tools, 10)
+            .into_iter()
+            .map(|i| tools[i].name)
+            .collect();
+        assert_eq!(&got, expected, "ranking drifted for prompt {prompt:?}");
+    }
+}
+
+#[test]
+fn empty_prompt_returns_empty() {
+    let tools = github_sample();
+    let idx = rank_tools_by_prompt("", &tools, 5);
+    assert!(idx.is_empty());
+}
+
+#[test]
+fn empty_catalogue_returns_empty() {
+    assert!(rank_tools_by_prompt("create a PR", &[], 5).is_empty());
+}
+
+#[test]
+fn abbreviation_expansion_works() {
+    let qt = query_tokens("create a PR from feature branch");
+    assert!(qt.contains("pr"));
+    assert!(qt.contains("pull"));
+    assert!(qt.contains("request"));
+}
+
+#[test]
+fn stopwords_removed() {
+    let qt = query_tokens("send the email to my manager");
+    assert!(!qt.contains("the"));
+    assert!(!qt.contains("to"));
+    assert!(!qt.contains("my"));
+    assert!(qt.contains("send"));
+    assert!(qt.contains("email"));
+    assert!(qt.contains("manager"));
+}
+
+#[test]
+fn verb_detection_handles_aliases() {
+    let v = detect_verbs("post a message to general channel");
+    assert!(v.contains(&ToolVerb::Send) || v.contains(&ToolVerb::Create));
+
+    let v = detect_verbs("delete all promotional emails");
+    assert!(v.contains(&ToolVerb::Delete));
+
+    let v = detect_verbs("merge pull request 42");
+    assert!(v.contains(&ToolVerb::Merge));
+}
+
+#[test]
+fn tool_verb_handles_plurals() {
+    assert_eq!(tool_verb("SLACK_DELETES_A_MESSAGE"), Some(ToolVerb::Delete));
+    assert_eq!(
+        tool_verb("GITHUB_CREATE_A_PULL_REQUEST"),
+        Some(ToolVerb::Create)
+    );
+    assert_eq!(tool_verb("GMAIL_SEND_EMAIL"), Some(ToolVerb::Send));
+    assert_eq!(tool_verb("NOTION_QUERY_DATABASE"), Some(ToolVerb::List));
+    // Neutral — no verb prefix recognised
+    assert_eq!(tool_verb("GITHUB_GIST_COMMENT"), None);
+}
+
+#[test]
+fn delete_query_excludes_create_tools() {
+    let tools = vec![
+        tool("GMAIL_SEND_EMAIL", "Sends an email."),
+        tool("GMAIL_DELETE_MESSAGE", "Deletes a message by id."),
+        tool("GMAIL_DELETE_THREAD", "Deletes a thread."),
+        tool("GMAIL_BATCH_DELETE_MESSAGES", "Bulk delete messages."),
+    ];
+    let idx = rank_tools_by_prompt("delete all promotional emails", &tools, 10);
+    for &i in &idx {
+        assert!(
+            tools[i].name.contains("DELETE"),
+            "non-DELETE tool leaked: {}",
+            tools[i].name
+        );
+    }
+    assert!(idx.len() >= 3);
+}
+
+#[test]
+fn selectable_tool_converts_from_a_name_description_pair() {
+    let t: SelectableTool<'_> = ("GMAIL_SEND_EMAIL", "Sends an email.").into();
+    assert_eq!(t.name, "GMAIL_SEND_EMAIL");
+    assert_eq!(t.description, "Sends an email.");
+}

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -1,3 +1,6 @@
+//! Unit tests for prompt-driven tool selection: verb classification,
+//! abbreviation expansion, stopword filtering, and ranked overlap scoring.
+
 use super::*;
 
 fn tool<'a>(name: &'a str, desc: &'a str) -> SelectableTool<'a> {

--- a/src/harness/tool/select/test.rs
+++ b/src/harness/tool/select/test.rs
@@ -168,6 +168,39 @@ fn tool_verb_handles_plurals() {
 }
 
 #[test]
+fn tool_verb_classifies_canonical_lowercase_names() {
+    // `ToolSchema::name` is canonical snake_case; comparing raw case against
+    // the (uppercase) prefix tables previously left every lowercase name
+    // unclassified, silently keeping the verb gate a no-op for real tool
+    // catalogues.
+    assert_eq!(
+        tool_verb("github_delete_a_pull_request"),
+        Some(ToolVerb::Delete)
+    );
+    assert_eq!(
+        tool_verb("github_create_a_pull_request"),
+        Some(ToolVerb::Create)
+    );
+    assert_eq!(tool_verb("gmail_send_email"), Some(ToolVerb::Send));
+}
+
+#[test]
+fn tool_verb_classifies_an_unprefixed_action_slug() {
+    // A name with no vendor prefix carries its verb in the first segment;
+    // unconditionally stripping the first segment as an assumed vendor
+    // prefix discarded the only verb present.
+    assert_eq!(
+        tool_verb("create_a_pull_request"),
+        Some(ToolVerb::Create)
+    );
+    assert_eq!(
+        tool_verb("CREATE_A_PULL_REQUEST"),
+        Some(ToolVerb::Create)
+    );
+    assert_eq!(tool_verb("delete_message"), Some(ToolVerb::Delete));
+}
+
+#[test]
 fn delete_query_excludes_create_tools() {
     let tools = vec![
         tool("GMAIL_SEND_EMAIL", "Sends an email."),

--- a/src/harness/tool/select/types.rs
+++ b/src/harness/tool/select/types.rs
@@ -1,0 +1,55 @@
+//! Types for prompt-driven tool selection.
+
+/// A borrowed view of one candidate tool, as the ranker sees it.
+///
+/// The ranker only ever reads a tool's name and its one-line description, so
+/// a host adapts whatever tool descriptor it owns into this shape with a
+/// borrowing `map` — no allocation beyond the `Vec` of views, and no
+/// dependency from this crate on the host's tool type.
+///
+/// This is a named struct rather than a `(&str, &str)` tuple deliberately:
+/// name hits are weighted three times as heavily as description hits, so a
+/// transposed tuple would silently change the ranking with nothing to catch
+/// it. Named fields make the transposition a compile error at the call site's
+/// literal, and make the call site read for itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectableTool<'a> {
+    /// Tool name or action slug, e.g. `"GITHUB_CREATE_A_PULL_REQUEST"`.
+    pub name: &'a str,
+    /// One-line description of what the tool does.
+    pub description: &'a str,
+}
+
+impl<'a> SelectableTool<'a> {
+    /// Creates a candidate view over a tool's name and description.
+    pub fn new(name: &'a str, description: &'a str) -> Self {
+        Self { name, description }
+    }
+}
+
+impl<'a> From<(&'a str, &'a str)> for SelectableTool<'a> {
+    fn from((name, description): (&'a str, &'a str)) -> Self {
+        Self::new(name, description)
+    }
+}
+
+/// Detected query intent. A small, stable set — expanding it risks
+/// over-matching (e.g. "open" is deliberately excluded because it appears in
+/// both "open a PR" and "open PRs").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolVerb {
+    /// Bring something into existence.
+    Create,
+    /// Transmit something to somebody.
+    Send,
+    /// Retrieve one known thing.
+    Read,
+    /// Enumerate or search over many things.
+    List,
+    /// Change something that exists.
+    Update,
+    /// Remove something that exists.
+    Delete,
+    /// Merge, approve, or accept.
+    Merge,
+}

--- a/src/harness/tool/select/types.rs
+++ b/src/harness/tool/select/types.rs
@@ -27,12 +27,6 @@ impl<'a> SelectableTool<'a> {
     }
 }
 
-impl<'a> From<(&'a str, &'a str)> for SelectableTool<'a> {
-    fn from((name, description): (&'a str, &'a str)) -> Self {
-        Self::new(name, description)
-    }
-}
-
 /// Detected query intent. A small, stable set — expanding it risks
 /// over-matching (e.g. "open" is deliberately excluded because it appears in
 /// both "open a PR" and "open PRs").

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,13 @@ pub use graph::{
     register_orchestration_tools,
 };
 
+// --- Graph: dependency-DAG validation (unique ids, landed edges, acyclicity) ---
+// Pure structure, no runtime state: a host projects its own nodes into the
+// borrowed `DagNode` view, so workflow phases, task boards and plan steps all
+// share one Kahn's-algorithm implementation. See `graph::dag`'s module docs for
+// how dangling edges and duplicate ids are treated.
+pub use graph::dag::{DagIssue, DagNode, has_cycle, validate_dag};
+
 // --- Graph: multi-stage sub-agent delegation (plan → execute ⇄ review → finalize) ---
 // The per-stage worker is injected, so the host supplies how a stage runs while
 // this crate owns the routing, revision budget, checkpoint/resume classification

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,8 +224,10 @@ pub use graph::{
 // Pure structure, no runtime state: a host projects its own nodes into the
 // borrowed `DagNode` view, so workflow phases, task boards and plan steps all
 // share one Kahn's-algorithm implementation. See `graph::dag`'s module docs for
-// how dangling edges and duplicate ids are treated.
-pub use graph::dag::{DagIssue, DagNode, has_cycle, validate_dag};
+// how dangling edges and duplicate ids are treated. The free functions
+// `has_cycle` / `validate_dag` stay behind `graph::dag::` to avoid generic-name
+// clashes at the crate root, matching `graph::export`.
+pub use graph::dag::{DagIssue, DagNode};
 
 // --- Graph: multi-stage sub-agent delegation (plan → execute ⇄ review → finalize) ---
 // The per-stage worker is injected, so the host supplies how a stage runs while

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,18 @@ pub use graph::{
     register_orchestration_tools,
 };
 
+// --- Graph: multi-stage sub-agent delegation (plan → execute ⇄ review → finalize) ---
+// The per-stage worker is injected, so the host supplies how a stage runs while
+// this crate owns the routing, revision budget, checkpoint/resume classification
+// and the durable human-approval interrupt. `DelegationState` is an on-disk
+// format — see `graph::delegation`'s README before changing its shape.
+pub use graph::delegation::{
+    CURRENT_SCHEMA_VERSION as DELEGATION_SCHEMA_VERSION, DelegationConfig, DelegationOutcome,
+    DelegationStage, DelegationStageOutput, DelegationState, PendingApproval, StepRecord,
+    delegation_graph_topology, deny_decision, resume_delegation, run_delegation,
+    run_delegation_durable, run_or_resume_delegation,
+};
+
 // --- Graph: per-thread goal (durable objective + graph-native continuation) ---
 // `goal_store` is the programmatic CRUD surface (get/set/complete/account_usage);
 // the tools and continuation helpers are re-exported flat for discoverability.


### PR DESCRIPTION
## Summary

Three modules extracted from the OpenHuman host, where each was generic code
sitting above the harness rather than product policy. Companion host PR:
tinyhumansai/openhuman (removes ~2.1k lines against these).

**`graph::delegation`** — the multi-stage delegation graph (plan → execute ⇄
review → finalize), with durable checkpoint/resume and human approval. ~888
production lines. The host's `DelegationConfig` equivalent reached its own
observability layer by a relative path, so the crate type gained an optional
`event_sink: Option<Arc<dyn GraphEventSink>>` (defaults `None`) and the host
attaches its tracing sink through that. Nothing host-specific came up with it.

**`graph::dag`** — Kahn's-algorithm DAG validation (`has_cycle`,
`validate_dag`). OpenHuman implemented this twice, and the crate had no
equivalent: `graph/export::validate()` only checks dangling references. Takes a
borrowed `DagNode<'a> { id, depends_on }` view, so no host type is involved.

**`harness::tool::select`** — a fuzzy prompt→tool relevance ranker used to
narrow a large toolkit before a model sees it. Takes
`SelectableTool<'a> { name, description }`. A named struct rather than
`&[(&str, &str)]` on purpose: name hits are weighted 3× description hits, so a
transposed tuple would silently change the ranking with nothing to catch it.

## API Or Behavior Changes

Additive only. Three new public modules; no existing item changed signature or
behavior.

- `graph::delegation` re-exported from `graph` and `lib`, with
  `CURRENT_SCHEMA_VERSION` aliased as `DELEGATION_SCHEMA_VERSION` at those
  levels (the bare name is too generic at crate root; the module path keeps the
  original spelling).
- `graph::dag` exports `DagNode`/`DagIssue` from `graph` and `lib`; the free
  functions stay behind `graph::dag::`, matching the existing convention for
  generically-named free functions (`graph::export`).
- `harness::tool::select` is exported through `harness/tool/mod.rs` only —
  `tinyagents::harness::tool::rank_tools_by_prompt` already resolves, so no
  `lib.rs` entry was added.
- No new third-party dependency; all three modules are stdlib-only apart from
  what the crate already had.

**`DelegationState` is a versioned on-disk checkpoint**, so its serde
representation had to cross unchanged. That was proven rather than assumed: the
serialized JSON was captured from the *original, pre-move* code and that exact
literal is asserted in `serialized_state_shape_is_pinned`. Two further tests
cover the other directions — `pre_versioned_state_decodes_with_documented_defaults`
(a legacy record with no `schema_version` still decodes to version `0` so it can
be classified and expired) and `default_state_shape_is_pinned`.

**Ranking parity for `select` was likewise measured, not assumed:** the ordering
was captured from the pre-extraction host code over a 1,000-action real-world
catalogue across 12 queries, re-captured after the move, and diffed
byte-identical. Both captures are retained as permanent snapshot guards
(`ranking_order_matches_the_pre_extraction_snapshot` here, and an adapter-level
twin host-side) so a future scoring tweak cannot drift silently.

One deliberate scope decision worth flagging for review: `validate_dag` has **no**
`SelfDependency` variant. A self-edge reports as `Cycle`, which reproduces one
host caller exactly; the other caller needs that error scoped to a newly added
node only, so it keeps a small local check and calls just `has_cycle`. Folding
it in here would have made a pre-existing node's dangling edge reject an
unrelated new insertion.

## Tests

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --all-features`
- [x] `cargo test` — 107 suites, **2,504 passed / 0 failed**
- [x] `cargo test --all-features` — 107 suites, **2,637 passed / 0 failed**

New coverage: 20 `graph::delegation::test::*` (17 ported from the host intact +
3 new serde-pinning tests), 11 `graph::dag::test::*`, 11
`harness::tool::select::test::*`, plus doctests on the new public examples.

The host's real-catalogue fixtures for the ranker (~1.8 MB of one specific
integration provider's tool dump) deliberately did **not** come with `select`:
a provider-neutral crate should not carry them. The split is by kind — synthetic
algorithm tests here, real-data tests retained host-side as adapter coverage,
nothing duplicated.

## Documentation

Module-level docs on all three, covering the non-obvious semantics: for `dag`,
that dangling edges are excluded from the cycle pass, that duplicate ids are
compared against the unique-id count so they cannot read as a cycle, and that a
self-edge is a cycle. `graph/delegation/README.md` documents the design, public
surface, and the on-disk-format constraint. `dag` and `select` follow the
existing convention for modules of their size (`graph::export`,
`graph::reducer`, `harness::prompt`, `harness::context` carry no README either).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable, resumable multi-stage delegation workflows with planning, execution, review, cancellation, retries, and optional human approval.
  * Added dependency graph validation for duplicate nodes, missing dependencies, and cycles.
  * Added prompt-based tool selection that ranks relevant tools by task intent.
  * Improved tool context interoperability and workspace isolation enforcement.
* **Documentation**
  * Expanded guidance for delegation workflows, approvals, checkpoints, and workspace isolation.
* **Chores**
  * Updated build and release automation to include required vendor components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->