### PR TITLE
fix(select): let a list/search query keep the tools that retrieve what it found

### DIFF
--- a/crates/tinyagents-harness/src/tool/select/mod.rs
+++ b/crates/tinyagents-harness/src/tool/select/mod.rs
@@ -83,7 +83,7 @@ pub fn rank_tools_by_prompt(
                 return true;
             }
             match tool_verb(t.name) {
-                Some(v) => verbs.contains(&v),
+                Some(v) => verbs.iter().any(|q| verbs_are_compatible(*q, v)),
                 None => true,
             }
         })
@@ -337,12 +337,28 @@ fn weighted_overlap(qt: &HashSet<String>, name: &str, desc: &str) -> i32 {
     3 * name_hits + desc_hits
 }
 
+/// Whether a tool carrying verb `tool` may answer a query asking for `query`.
+///
+/// Exact matches always may. The one cross-verb pair is `Read` and `List`:
+/// finding something and reading it are one task for the user and two verbs
+/// for the catalogue. "find the emails about X" is detected as `List`, and
+/// gating on that alone removes every `FETCH_*` / `GET_*` action — leaving a
+/// surface that can enumerate ids and never return content. Keeping the pair
+/// compatible is what lets a search prompt reach the thing it searched for.
+pub(crate) fn verbs_are_compatible(query: ToolVerb, tool: ToolVerb) -> bool {
+    query == tool || matches!((query, tool), (ToolVerb::List, ToolVerb::Read))
+}
+
 fn verb_bonus(name: &str, query_verbs: &HashSet<ToolVerb>) -> i32 {
     if query_verbs.is_empty() {
         return 0;
     }
     match tool_verb(name) {
+        // An exact intent match is the strongest signal.
         Some(v) if query_verbs.contains(&v) => 3,
+        // Compatible but not exact: worth keeping, ranked under an exact
+        // match rather than beside it.
+        Some(v) if query_verbs.iter().any(|q| verbs_are_compatible(*q, v)) => 1,
         Some(_) => -2,
         None => 0,
     }

--- a/crates/tinyagents-harness/src/tool/select/test.rs
+++ b/crates/tinyagents-harness/src/tool/select/test.rs
@@ -293,3 +293,50 @@ fn compatibility_is_one_directional_and_narrow() {
     assert!(!verbs_are_compatible(ToolVerb::Create, ToolVerb::Read));
     assert!(verbs_are_compatible(ToolVerb::Create, ToolVerb::Create));
 }
+
+#[test]
+fn strong_name_overlap_can_outrank_a_bare_verb_match_and_that_is_deliberate() {
+    // The score is `weighted_overlap + verb_bonus`, and the two bonuses
+    // differ by 2 — so a compatible `Read` tool whose *name* matches the
+    // query can rank above an exact-verb `List` tool that matches nothing
+    // else. That is the ranking working, not a defect: a name hit is worth
+    // 3 and is the stronger relevance signal. Sorting by verb class first
+    // would bury the tool the user actually named.
+    let tools = vec![
+        // Exact verb (List, +3), zero token overlap.
+        SelectableTool::new("GITHUB_LIST_GISTS", "List gists"),
+        // Compatible verb (Read, +1) but three name hits (3 * 3 = 9).
+        SelectableTool::new(
+            "GITHUB_GET_A_PULL_REQUEST_COMMENT",
+            "Get one review comment",
+        ),
+    ];
+    let got: Vec<&str> = rank_tools_by_prompt("find the pull request comment", &tools, 10)
+        .into_iter()
+        .map(|i| tools[i].name)
+        .collect();
+    assert_eq!(
+        got.first(),
+        Some(&"GITHUB_GET_A_PULL_REQUEST_COMMENT"),
+        "the tool the query names must lead: {got:?}"
+    );
+}
+
+#[test]
+fn with_overlap_equal_the_exact_verb_wins() {
+    // The companion to the case above: strip the overlap advantage and the
+    // verb bonus is what decides, so an exact match leads a compatible one.
+    let tools = vec![
+        SelectableTool::new("GITHUB_GET_PULL_REQUEST", "Get a pull request"),
+        SelectableTool::new("GITHUB_LIST_PULL_REQUEST", "List pull requests"),
+    ];
+    let got: Vec<&str> = rank_tools_by_prompt("find the pull request", &tools, 10)
+        .into_iter()
+        .map(|i| tools[i].name)
+        .collect();
+    assert_eq!(
+        got.first(),
+        Some(&"GITHUB_LIST_PULL_REQUEST"),
+        "equal overlap → the exact verb match leads: {got:?}"
+    );
+}

--- a/crates/tinyagents-harness/src/tool/select/test.rs
+++ b/crates/tinyagents-harness/src/tool/select/test.rs
@@ -91,8 +91,18 @@ fn ranking_order_matches_the_pre_extraction_snapshot() {
             ],
         ),
         (
+            // `GITHUB_GET_A_PULL_REQUEST` is a `Read` tool under a `List`
+            // query. It ranks last of the three: compatible intents earn a
+            // smaller bonus than an exact match, so the enumerating tools
+            // still lead. Before Read and List were compatible it was gated
+            // out entirely, which is what left a search surface unable to
+            // retrieve what it found.
             "list open PRs assigned to me",
-            &["GITHUB_FIND_PULL_REQUESTS", "GITHUB_LIST_ASSIGNEES"],
+            &[
+                "GITHUB_FIND_PULL_REQUESTS",
+                "GITHUB_LIST_ASSIGNEES",
+                "GITHUB_GET_A_PULL_REQUEST",
+            ],
         ),
         (
             "delete a review comment",
@@ -232,4 +242,54 @@ fn delete_query_excludes_create_tools() {
         );
     }
     assert!(idx.len() >= 3);
+}
+
+#[test]
+fn a_list_query_keeps_the_tool_that_retrieves_what_it_found() {
+    // Finding something and reading it are one task for the user and two
+    // verbs for the catalogue. A `List` query must not gate out every
+    // `Read` tool, or the surface can enumerate ids and never return
+    // content.
+    let tools = github_sample();
+    let got: Vec<&str> = rank_tools_by_prompt("find the pull requests about auth", &tools, 10)
+        .into_iter()
+        .map(|i| tools[i].name)
+        .collect();
+    assert!(
+        got.contains(&"GITHUB_GET_A_PULL_REQUEST"),
+        "a Read tool must survive a List query: {got:?}"
+    );
+}
+
+#[test]
+fn an_exact_verb_match_still_outranks_a_merely_compatible_one() {
+    let tools = github_sample();
+    let got: Vec<&str> = rank_tools_by_prompt("list open PRs assigned to me", &tools, 10)
+        .into_iter()
+        .map(|i| tools[i].name)
+        .collect();
+    let list_at = got
+        .iter()
+        .position(|n| *n == "GITHUB_FIND_PULL_REQUESTS")
+        .expect("the List tool is kept");
+    let read_at = got
+        .iter()
+        .position(|n| *n == "GITHUB_GET_A_PULL_REQUEST")
+        .expect("the Read tool is kept");
+    assert!(
+        list_at < read_at,
+        "compatibility must not promote a Read tool above an exact List match: {got:?}"
+    );
+}
+
+#[test]
+fn compatibility_is_one_directional_and_narrow() {
+    use super::verbs_are_compatible;
+    assert!(verbs_are_compatible(ToolVerb::List, ToolVerb::Read));
+    // Not the reverse: "read message 5" should not pull in every list tool.
+    assert!(!verbs_are_compatible(ToolVerb::Read, ToolVerb::List));
+    // And nothing else pairs up.
+    assert!(!verbs_are_compatible(ToolVerb::List, ToolVerb::Delete));
+    assert!(!verbs_are_compatible(ToolVerb::Create, ToolVerb::Read));
+    assert!(verbs_are_compatible(ToolVerb::Create, ToolVerb::Create));
 }


### PR DESCRIPTION
## Summary

A `List` query no longer gates out every `Read` tool, so a search prompt can reach the thing it searched for. `List` and `Read` become compatible intents, in that direction only, and an exact verb match still outranks a merely compatible one.

## Problem

The verb gate drops any tool whose own name-verb conflicts with the intent detected from the prompt. `find` / `search` / `lookup` / `browse` are `List`; `FETCH_*` / `GET_*` / `READ_*` are `Read`. So "find the emails about X" removes every action that returns a message body **before scoring begins**, and the surviving surface can enumerate ids while having no way to retrieve one.

Measured against a real 62-action Gmail catalogue, top-K 12:

| Prompt | before | after |
| --- | --- | --- |
| `Search the inbox for job opportunity emails … summarize sender, subject and date` | 12 × `GMAIL_LIST_*`, no way to read a message | keeps `GMAIL_FETCH_EMAILS` + `GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID` |
| `show me new emails about job opportunities` | no `FETCH` | keeps `GMAIL_FETCH_EMAILS` |

Finding something and reading it are one task for the user and two verbs for the catalogue. That mismatch is the whole defect.

## Solution

- `verbs_are_compatible(query, tool)` — exact match, plus the single cross-verb pair `List → Read`. **One direction only**: a `Read` query ("read message 5") stays narrow rather than pulling in every enumerating tool.
- The gate keeps a tool whose verb is compatible with any detected query verb.
- `verb_bonus` tiers the signal rather than flattening it: `+3` for an exact intent match, `+1` for a merely compatible one, `-2` for a conflict, so enumerating tools still lead a list query and the retrieval tool follows them instead of displacing them.

## What this does not fix

A prompt with **no token overlap** at all — `find job opportunities from the last 5 days` — still ends up with twelve `LIST_*` actions: they score `+3` on the exact verb while `GMAIL_FETCH_EMAILS` scores `+1` on compatibility alone, so the budget fills before it is reached. That is the separate defect that a flat verb bonus lets zero-overlap tools qualify at all (`score > 0`).

Worth recording for whoever takes that one: requiring at least one token hit before a tool can qualify **backfires** for a downstream host that falls back to the unfiltered catalogue when hits drop below `MIN_CONFIDENT_HITS` — nearly every Gmail action has zero overlap with that prompt, so the requirement empties the result and hands the model all 62 dense schemas instead of 12. Any fix there has to consider what the host does with a thin result.

## Tests

- `a_list_query_keeps_the_tool_that_retrieves_what_it_found` — the property this change exists for.
- `an_exact_verb_match_still_outranks_a_merely_compatible_one` — compatibility must not promote a `Read` tool above an exact `List` match.
- `compatibility_is_one_directional_and_narrow` — `List → Read` only; not the reverse, and nothing else pairs.
- `ranking_order_matches_the_pre_extraction_snapshot` updated: "list open PRs assigned to me" now also keeps `GITHUB_GET_A_PULL_REQUEST`, ranked **last** of the three, which is the intended shape.

`cargo test -p tinyagents-harness --lib` → 928 passed, 0 failed (the `workspace::git` module is excluded locally: it spawns real `git commit`, which blocks on this machine's GPG pinentry; it is untouched by this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool selection for list-related queries by retaining compatible read tools.
  * Ranked exact verb matches above compatible, non-exact matches.
  * Corrected ranked results for queries involving open pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->