### PR TITLE
fix(ci): scope release packaging and keep workspace versions in lockstep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,22 @@ jobs:
 
       - name: Update crate version
         env:
+          CURRENT_VERSION: ${{ steps.version.outputs.current_version }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
           perl -0pi -e 's/(\[workspace\.package\][\s\S]*?\nversion = ")[^"]+(")/$1$ENV{NEXT_VERSION}$2/' Cargo.toml
-          cargo update -p "$CRATE_NAME" --precise "$NEXT_VERSION"
+
+          # Intra-workspace path dependencies (e.g. `tinyagents-tracing =
+          # { path = "...", version = "2.1.1" }`) pin the workspace version
+          # as a caret requirement. On a major bump the old requirement no
+          # longer matches the new version, so keep them in lockstep with
+          # the workspace bump or `cargo update` fails to resolve.
+          perl -pi -e 's/(tinyagents-[\w-]+\s*=\s*\{[^}]*version\s*=\s*")\Q$ENV{CURRENT_VERSION}\E(")/$1$ENV{NEXT_VERSION}$2/g' crates/*/Cargo.toml
+
+          # Refresh every workspace member's Cargo.lock entry (not just
+          # $CRATE_NAME) so later `--locked` commands don't see a stale
+          # lockfile.
+          cargo update --workspace
 
       - name: Commit version bump and tag
         env:
@@ -118,12 +130,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
+          git add Cargo.toml Cargo.lock crates/*/Cargo.toml
           git commit -m "Release ${RELEASE_TAG}"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
 
       - name: Package crate
-        run: cargo package --locked
+        run: cargo package --locked -p "$CRATE_NAME"
 
       - name: Push release commit and tag
         env:
@@ -133,6 +145,6 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Publish to crates.io
-        run: cargo publish --locked
+        run: cargo publish --locked -p "$CRATE_NAME"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

PR #135 fixed the `Release` workflow's version resolution after the crate split, but it was merged before the follow-up commit addressing the review feedback was pushed. `main` therefore still carries three issues that were raised and agreed on that PR:

1. **Un-scoped packaging.** `cargo package --locked` and `cargo publish --locked` run at the workspace root and operate on all `default-members`, so they can process crates other than `$CRATE_NAME`.
2. **Stale lockfile entries.** Seven workspace members inherit the root version, but `cargo update -p "$CRATE_NAME" --precise "$NEXT_VERSION"` refreshes only `tinyagents-harness`. The other `Cargo.lock` entries keep the previous version, which makes the later `--locked` commands fail.
3. **Intra-workspace requirements not bumped (P1).** On `bump: major` the workflow raises every package 2.x → 3.0.0 but leaves caret requirements such as `tinyagents-tracing = { path = "...", version = "2.1.1" }` in `crates/tinyagents-harness/Cargo.toml` untouched. Those requirements reject 3.0.0, so resolution fails before the release commit is made.

## Fix

Carries the reviewed change from `fix-release-version-resolution` onto `main`:

- Added `-p "$CRATE_NAME"` to both `cargo package --locked` and `cargo publish --locked`.
- Replaced `cargo update -p "$CRATE_NAME" --precise "$NEXT_VERSION"` with `cargo update --workspace`.
- Added a bump-agnostic `perl` rewrite that moves every intra-workspace path-dependency version requirement from `$CURRENT_VERSION` to `$NEXT_VERSION` before `cargo update --workspace` runs, and added `crates/*/Cargo.toml` to the `git add` so the rewritten manifests land in the release commit.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses cleanly.
- `cargo update --workspace --dry-run` resolves against the real repo.
- The perl regex was run against a scratch copy of `crates/*/Cargo.toml` with `CURRENT_VERSION=2.1.1` / `NEXT_VERSION=3.0.0`: all 10 intra-workspace requirements updated to `3.0.0`, while `version.workspace = true` lines were correctly left alone.

CI configuration only; no library code changes, so no tests were run.

Follow-up to #135.
