### PR TITLE
fix(ci): skip crates.io packaging for unpublished workspace crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,21 @@ jobs:
           git commit -m "Release ${RELEASE_TAG}"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
 
+      - name: Check crates.io publishability
+        id: publishable
+        run: |
+          set -euo pipefail
+
+          publish="$(cargo metadata --no-deps --format-version 1 | jq -r --arg crate "$CRATE_NAME" '.packages[] | select(.name == $crate) | .publish')"
+          if [[ "$publish" == "[]" ]]; then
+            echo "publishable=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${CRATE_NAME} has publish = false; skipping crates.io package/publish steps."
+          else
+            echo "publishable=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Package crate
+        if: steps.publishable.outputs.publishable == 'true'
         run: cargo package --locked -p "$CRATE_NAME"
 
       - name: Push release commit and tag
@@ -145,6 +159,7 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Publish to crates.io
+        if: steps.publishable.outputs.publishable == 'true'
         run: cargo publish --locked -p "$CRATE_NAME"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/tinyagents-graph/Cargo.toml
+++ b/crates/tinyagents-graph/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-graph"
 version.workspace = true
 edition.workspace = true

--- a/crates/tinyagents-harness/Cargo.toml
+++ b/crates/tinyagents-harness/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-harness"
 version.workspace = true
 edition.workspace = true

--- a/crates/tinyagents-language/Cargo.toml
+++ b/crates/tinyagents-language/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-language"
 version.workspace = true
 edition.workspace = true

--- a/crates/tinyagents-registry/Cargo.toml
+++ b/crates/tinyagents-registry/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-registry"
 version.workspace = true
 edition.workspace = true

--- a/crates/tinyagents-session/Cargo.toml
+++ b/crates/tinyagents-session/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-session"
 version.workspace = true
 edition.workspace = true

--- a/crates/tinyagents-tracing/Cargo.toml
+++ b/crates/tinyagents-tracing/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "tinyagents-tracing"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## Problem

Release run [33329006200](https://github.com/tinyhumansai/tinyagents/actions/runs/33329006200) got past version resolution and the workspace version bump (2.1.1 → 2.1.2), then failed in **Package crate**:

```
error: failed to prepare local package for uploading

Caused by:
  no matching package named `tinyagents-tracing` found
  location searched: crates.io index
  required by package `tinyagents-harness v2.1.2`
```

After the crate split, `tinyagents-harness` depends on its sibling workspace crates (`tinyagents-tracing`, `-graph`, `-language`, `-registry`, `-session`). None of them exist on crates.io, so `cargo package` cannot resolve them from the index. Packaging `tinyagents-harness` for crates.io would require publishing all five siblings first.

That is not wanted: consumers now depend on these crates via GitHub (git dependencies / vendored submodules), not crates.io.

## Fix

- Added a `Check crates.io publishability` step that reads the resolved `publish` field for `$CRATE_NAME` via `cargo metadata --no-deps --format-version 1 | jq`, and gated **Package crate** and **Publish to crates.io** on it. When the crate is unpublishable the steps are skipped with a `::notice::` instead of failing the run.
- Marked the workspace member crates `publish = false`, which is the honest expression of "these are consumed from GitHub, not the registry" and prevents an accidental publish. (`tinyagents-integration-tests` already had it.)

The version bump, release commit, tag and push steps are unchanged and still run, so a release still produces its tag and artifacts.

This mirrors the pattern already merged in the sibling repos tinycortex (#160) and tinychannels (#20), keeping release behaviour consistent across the modules.

## Verification

- `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="tinyagents-harness") | .publish'` → `[]`, so the gate takes the skip path.
- `cargo check --workspace` passes with the `publish = false` additions.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses cleanly.

No library code changed, so no tests were run.

Follow-up to #135 and #136.
