### PR TITLE
fix(ci): resolve release workflow version lookup after crate split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
-          perl -0pi -e 's/(\[package\][\s\S]*?\nversion = ")[^"]+(")/$1$ENV{NEXT_VERSION}$2/' Cargo.toml
+          perl -0pi -e 's/(\[workspace\.package\][\s\S]*?\nversion = ")[^"]+(")/$1$ENV{NEXT_VERSION}$2/' Cargo.toml
           cargo update -p "$CRATE_NAME" --precise "$NEXT_VERSION"
 
       - name: Commit version bump and tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     env:
-      CRATE_NAME: tinyagents
+      # The crate previously named `tinyagents` was split into per-concern
+      # crates in `crates/*` (see commit 612ea5e). Version is now inherited
+      # from `[workspace.package].version` in the root Cargo.toml rather
+      # than set literally in a crate's own `[package]` table, so we track
+      # it via `tinyagents-harness`, which is always present and shares the
+      # workspace-inherited version.
+      CRATE_NAME: tinyagents-harness
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Problem

The `Release` workflow fails immediately on `main` and cannot cut a release at all.

Run [33327740303](https://github.com/tinyhumansai/tinyagents/actions/runs/33327740303) fails in the `Release Rust Crate` job, step **Compute next version**:

```
Could not resolve current version for crate tinyagents
```

The crate itself is healthy — `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo build --all-targets --all-features` all pass on `main`. This is a workflow bug, not a code bug.

## Root cause

Commit `612ea5e` ("refactor: split tinyagents into focused crates") split the single `tinyagents` crate into `crates/tinyagents-{harness,language,graph,registry,session,tracing,integration-tests}`. Every member now inherits its version from `[workspace.package]` via `version.workspace = true` rather than declaring a literal version in its own `[package]` table.

The "Compute next version" step still looked up a package literally named `tinyagents` through `cargo metadata`. No such package exists any more, so the lookup resolved to an empty string and tripped the guard. The last successful release, `v2.1.1`, predates the split.

A second latent bug sat directly behind it: the next step, "Update crate version", used a `perl` regex anchored on a `[package]` table that no longer exists in the root `Cargo.toml` (only `[workspace.package]` does). The bump would have silently no-opped, and the subsequent `cargo update -p "$CRATE_NAME" --precise` would have failed on the resulting version mismatch.

## Fix

- `CRATE_NAME: tinyagents` → `CRATE_NAME: tinyagents-harness` — a real, always-present workspace default-member whose version is inherited from `[workspace.package]`. Commented in place so the reason survives.
- Re-anchored the `perl` regex from `\[package\]` to `\[workspace\.package\]` so the version bump actually lands.

## Verification

- `CRATE_NAME=tinyagents cargo metadata --format-version 1 --no-deps | jq -r '...'` → empty, reproducing the failure.
- `CRATE_NAME=tinyagents-harness cargo metadata --format-version 1 --no-deps | jq -r '...'` → `2.1.1`, confirming the fix resolves.
- The updated regex bumps `[workspace.package].version` from `2.1.1` to `2.1.2` in a scratch copy of `Cargo.toml`, leaving the rest of the file untouched.

Tests were not run — this changes CI configuration only, and `main` already builds and lints clean.
