### PR TITLE
fix(orchestration): retain cancelled tasks for waiters

### DIFF
--- a/src/graph/orchestration/runtime.rs
+++ b/src/graph/orchestration/runtime.rs
@@ -291,6 +291,41 @@ where
         self.cancel_where(|_| true)
     }
 
+    /// Cancels every executor while retaining its registry entry for a waiter.
+    ///
+    /// `publish_terminal` runs for each entry before its cooperative token and
+    /// hard-abort handle are triggered. Applications use it to publish their
+    /// own terminal cancellation payload through the registered status
+    /// channel. The now-terminal entry stays registered until [`Self::wait`]
+    /// observes and prunes it (or a later soft-cap sweep does), preventing a
+    /// waiter that already knows the task id from racing removal.
+    ///
+    /// The callback runs while the registry lock is held and must not call back
+    /// into this registry.
+    pub fn cancel_all_retaining(
+        &self,
+        mut publish_terminal: impl FnMut(&Metadata, &Status),
+    ) -> std::result::Result<Vec<DetachedTaskSnapshot<Metadata, Status>>, DetachedTaskRegistryError>
+    {
+        let mut cancelled = {
+            let guard = self.lock()?;
+            let mut cancelled = Vec::with_capacity(guard.len());
+            for (task_id, entry) in guard.iter() {
+                let current = entry.status.borrow().clone();
+                publish_terminal(&entry.metadata, &current);
+                entry.cancellation.cancel();
+                entry.abort.abort();
+                cancelled.push(Self::snapshot_entry(task_id, entry));
+            }
+            cancelled
+        };
+        cancelled.sort_by(|left, right| left.task_id.as_str().cmp(right.task_id.as_str()));
+        for entry in &cancelled {
+            self.steering.deregister(&entry.task_id);
+        }
+        Ok(cancelled)
+    }
+
     /// Prunes every entry whose latest watched status is terminal.
     pub fn sweep_terminal(&self) -> std::result::Result<usize, DetachedTaskRegistryError> {
         let removed = {

--- a/src/graph/orchestration/test.rs
+++ b/src/graph/orchestration/test.rs
@@ -41,11 +41,15 @@ fn in_memory_store_tracks_task_lifecycle() {
 enum RuntimeStatus {
     Running,
     Completed(String),
+    Cancelled,
 }
 
 fn runtime_registry() -> DetachedTaskRegistry<String, RuntimeStatus> {
     DetachedTaskRegistry::new(SteeringRegistry::new(), 2, |status| {
-        matches!(status, RuntimeStatus::Completed(_))
+        matches!(
+            status,
+            RuntimeStatus::Completed(_) | RuntimeStatus::Cancelled
+        )
     })
 }
 
@@ -155,10 +159,54 @@ async fn detached_registry_cancel_is_cooperative_then_aborts_and_returns_metadat
 }
 
 #[tokio::test]
+async fn detached_registry_can_cancel_executors_without_removing_waitable_status() {
+    let registry = runtime_registry();
+    let task_id = TaskId::new("detached-retained-cancel");
+    let (tx, rx, cancellation, join) = detached_handles();
+    registry
+        .register(
+            task_id.clone(),
+            "parent",
+            "worker-meta".to_string(),
+            rx,
+            cancellation.clone(),
+            join.abort_handle(),
+        )
+        .unwrap();
+
+    let cancelled = registry
+        .cancel_all_retaining(|metadata, status| {
+            assert_eq!(metadata, "worker-meta");
+            assert_eq!(status, &RuntimeStatus::Running);
+            tx.send(RuntimeStatus::Cancelled).unwrap();
+        })
+        .unwrap();
+
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(cancelled[0].task_id, task_id);
+    assert_eq!(cancelled[0].status, RuntimeStatus::Cancelled);
+    assert!(cancellation.is_cancelled());
+    assert!(join.await.unwrap_err().is_cancelled());
+    assert_eq!(registry.len().unwrap(), 1, "a waiter still needs the entry");
+
+    assert_eq!(
+        registry
+            .wait(&task_id, "parent", std::time::Duration::from_secs(1))
+            .await
+            .unwrap(),
+        DetachedTaskWaitOutcome::Terminal(RuntimeStatus::Cancelled)
+    );
+    assert!(registry.is_empty().unwrap());
+}
+
+#[tokio::test]
 async fn detached_registry_uses_shared_steering_and_sweeps_terminal_at_soft_cap() {
     let steering = SteeringRegistry::new();
     let registry = DetachedTaskRegistry::new(steering.clone(), 1, |status: &RuntimeStatus| {
-        matches!(status, RuntimeStatus::Completed(_))
+        matches!(
+            status,
+            RuntimeStatus::Completed(_) | RuntimeStatus::Cancelled
+        )
     });
     let first = TaskId::new("detached-first");
     let (first_tx, first_rx, first_cancel, first_join) = detached_handles();
@@ -215,7 +263,10 @@ impl Clone for PanickingMetadata {
 async fn detached_registry_reports_a_poisoned_lock() {
     let registry =
         DetachedTaskRegistry::new(SteeringRegistry::new(), 2, |status: &RuntimeStatus| {
-            matches!(status, RuntimeStatus::Completed(_))
+            matches!(
+                status,
+                RuntimeStatus::Completed(_) | RuntimeStatus::Cancelled
+            )
         });
     let task_id = TaskId::new("detached-poison");
     let (_tx, rx, cancellation, join) = detached_handles();


### PR DESCRIPTION
## Summary

- add a cancellation path that aborts detached executors without immediately removing their registry entries
- publish application terminal state before aborting, so a waiter cannot race entry removal
- cover retained cancellation through terminal wait and pruning

## API Or Behavior Changes

Adds `DetachedTaskRegistry::cancel_all_retaining`. Cancelled entries remain waitable until `wait` observes their terminal status or a later soft-cap sweep prunes them.

## Tests

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo build --all-targets --all-features`
- [ ] `cargo test`
- [ ] `cargo test --all-features`
- [x] `cargo test graph::orchestration::test::detached_registry`

## Documentation

The new public method has API documentation describing retention, pruning, callback ordering, and lock constraints.